### PR TITLE
Add Building to transactions schema

### DIFF
--- a/database/procedures/log_transaction.sql
+++ b/database/procedures/log_transaction.sql
@@ -6,7 +6,8 @@ CREATE PROCEDURE LogTransaction
     @transaction_id UNIQUEIDENTIFIER,
     @item_id INT,
     @transaction_type VARCHAR(50),
-    @quantity INT
+    @quantity INT,
+    @building_id INT
 AS
 BEGIN
     INSERT INTO Transactions (
@@ -14,13 +15,15 @@ BEGIN
         transaction_id,
         item_id,
         transaction_type,
-        quantity
+        quantity,
+        building_id
     )
     VALUES (
         @user_id,
         @transaction_id,
         @item_id,
         @transaction_type,
-        @quantity
+        @quantity,
+        @building_id
     );
 END;

--- a/database/procedures/process_checkout.sql
+++ b/database/procedures/process_checkout.sql
@@ -4,6 +4,7 @@ GO
 CREATE PROCEDURE ProcessCheckout
     @user_id INT,
     @items NVARCHAR(MAX),
+    @building_code NVARCHAR(50),
     @message NVARCHAR(MAX) = NULL OUTPUT
 AS
 BEGIN
@@ -11,6 +12,17 @@ BEGIN
 
     print @user_id
     print @items
+    print @building_code
+
+    -- Get the building_id from the building_code
+    DECLARE @building_id INT;
+    SELECT @building_id = id FROM Buildings WHERE code = @building_code;
+
+    IF @building_id IS NULL
+    BEGIN
+        SELECT 'Error' AS Status, 'Invalid building code' AS message;
+        RETURN;
+    END
     
     -- Validate JSON
     IF ISJSON(@items) = 0
@@ -91,7 +103,8 @@ BEGIN
                 @transaction_id = @TransactionId,
                 @item_id = @CurrentItemId,
                 @transaction_type = 'CHECKOUT',
-                @quantity = @CurrentQuantity
+                @quantity = @CurrentQuantity,
+                @building_id = @building_id;
                 
             FETCH NEXT FROM item_cursor INTO @CurrentItemId, @CurrentQuantity
         END

--- a/database/procedures/process_welcome_basket_checkout.sql
+++ b/database/procedures/process_welcome_basket_checkout.sql
@@ -5,10 +5,21 @@ CREATE PROCEDURE ProcessWelcomeBasketCheckout
     @user_id INT,
     @mattress_size INT,
     @quantity INT,
+    @building_code NVARCHAR(50),
     @message NVARCHAR(MAX) = NULL OUTPUT
 AS
 BEGIN
     SET NOCOUNT ON;
+
+    -- Get the building_id from the building_code
+    DECLARE @building_id INT;
+    SELECT @building_id = id FROM Buildings WHERE code = @building_code;
+
+    IF @building_id IS NULL
+    BEGIN
+        SELECT 'Error' AS Status, 'Invalid building code' AS message;
+        RETURN;
+    END
 
     -- Create a table variable to hold welcome basket items
     DECLARE @CartItems CartItemsType;
@@ -68,7 +79,8 @@ BEGIN
                 @transaction_id = @TransactionId,
                 @item_id = @CurrentItemId,
                 @transaction_type = 'CHECKOUT',
-                @quantity = @CurrentQuantity;
+                @quantity = @CurrentQuantity,
+                @building_id = @building_id;
 
             FETCH NEXT FROM item_cursor INTO @CurrentItemId, @CurrentQuantity;
         END

--- a/database/tables/transaction.sql
+++ b/database/tables/transaction.sql
@@ -9,6 +9,7 @@ CREATE TABLE Transactions (
     transaction_type VARCHAR(50) NOT NULL,
     quantity INT NOT NULL,
     transaction_date DATETIME DEFAULT GETDATE() NOT NULL,
+    building_id INT NOT NULL
 );
 
 GO

--- a/src/components/Checkout/CheckoutAPICalls.tsx
+++ b/src/components/Checkout/CheckoutAPICalls.tsx
@@ -4,13 +4,14 @@ import { ENDPOINTS, HEADERS } from '../../types/constants';
 
 export async function processWelcomeBasket(user: ClientPrincipal | null, currentUserId: number, checkoutItems: CheckoutItem[], buildingCode: string) {
   HEADERS['X-MS-API-ROLE'] = getRole(user);
-  const response = await fetch(`${ENDPOINTS.CHECKOUT_WELCOME_BASKET}?buildingCode=${buildingCode}`, {
+  const response = await fetch(ENDPOINTS.CHECKOUT_WELCOME_BASKET, {
     method: 'POST',
     headers: HEADERS,
     body: JSON.stringify({
       user_id: currentUserId,
       mattress_size: checkoutItems[0].id,
       quantity: checkoutItems[0].quantity,
+      building_code: buildingCode,
       message: "",
     }),
   });
@@ -19,12 +20,13 @@ export async function processWelcomeBasket(user: ClientPrincipal | null, current
 
 export async function processGeneralItems(user: ClientPrincipal | null, currentUserId: number, checkoutItems: CheckoutItem[], buildingCode: string) {
   HEADERS['X-MS-API-ROLE'] = getRole(user);
-  const response = await fetch(`${ENDPOINTS.CHECKOUT_GENERAL_ITEMS}?buildingCode=${buildingCode}`, {
+  const response = await fetch(ENDPOINTS.CHECKOUT_GENERAL_ITEMS, {
     method: 'POST',
     headers: HEADERS,
     body: JSON.stringify({
       user_id: currentUserId,
       items: checkoutItems.map((item) => ({ id: item.id, quantity: item.quantity })),
+      building_code: buildingCode,
       message: "",
     }),
   });

--- a/src/components/Checkout/CheckoutAPICalls.tsx
+++ b/src/components/Checkout/CheckoutAPICalls.tsx
@@ -2,9 +2,9 @@ import { getRole } from '../contexts/UserContext';
 import { CheckoutItem, ClientPrincipal } from '../../types/interfaces';
 import { ENDPOINTS, HEADERS } from '../../types/constants';
 
-export async function processWelcomeBasket(user: ClientPrincipal | null, currentUserId: number, checkoutItems: CheckoutItem[]) {
+export async function processWelcomeBasket(user: ClientPrincipal | null, currentUserId: number, checkoutItems: CheckoutItem[], buildingCode: string) {
   HEADERS['X-MS-API-ROLE'] = getRole(user);
-  const response = await fetch(ENDPOINTS.CHECKOUT_WELCOME_BASKET, {
+  const response = await fetch(`${ENDPOINTS.CHECKOUT_WELCOME_BASKET}?buildingCode=${buildingCode}`, {
     method: 'POST',
     headers: HEADERS,
     body: JSON.stringify({
@@ -17,9 +17,9 @@ export async function processWelcomeBasket(user: ClientPrincipal | null, current
   return await response.json();
 }
 
-export async function processGeneralItems(user: ClientPrincipal | null, currentUserId: number, checkoutItems: CheckoutItem[]) {
+export async function processGeneralItems(user: ClientPrincipal | null, currentUserId: number, checkoutItems: CheckoutItem[], buildingCode: string) {
   HEADERS['X-MS-API-ROLE'] = getRole(user);
-  const response = await fetch(ENDPOINTS.CHECKOUT_GENERAL_ITEMS, {
+  const response = await fetch(`${ENDPOINTS.CHECKOUT_GENERAL_ITEMS}?buildingCode=${buildingCode}`, {
     method: 'POST',
     headers: HEADERS,
     body: JSON.stringify({

--- a/src/components/Checkout/CheckoutDialog.tsx
+++ b/src/components/Checkout/CheckoutDialog.tsx
@@ -61,9 +61,9 @@ export const CheckoutDialog: React.FC<CheckoutDialogProps> = ({ open, onClose, c
       let data = null;
       if (isWelcomeBasket) {
         // pass "currentUserId" to the processWelcomeBasket function
-        data = await processWelcomeBasket(user, currentUserId, checkoutItems);
+        data = await processWelcomeBasket(user, currentUserId, checkoutItems, selectedBuildingCode);
       } else {
-        data = await processGeneralItems(user, currentUserId, checkoutItems);
+        data = await processGeneralItems(user, currentUserId, checkoutItems, selectedBuildingCode);
       }
 
       const result = data.value[0];


### PR DESCRIPTION
## Description

The PR enables the tracking of building data in transactions.

Approach:
- The APIs are called in CheckoutDialog.tsx (processWelcomeBasket, processGeneralItems). Those APIs need to get an additional parameter: buildingCode. 
- CheckoutDialog already has selectedBuildingCode as a member of its CheckoutDialogProps. We can use that as the parameter. 

Schema:
- The transactions table needs an additional column: building_id
- The log_transaction stored_proc needs that same building_id

StoredPros:
- The procedures in process_checkout.sql and process_welcome_basket_checkout.sql need to get an additional parameter: building_code
- That building_code needs to be used to get the ID of the building in the table (because the log_transaction stored_proc takes an ID, and on the React side we pass in the buildingCode) 

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

[PIT-213](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-213)

## QA Instructions, Screenshots, Recordings


