### PR TITLE
changing authority url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,12 @@ VITE_APPLICATION_NAME=Plymouth Housing
 # You will need to get this from your partner or dev lead. 
 # Once you have set them, run `source .env.local`
 
-VITE_AUTH_CLIENT_ID=7c5c1bb2-faea-4bcf-babd-4fd023fabfd6 # appid as in Entra App Registration
-VITE_AUTH_AUTHORITY=https://login.microsoftonline.com/common # d20d3333-d19c-428c-bc6b-1f3f1a94a1c8 # tenant id
-VITE_AUTH_REDIRECT_URI=http://localhost:3000 # callback URI
+#appid as found in Entra App Registration
+VITE_AUTH_CLIENT_ID=7c5c1bb2-faea-4bcf-babd-4fd023fabfd6 
+# this url only allows members of this tenant id
+VITE_AUTH_AUTHORITY=https://login.microsoftonline.com/d20d3333-d19c-428c-bc6b-1f3f1a94a1c8 
+# callback URI. This must match one of the values in Entra App Registration. 
+VITE_AUTH_REDIRECT_URI=http://localhost:3000 # 3000 for regular Vite app. 4280 for SWA proxy (needed for API to work)
 
 # //TODO These are old supabase vars that will need to be removed with Supabase
 VITE_SUPABASE_URL=

--- a/src/authConfig.tsx
+++ b/src/authConfig.tsx
@@ -12,9 +12,10 @@ export const msalConfig: Configuration = {
   //This is the configuration for Azure Entra ID authentication
   //The Azure App Registration must be configured with the redirectUri
   auth: {
-    clientId: import.meta.env.VITE_AUTH_CLIENT_ID, // This is the ONLY mandatory field that you need to supply.
-    authority: import.meta.env.VITE_AUTH_AUTHORITY, // Replace the placeholder with your tenant subdomain
-    redirectUri: import.meta.env.VITE_AUTH_REDIRECT_URI, // Points to window.location.origin. You must register this URI on Microsoft Entra admin center/App Registration.
+    //see the .env.example file for explanation and examples
+    clientId: import.meta.env.VITE_AUTH_CLIENT_ID, 
+    authority: import.meta.env.VITE_AUTH_AUTHORITY, 
+    redirectUri: import.meta.env.VITE_AUTH_REDIRECT_URI, 
     postLogoutRedirectUri: '/login',
   },
   system: {


### PR DESCRIPTION
## Description

In fixing the bug 126, I had to change an OAuth URL on github and a setting in Azure Entra. This is a breaking change. You will have to update your local .env.local with the new VITE_AUTH_AUTHORITY URL. 

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

[#126 ](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-126?atlOrigin=eyJpIjoiNjEzNzQzMzI0NzgyNGJiMzg1MTk0NjJlZTBjOWYxNzEiLCJwIjoiaiJ9)

## QA Instructions, Screenshots, Recordings

Just run the app and make sure you can log in with one of the two plymouth accounts and not with your gmail or live account. 
