### PR TITLE
#176 Hide profile and setting tab

### DIFF
--- a/src/layout/MainLayout/Header/HeaderContent/Profile/ProfileTab.tsx
+++ b/src/layout/MainLayout/Header/HeaderContent/Profile/ProfileTab.tsx
@@ -1,4 +1,3 @@
-// import React, { useState } from 'react';
 import React from 'react';
 
 // material-ui
@@ -12,12 +11,7 @@ import { useTheme } from '@mui/material/styles';
 
 // assets
 import {
-//   EditOutlined,
   LogoutOutlined,
-/*   ProfileOutlined,
-
-  UserOutlined,
-  WalletOutlined, */
 } from '@ant-design/icons';
 
 // ==============================|| HEADER PROFILE - PROFILE TAB ||============================== //
@@ -27,11 +21,6 @@ type ProfileTabProps = {
 
 const ProfileTab: React.FC<ProfileTabProps> = ({ handleLogout }) => {
   const theme = useTheme();
-
-/*   const [selectedIndex, setSelectedIndex] = useState(0);
-  const handleListItemClick = (_event: React.SyntheticEvent, index: number) => {
-    setSelectedIndex(index);
-  };  */
 
   return (
     <List
@@ -44,43 +33,6 @@ const ProfileTab: React.FC<ProfileTabProps> = ({ handleLogout }) => {
         },
       }}
     >
-      {/* <ListItemButton
-        selected={selectedIndex === 0}
-        onClick={(event) => handleListItemClick(event, 0)}
-      >
-        <ListItemIcon>
-          <EditOutlined />
-        </ListItemIcon>
-        <ListItemText primary="Edit Profile" />
-      </ListItemButton>
-      <ListItemButton
-        selected={selectedIndex === 1}
-        onClick={(event) => handleListItemClick(event, 1)}
-      >
-        <ListItemIcon>
-          <UserOutlined />
-        </ListItemIcon>
-        <ListItemText primary="View Profile" />
-      </ListItemButton>
-
-      <ListItemButton
-        selected={selectedIndex === 3}
-        onClick={(event) => handleListItemClick(event, 3)}
-      >
-        <ListItemIcon>
-          <ProfileOutlined />
-        </ListItemIcon>
-        <ListItemText primary="Social Profile" />
-      </ListItemButton>
-      <ListItemButton
-        selected={selectedIndex === 4}
-        onClick={(event) => handleListItemClick(event, 4)}
-      >
-        <ListItemIcon>
-          <WalletOutlined />
-        </ListItemIcon>
-        <ListItemText primary="Billing" />
-      </ListItemButton> */}
       <ListItemButton onClick={handleLogout}>
         <ListItemIcon>
           <LogoutOutlined />

--- a/src/layout/MainLayout/Header/HeaderContent/Profile/index.tsx
+++ b/src/layout/MainLayout/Header/HeaderContent/Profile/index.tsx
@@ -1,6 +1,4 @@
-import {
-//     ReactNode,
-    useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 
 // material-ui
 import {
@@ -14,13 +12,10 @@ import {
   Paper,
   Popper,
   Stack,
-//   Tab,
   Tabs,
   Typography,
 } from '@mui/material';
-import {
-//     Direction,
-    useTheme } from '@mui/material/styles';
+import { useTheme } from '@mui/material/styles';
 
 // project import
 import Transitions from '../../../../../components/@extended/Transitions';

--- a/src/layout/MainLayout/Header/HeaderContent/Profile/index.tsx
+++ b/src/layout/MainLayout/Header/HeaderContent/Profile/index.tsx
@@ -1,4 +1,6 @@
-import { ReactNode, useContext, useEffect, useRef, useState } from 'react';
+import {
+//     ReactNode,
+    useContext, useEffect, useRef, useState } from 'react';
 
 // material-ui
 import {
@@ -8,65 +10,67 @@ import {
   CardContent,
   ClickAwayListener,
   Grid,
-//   IconButton,
+  IconButton,
   Paper,
   Popper,
   Stack,
-  Tab,
+//   Tab,
   Tabs,
   Typography,
 } from '@mui/material';
-import { Direction, useTheme } from '@mui/material/styles';
+import {
+//     Direction,
+    useTheme } from '@mui/material/styles';
 
 // project import
 import Transitions from '../../../../../components/@extended/Transitions';
 import MainCard from '../../../../../components/MainCard';
-import ProfileTab from './ProfileTab';
-import SettingTab from './SettingTab';
+// import ProfileTab from './ProfileTab';
+// import SettingTab from './SettingTab';
 
 // assets
 import {
-//   LogoutOutlined,
-  SettingOutlined,
-  UserOutlined,
+  LogoutOutlined,
+//   SettingOutlined,
+//   UserOutlined,
 } from '@ant-design/icons';
 import { UserContext } from '../../../../../components/contexts/UserContext';
 import { useMsal } from '@azure/msal-react';
 
-interface TabPanelProps {
-  children: ReactNode;
-  index: number;
-  value: number;
-  dir: Direction;
-}
+// interface TabPanelProps {
+//   children: ReactNode;
+//   index: number;
+//   value: number;
+//   dir: Direction;
+// }
 // tab panel wrapper
-const TabPanel: React.FC<TabPanelProps> = ({
-  children,
-  value,
-  index,
-  dir,
-  ...other
-}) => {
-  return (
-    <div
-      role="tabpanel"
-      hidden={value !== index}
-      id={`profile-tabpanel-${index}`}
-      aria-labelledby={`profile-tab-${index}`}
-      dir={dir}
-      {...other}
-    >
-      {value === index && children}
-    </div>
-  );
-};
-
-function a11yProps(index: number) {
-  return {
-    id: `profile-tab-${index}`,
-    'aria-controls': `profile-tabpanel-${index}`,
-  };
-}
+// const TabPanel: React.FC<TabPanelProps> = ({
+//   children,
+//   value,
+//   index,
+//   dir,
+//   ...other
+// }) => {
+//   return (
+//     <div
+//       role="tabpanel"
+//       hidden={value !== index}
+//       id={`profile-tabpanel-${index}`}
+//       aria-labelledby={`profile-tab-${index}`}
+//       dir={dir}
+//       {...other}
+//     >
+//       {value === index && children}
+//     </div>
+//   );
+// };
+//
+// function a11yProps(index: number) {
+//   return {
+//     id: `profile-tab-${index}`,
+//     'aria-controls': `profile-tabpanel-${index}`,
+//   };
+// }
 
 // ==============================|| HEADER CONTENT - PROFILE ||============================== //
 
@@ -198,13 +202,13 @@ const Profile = () => {
                           </Stack>
                         </Grid>
                         <Grid item>
-                        {/*  <IconButton
+                         <IconButton
                             size="large"
                             color="secondary"
                             onClick={handleLogout}
                           >
                             <LogoutOutlined />
-                          </IconButton> */}
+                          </IconButton>
                         </Grid>
                       </Grid>
                     </CardContent>
@@ -217,7 +221,7 @@ const Profile = () => {
                             onChange={handleChange}
                             aria-label="profile tabs"
                           >
-                            <Tab
+                            {/* <Tab
                               sx={{
                                 display: 'flex',
                                 flexDirection: 'row',
@@ -254,15 +258,15 @@ const Profile = () => {
                               }
                               label="Setting"
                               {...a11yProps(1)}
-                            />
+                            /> */}
                           </Tabs>
                         </Box>
-                        <TabPanel value={value} index={0} dir={theme.direction}>
+                        {/* <TabPanel value={value} index={0} dir={theme.direction}>
                           <ProfileTab handleLogout={handleLogout} />
                         </TabPanel>
                         <TabPanel value={value} index={1} dir={theme.direction}>
                           <SettingTab />
-                        </TabPanel>
+                        </TabPanel>  */}
                       </>
                     )}
                   </MainCard>


### PR DESCRIPTION
## Description

The PR hides the Profile and Settings tabs and only displays the Logout icon.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

[PIT-176](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-176)

## QA Instructions, Screenshots, Recordings

It has been tested locally, and the screenshot has been attached to the user story.

