### PR TITLE
initial checkout layout

### DIFF
--- a/src/data/checkoutPage.ts
+++ b/src/data/checkoutPage.ts
@@ -1,0 +1,76 @@
+export const categories = [
+  {
+    id: "1",
+    name: "personal care",
+    description: "All electronics",
+    items: [
+      {
+        id: "11",
+        name: "shaving kits",
+      },
+      {
+        id: "12",
+        name: "deodorant",
+      },
+      {
+        id: "13",
+        name: "hair care",
+      },
+      {
+        id: "14",
+        name: "skin care",
+      },
+      {
+        id: "15",
+        name: "oral care",
+      },
+      {
+        id: "16",
+        name: "sanitary care",
+      },
+    ],
+  },
+  {
+    id: "2",
+    name: "cleaning supplies",
+    description: "All cleaning supplies",
+    items: [
+      {
+        id: "21",
+        name: "cleaning tools",
+      },
+      {
+        id: "22",
+        name: "cleaning chemicals",
+      },
+      {
+        id: "23",
+        name: "cleaning equipment",
+      },
+    ],
+  },
+];
+
+
+export const buildingCodes = [
+  {
+    "code": "ALM",
+    "name": "Bob and Marcia Almquist Place"
+  },
+  {
+    "code": "BHR",
+    "name": "Baker Hill Road"
+  },
+  {
+    "code": "CST",
+    "name": "Central Street"
+  },
+  {
+    "code": "DFR",
+    "name": "Deerfield Road"
+  },
+  {
+    "code": "EMR",
+    "name": "Elm Ridge Drive"
+  }
+];

--- a/src/menu-items/index.tsx
+++ b/src/menu-items/index.tsx
@@ -51,6 +51,14 @@ const dashboard = {
       icon: icons.FileExclamationOutlined,
       breadcrumbs: false,
     },
+    {
+      id: 'checkout',
+      title: 'Checkout',
+      type: 'item',
+      url: '/checkout',
+      icon: icons.EyeInvisibleOutlined,
+      breadcrumbs: false,
+    },
   ],
 };
 

--- a/src/pages/CheckoutPage.tsx
+++ b/src/pages/CheckoutPage.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-
 import {
   MenuItem,
   Select,
@@ -17,11 +16,8 @@ import {
   DialogContent,
   DialogTitle,
 } from '@mui/material';
-
 import { Search, Add, Remove, Close } from '@mui/icons-material';
-
-// data
-import { categories, buildingCodes } from '../data/checkoutPage';
+import { categories, buildingCodes } from '../data/checkoutPage'; //TODO remove when SQL Is hooked up
 
 type CheckoutItem = {
   id: string;
@@ -38,14 +34,14 @@ const CheckoutPage = () => {
 
   const [checkoutItems, setCheckoutItems] = useState<CheckoutItem[]>([]);
   const [openSummary, setOpenSummary] = useState(false);
-
+  const [selectedBuildingCode, setSelectedBuildingCode] = useState('');
 
   const removeItemFromCart = (itemId: string) => {
     setCheckoutItems(checkoutItems.filter((addedItem: CheckoutItem) => addedItem.id !== itemId));
   }
 
   const addItemToCart = (item: Item, quantity: number) => {
-    const foundIndex = checkoutItems.findIndex((addedItem: any) => addedItem.id === item.id);
+    const foundIndex = checkoutItems.findIndex((addedItem: CheckoutItem) => addedItem.id === item.id);
     if (foundIndex !== -1) {
       const foundItem = checkoutItems[foundIndex];
       if (foundItem.quantity + quantity === 0) {
@@ -75,18 +71,19 @@ const CheckoutPage = () => {
     return <IconButton style={{ backgroundColor: "#E8E8E8", width: "30px", height: "30px" }} onClick={() => addItemToCart(item, 1)}><Add /></IconButton>
   }
 
-
   return (
     <div style={{ margin: "auto 100px" }}>
       <h2>Check out</h2>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "end" }}>
         <div>
           <FormControl style={{ width: "150px" }}>
-            <InputLabel id="demo-simple-select-label">Building Code</InputLabel>
+            <InputLabel id="select-building-code-label">Building Code</InputLabel>
             <Select
-              labelId="demo-simple-select-label"
-              id="demo-simple-select"
+              labelId="select-building-code-label"
+              id="select-building-code"
               label="Building Code"
+              value={selectedBuildingCode || ''}
+              onChange={(event) => setSelectedBuildingCode(event.target.value)}
             >
               {buildingCodes.map((buildingCode) => (
                 <MenuItem key={buildingCode.code} value={buildingCode.code}>{buildingCode.code} ({buildingCode.name})</MenuItem>
@@ -114,7 +111,7 @@ const CheckoutPage = () => {
               {category.items.map(item => (
                 <Card key={item.id} style={{
                   display: "flex", justifyContent: "space-between", alignItems: "center", width: "238px", height: "70px", margin: "10px", borderRadius: "10px",
-                  backgroundColor: checkoutItems.find((v: any) => v.id === item.id) ? "#C0C0C0" : "white"
+                  backgroundColor: checkoutItems.find((v: CheckoutItem) => v.id === item.id) ? "#C0C0C0" : "white"
                 }}>
                   <CardContent>
                     <h4>{item.name}</h4>
@@ -139,10 +136,9 @@ const CheckoutPage = () => {
         onClose={() => setOpenSummary(false)}
         aria-labelledby="customized-dialog-title"
         open={openSummary}
-
       >
         <DialogTitle sx={{ m: 0, p: 2 }} id="customized-dialog-title">
-          <span style={{fontSize: "1.5rem"}}>Check Out Summary</span>
+          <span style={{ fontSize: "1.5rem" }}>Check Out Summary</span>
         </DialogTitle>
         <IconButton
           aria-label="close"
@@ -159,8 +155,8 @@ const CheckoutPage = () => {
         <DialogContent dividers style={{ width: "500px" }}>
           {
             checkoutItems.map((item: CheckoutItem) => (
-              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderRadius: "10px" }}>
-                <div style={{ display: "flex", justifyContent: "space-between", width: "370px", alignItems: "center"}}>
+              <div key={item.id} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderRadius: "10px" }}>
+                <div style={{ display: "flex", justifyContent: "space-between", width: "370px", alignItems: "center" }}>
                   <div>
                     <h4>{item.name}</h4>
                   </div>
@@ -172,7 +168,6 @@ const CheckoutPage = () => {
               </div>
             ))
           }
-
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setOpenSummary(false)}>

--- a/src/pages/CheckoutPage.tsx
+++ b/src/pages/CheckoutPage.tsx
@@ -1,0 +1,190 @@
+import { useState } from 'react';
+
+import {
+  MenuItem,
+  Select,
+  FormControl,
+  InputLabel,
+  TextField,
+  InputAdornment,
+  Card,
+  CardActions,
+  CardContent,
+  IconButton,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from '@mui/material';
+
+import { Search, Add, Remove, Close } from '@mui/icons-material';
+
+// data
+import { categories, buildingCodes } from '../data/checkoutPage';
+
+type CheckoutItem = {
+  id: string;
+  name: string;
+  quantity: number;
+}
+
+type Item = {
+  id: string;
+  name: string;
+}
+
+const CheckoutPage = () => {
+
+  const [checkoutItems, setCheckoutItems] = useState<CheckoutItem[]>([]);
+  const [openSummary, setOpenSummary] = useState(false);
+
+
+  const removeItemFromCart = (itemId: string) => {
+    setCheckoutItems(checkoutItems.filter((addedItem: CheckoutItem) => addedItem.id !== itemId));
+  }
+
+  const addItemToCart = (item: Item, quantity: number) => {
+    const foundIndex = checkoutItems.findIndex((addedItem: any) => addedItem.id === item.id);
+    if (foundIndex !== -1) {
+      const foundItem = checkoutItems[foundIndex];
+      if (foundItem.quantity + quantity === 0) {
+        removeItemFromCart(item.id);
+      } else {
+        const updatedItems = [...checkoutItems];
+        updatedItems[foundIndex] = { ...foundItem, quantity: foundItem.quantity + quantity };
+        setCheckoutItems(updatedItems);
+      }
+    } else {
+      const updatedItems = [...checkoutItems, { ...item, quantity: 1 }];
+      setCheckoutItems(updatedItems);
+    }
+  }
+
+  const renderItemQuantityButtons = (item: Item | CheckoutItem) => {
+    const foundInCart = checkoutItems.find((v: CheckoutItem) => v.id === item.id);
+    if (foundInCart) {
+      return (
+        <div style={{ display: "flex" }}>
+          <IconButton style={{ backgroundColor: "#E8E8E8", width: "20px", height: "20px" }} onClick={() => addItemToCart(item, -1)}><Remove fontSize="small" /></IconButton>
+          <span style={{ fontWeight: "bold", margin: "0 10px" }}>{foundInCart.quantity}</span>
+          <IconButton style={{ backgroundColor: "#E8E8E8", width: "20px", height: "20px" }} onClick={() => addItemToCart(item, 1)}><Add fontSize="small" /></IconButton>
+        </div>
+      );
+    }
+    return <IconButton style={{ backgroundColor: "#E8E8E8", width: "30px", height: "30px" }} onClick={() => addItemToCart(item, 1)}><Add /></IconButton>
+  }
+
+
+  return (
+    <div style={{ margin: "auto 100px" }}>
+      <h2>Check out</h2>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "end" }}>
+        <div>
+          <FormControl style={{ width: "150px" }}>
+            <InputLabel id="demo-simple-select-label">Building Code</InputLabel>
+            <Select
+              labelId="demo-simple-select-label"
+              id="demo-simple-select"
+              label="Building Code"
+            >
+              {buildingCodes.map((buildingCode) => (
+                <MenuItem key={buildingCode.code} value={buildingCode.code}>{buildingCode.code} ({buildingCode.name})</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </div>
+        <div>
+          <TextField variant="standard" placeholder="Search..." type="search"
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Search />
+                </InputAdornment>
+              ),
+            }}
+          />
+        </div>
+      </div>
+      <div style={{ borderRadius: "10px", backgroundColor: "#F0F0F0" }}>
+        {categories.map((category) => (
+          <div key={category.id}>
+            <h3 style={{ margin: "20px 20px" }}>{category.name}</h3>
+            <div style={{ display: "flex", flexDirection: "row", flexWrap: "wrap" }}>
+              {category.items.map(item => (
+                <Card key={item.id} style={{
+                  display: "flex", justifyContent: "space-between", alignItems: "center", width: "238px", height: "70px", margin: "10px", borderRadius: "10px",
+                  backgroundColor: checkoutItems.find((v: any) => v.id === item.id) ? "#C0C0C0" : "white"
+                }}>
+                  <CardContent>
+                    <h4>{item.name}</h4>
+                  </CardContent>
+                  <CardActions style={{ border: "1px red blue" }}>
+                    {renderItemQuantityButtons(item)}
+                  </CardActions>
+                </Card>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      {checkoutItems.length > 0 && (
+        <div style={{ padding: "0 100px", display: "flex", justifyContent: "space-between", alignItems: "center", width: "100%", height: "100px", backgroundColor: "#C0C0C0" }}>
+          <p>{checkoutItems.reduce((accumulator, item) => accumulator + item.quantity, 0)} items selected</p>
+          <Button variant="text" style={{ color: "black", backgroundColor: "white" }} onClick={() => setOpenSummary(true)}>Continue</Button>
+        </div>
+      )}
+
+      <Dialog
+        onClose={() => setOpenSummary(false)}
+        aria-labelledby="customized-dialog-title"
+        open={openSummary}
+
+      >
+        <DialogTitle sx={{ m: 0, p: 2 }} id="customized-dialog-title">
+          <span style={{fontSize: "1.5rem"}}>Check Out Summary</span>
+        </DialogTitle>
+        <IconButton
+          aria-label="close"
+          onClick={() => setOpenSummary(false)}
+          sx={{
+            position: 'absolute',
+            right: 8,
+            top: 8,
+            color: (theme) => theme.palette.grey[500],
+          }}
+        >
+          <Close />
+        </IconButton>
+        <DialogContent dividers style={{ width: "500px" }}>
+          {
+            checkoutItems.map((item: CheckoutItem) => (
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderRadius: "10px" }}>
+                <div style={{ display: "flex", justifyContent: "space-between", width: "370px", alignItems: "center"}}>
+                  <div>
+                    <h4>{item.name}</h4>
+                  </div>
+                  {renderItemQuantityButtons(item)}
+                </div>
+                <div>
+                  <Button variant="text" onClick={() => removeItemFromCart(item.id)}>Remove</Button>
+                </div>
+              </div>
+            ))
+          }
+
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpenSummary(false)}>
+            Cancel
+          </Button>
+          <Button autoFocus >
+            Confirm
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}
+
+export default CheckoutPage;

--- a/src/pages/checkout/CheckoutDialog.tsx
+++ b/src/pages/checkout/CheckoutDialog.tsx
@@ -8,7 +8,7 @@ import {
   Button,
 } from '@mui/material';
 import { Close } from '@mui/icons-material';
-import { CheckoutItem } from './CheckoutPage'; // Assuming CheckoutItem is defined in the same file
+import { CheckoutItem } from '../../types/interfaces'
 
 type CheckoutDialogProps = {
   open: boolean;

--- a/src/pages/checkout/CheckoutDialog.tsx
+++ b/src/pages/checkout/CheckoutDialog.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  IconButton,
+  Button,
+} from '@mui/material';
+import { Close } from '@mui/icons-material';
+import { CheckoutItem } from './CheckoutPage'; // Assuming CheckoutItem is defined in the same file
+
+type CheckoutDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  checkoutItems: CheckoutItem[];
+  removeItemFromCart: (itemId: string) => void;
+  renderItemQuantityButtons: (item: CheckoutItem) => JSX.Element;
+};
+
+const CheckoutDialog: React.FC<CheckoutDialogProps> = ({
+  open,
+  onClose,
+  checkoutItems,
+  removeItemFromCart,
+  renderItemQuantityButtons,
+}) => {
+  return (
+    <Dialog onClose={onClose} aria-labelledby="customized-dialog-title" open={open}>
+      <DialogTitle sx={{ m: 0, p: 2 }} id="customized-dialog-title">
+        <span style={{ fontSize: "1.5rem" }}>Check Out Summary</span>
+      </DialogTitle>
+      <IconButton
+        aria-label="close"
+        onClick={onClose}
+        sx={{
+          position: 'absolute',
+          right: 8,
+          top: 8,
+          color: (theme) => theme.palette.grey[500],
+        }}
+      >
+        <Close />
+      </IconButton>
+      <DialogContent dividers style={{ width: "500px" }}>
+        {checkoutItems.map((item: CheckoutItem) => (
+          <div key={item.id} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderRadius: "10px" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", width: "370px", alignItems: "center" }}>
+              <div>
+                <h4>{item.name}</h4>
+              </div>
+              {renderItemQuantityButtons(item)}
+            </div>
+            <div>
+              <Button variant="text" onClick={() => removeItemFromCart(item.id)}>Remove</Button>
+            </div>
+          </div>
+        ))}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button autoFocus>Confirm</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default CheckoutDialog;

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -11,13 +11,10 @@ import {
   CardContent,
   IconButton,
   Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
 } from '@mui/material';
-import { Search, Add, Remove, Close } from '@mui/icons-material';
-import { categories, buildingCodes } from '../data/checkoutPage'; //TODO remove when SQL Is hooked up
+import { Search, Add, Remove } from '@mui/icons-material';
+import CheckoutDialog from './CheckoutDialog';
+import { categories, buildingCodes } from '../../data/checkoutPage'; //TODO remove when SQL Is hooked up
 
 type CheckoutItem = {
   id: string;
@@ -31,7 +28,6 @@ type Item = {
 }
 
 const CheckoutPage = () => {
-
   const [checkoutItems, setCheckoutItems] = useState<CheckoutItem[]>([]);
   const [openSummary, setOpenSummary] = useState(false);
   const [selectedBuildingCode, setSelectedBuildingCode] = useState('');
@@ -132,52 +128,13 @@ const CheckoutPage = () => {
         </div>
       )}
 
-      <Dialog
-        onClose={() => setOpenSummary(false)}
-        aria-labelledby="customized-dialog-title"
+      <CheckoutDialog
         open={openSummary}
-      >
-        <DialogTitle sx={{ m: 0, p: 2 }} id="customized-dialog-title">
-          <span style={{ fontSize: "1.5rem" }}>Check Out Summary</span>
-        </DialogTitle>
-        <IconButton
-          aria-label="close"
-          onClick={() => setOpenSummary(false)}
-          sx={{
-            position: 'absolute',
-            right: 8,
-            top: 8,
-            color: (theme) => theme.palette.grey[500],
-          }}
-        >
-          <Close />
-        </IconButton>
-        <DialogContent dividers style={{ width: "500px" }}>
-          {
-            checkoutItems.map((item: CheckoutItem) => (
-              <div key={item.id} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderRadius: "10px" }}>
-                <div style={{ display: "flex", justifyContent: "space-between", width: "370px", alignItems: "center" }}>
-                  <div>
-                    <h4>{item.name}</h4>
-                  </div>
-                  {renderItemQuantityButtons(item)}
-                </div>
-                <div>
-                  <Button variant="text" onClick={() => removeItemFromCart(item.id)}>Remove</Button>
-                </div>
-              </div>
-            ))
-          }
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setOpenSummary(false)}>
-            Cancel
-          </Button>
-          <Button autoFocus >
-            Confirm
-          </Button>
-        </DialogActions>
-      </Dialog>
+        onClose={() => setOpenSummary(false)}
+        checkoutItems={checkoutItems}
+        removeItemFromCart={removeItemFromCart}
+        renderItemQuantityButtons={renderItemQuantityButtons}
+      />
     </div>
   );
 }

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -13,19 +13,9 @@ import {
   Button,
 } from '@mui/material';
 import { Search, Add, Remove } from '@mui/icons-material';
+import { CheckoutItem, Item } from '../../types/interfaces';
 import CheckoutDialog from './CheckoutDialog';
 import { categories, buildingCodes } from '../../data/checkoutPage'; //TODO remove when SQL Is hooked up
-
-type CheckoutItem = {
-  id: string;
-  name: string;
-  quantity: number;
-}
-
-type Item = {
-  id: string;
-  name: string;
-}
 
 const CheckoutPage = () => {
   const [checkoutItems, setCheckoutItems] = useState<CheckoutItem[]>([]);

--- a/src/pages/routes.tsx
+++ b/src/pages/routes.tsx
@@ -12,6 +12,7 @@ import DashboardDefault from './dashboard';
 import Page404 from './error/404';
 import Inventory from './inventory';
 import VolunteerHome from './VolunteerHome';
+import CheckoutPage from './CheckoutPage';
 
 const routes = [
   {
@@ -62,7 +63,15 @@ const routes = [
         path: 'privacy',
         element: <PrivacyPage />,
       },
-    ],
+      {
+        path: "drag-drop",
+        element: <DragDropPage />,
+      },
+      {
+        path: "checkout",
+        element: <CheckoutPage />,
+      },
+    ]
   },
   {
     path: '/',

--- a/src/pages/routes.tsx
+++ b/src/pages/routes.tsx
@@ -12,7 +12,7 @@ import DashboardDefault from './dashboard';
 import Page404 from './error/404';
 import Inventory from './inventory';
 import VolunteerHome from './VolunteerHome';
-import CheckoutPage from './CheckoutPage';
+import CheckoutPage from './checkout/CheckoutPage';
 
 const routes = [
   {

--- a/src/pages/routes.tsx
+++ b/src/pages/routes.tsx
@@ -64,10 +64,6 @@ const routes = [
         element: <PrivacyPage />,
       },
       {
-        path: "drag-drop",
-        element: <DragDropPage />,
-      },
-      {
         path: "checkout",
         element: <CheckoutPage />,
       },

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -1,0 +1,12 @@
+export type CheckoutItem = {
+    id: string;
+    name: string;
+    quantity: number;
+  }
+  
+export type Item = {
+    id: string;
+    name: string;
+  }
+  
+  


### PR DESCRIPTION
## Description

Implement based on [the updated figma design](https://www.figma.com/design/afHN8okeHtD1tRSsWLrBKW/Plymouth-housing-design?node-id=1-3&node-type=canvas) 
Endpoint: /checkout
User can tap on "+" icon to select an item and update items' quantity
Show "Checkout Summary" when continue checking out with the button at the bottom of the page.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## QA Instructions, Screenshots, Recordings
- Run project
- Go to /checkout


