### PR TITLE
add server to config for dev container

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,4 +8,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom'
   },
+  server: {
+    host: true
+  }, 
 })


### PR DESCRIPTION
## Description

This config section is needed for devcontainer workflow on Windows systems. 

Please make sure that this still works on Mac and on non-dev container set up (I don't have either one). 

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

- Closes 110

## QA Instructions, Screenshots, Recordings

Please make sure that `npm run dev` still brings up the site. 
