### PR TITLE
#166 Remove privacy link in footer of admin pages

### DIFF
--- a/src/layout/MainLayout/Drawer/DrawerFooter/index.tsx
+++ b/src/layout/MainLayout/Drawer/DrawerFooter/index.tsx
@@ -5,26 +5,11 @@
  *
  */
 
-// material-ui
-// import { ListItemButton } from '@mui/material';
-
-// project import
-// import { Link } from 'react-router-dom';
-
 // ==============================|| DRAWER HEADER ||============================== //
 
 const DrawerFooter = () => {
   return (
       <>
-    {/* <ListItemButton style={{ position: 'fixed', bottom: 0, paddingBottom: 10 }}>
-      <Link
-        style={{ textDecoration: 'none' }}
-        color="secondary"
-        to={`/privacy`}
-      >
-        Privacy Policy
-      </Link>
-    </ListItemButton> */}
     </>
   );
 };

--- a/src/layout/MainLayout/Drawer/DrawerFooter/index.tsx
+++ b/src/layout/MainLayout/Drawer/DrawerFooter/index.tsx
@@ -6,16 +6,17 @@
  */
 
 // material-ui
-import { ListItemButton } from '@mui/material';
+// import { ListItemButton } from '@mui/material';
 
 // project import
-import { Link } from 'react-router-dom';
+// import { Link } from 'react-router-dom';
 
 // ==============================|| DRAWER HEADER ||============================== //
 
 const DrawerFooter = () => {
   return (
-    <ListItemButton style={{ position: 'fixed', bottom: 0, paddingBottom: 10 }}>
+      <>
+    {/* <ListItemButton style={{ position: 'fixed', bottom: 0, paddingBottom: 10 }}>
       <Link
         style={{ textDecoration: 'none' }}
         color="secondary"
@@ -23,7 +24,8 @@ const DrawerFooter = () => {
       >
         Privacy Policy
       </Link>
-    </ListItemButton>
+    </ListItemButton> */}
+    </>
   );
 };
 

--- a/src/layout/MinimalLayout/MinimalFooter.tsx
+++ b/src/layout/MinimalLayout/MinimalFooter.tsx
@@ -47,27 +47,6 @@ const MinimalFooter = () => {
           spacing={matchDownSM ? 1 : 3}
           textAlign={matchDownSM ? 'center' : 'inherit'}
         >
-        {/* Comment out the Github and Privacy Policy links */}
-        {/*  <Typography
-            variant="subtitle2"
-            color="secondary"
-            component={Link}
-            href="https://material-ui.com/store/contributors/codedthemes/"
-            target="_blank"
-            underline="hover"
-          >
-            Github
-          </Typography>
-          <Typography
-            variant="subtitle2"
-            color="secondary"
-            component={Link}
-            href="https://www.digitalaidseattle.org/privacy"
-            target="_blank"
-            underline="hover"
-          >
-            Privacy Policy
-          </Typography> */}
         </Stack>
       </Stack>
     </Container>


### PR DESCRIPTION
## Description

The PR removes the privacy page link in the footer of admin pages.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

[PIT-166](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-166)

## QA Instructions, Screenshots, Recordings

It has been tested locally, and the screenshot has been attached to the user story.

