### PR TITLE
Misty/242 navbar position for Checkout Page should be fixed

### DIFF
--- a/src/components/Checkout/Navbar.tsx
+++ b/src/components/Checkout/Navbar.tsx
@@ -11,11 +11,11 @@ const Navbar = ({ filteredData, scrollToCategory }: dataProps) => {
   return (
     <Box
       sx={{
+        position: 'sticky', top: 0, background: 'cyan', height: '64px', zIndex: 2002,
         display: 'flex',
         overflowX: 'auto',
         gap: 2,
         whiteSpace: 'nowrap',
-        height: '64px',
       }}
     >
       <Button onClick={() => scrollToCategory('Welcome Basket')} sx={{ color: 'black' }}>

--- a/src/components/Checkout/Navbar.tsx
+++ b/src/components/Checkout/Navbar.tsx
@@ -17,11 +17,11 @@ const Navbar = ({ filteredData, scrollToCategory }: dataProps) => {
         whiteSpace: 'nowrap',
       }}
     >
-      <Button onClick={() => scrollToCategory('Welcome Basket')} sx={{ color: 'black' }}>
+      <Button onClick={() => scrollToCategory('Welcome Basket')} sx={{ color: 'black', minWidth: 'auto' }}>
           Welcome Basket
         </Button>
       {filteredData.map((categories) => (
-        <Button key={categories.category} onClick={() => scrollToCategory(categories.category)} sx={{ color: 'black' }}>
+        <Button key={categories.category} onClick={() => scrollToCategory(categories.category)} sx={{ color: 'black',  minWidth: 'auto' }}>
           {categories.category}
         </Button>
       ))}

--- a/src/components/Checkout/Navbar.tsx
+++ b/src/components/Checkout/Navbar.tsx
@@ -11,7 +11,11 @@ const Navbar = ({ filteredData, scrollToCategory }: dataProps) => {
   return (
     <Box
       sx={{
-        position: 'sticky', top: 0, background: 'cyan', height: '64px', zIndex: 2002,
+        position: 'sticky', 
+        top: 0, 
+        height: '64px', 
+        zIndex: 2002,
+        background: 'white',
         display: 'flex',
         overflowX: 'auto',
         gap: 2,

--- a/src/components/Checkout/Navbar.tsx
+++ b/src/components/Checkout/Navbar.tsx
@@ -15,6 +15,7 @@ const Navbar = ({ filteredData, scrollToCategory }: dataProps) => {
         top: 0, 
         height: '64px', 
         zIndex: 2002,
+        p: 1,
         background: 'white',
         display: 'flex',
         overflowX: 'auto',

--- a/src/components/Checkout/Navbar.tsx
+++ b/src/components/Checkout/Navbar.tsx
@@ -11,12 +11,6 @@ const Navbar = ({ filteredData, scrollToCategory }: dataProps) => {
   return (
     <Box
       sx={{
-        position: 'sticky', 
-        top: 0, 
-        height: '64px', 
-        zIndex: 2002,
-        p: 1,
-        background: 'white',
         display: 'flex',
         overflowX: 'auto',
         gap: 2,

--- a/src/components/Checkout/SearchBar.tsx
+++ b/src/components/Checkout/SearchBar.tsx
@@ -21,6 +21,9 @@ const SearchBar: React.FC<SearchBarProps> = ({ data, setSearchData, setSearchAct
     }
     setSearchTerm(e.target.value);
     filterFunction(e.target.value);
+    // reset scroll position
+    const scrollContainer = document.getElementById('scrollContainer');
+    if (scrollContainer) scrollContainer.scrollTop = 0;
   };
 
   const filterFunction = (term: string) => {

--- a/src/components/MainCard.tsx
+++ b/src/components/MainCard.tsx
@@ -37,7 +37,7 @@ const MainCard: React.FC<MainCardProp> = forwardRef(
       boxShadow,
       children,
       content = true,
-      contentSX = {},
+      contentSX = {height: '70vh', overflow: 'auto'}, 
       darkTitle,
       elevation,
       secondary,
@@ -59,6 +59,7 @@ const MainCard: React.FC<MainCardProp> = forwardRef(
         ref={ref as any}
         {...others}
         sx={{
+          height: '100%',
           border: border ? '1px solid' : 'none',
           borderRadius: 2,
           borderColor:

--- a/src/components/MainCard.tsx
+++ b/src/components/MainCard.tsx
@@ -102,8 +102,7 @@ const MainCard: React.FC<MainCardProp> = forwardRef(
         )}
 
         {/* card content */}
-        // id is used to select container,
-        // to reset its scroll value as needed for the checkout page
+        {/* id is used to select container, to reset its scroll value in the checkout page */}
         {content && <CardContent sx={contentSX} id="scrollContainer">{children}</CardContent>}
         {!content && children}
       </Card>

--- a/src/components/MainCard.tsx
+++ b/src/components/MainCard.tsx
@@ -102,6 +102,8 @@ const MainCard: React.FC<MainCardProp> = forwardRef(
         )}
 
         {/* card content */}
+        // id is used to select container,
+        // to reset its scroll value as needed for the checkout page
         {content && <CardContent sx={contentSX} id="scrollContainer">{children}</CardContent>}
         {!content && children}
       </Card>

--- a/src/components/MainCard.tsx
+++ b/src/components/MainCard.tsx
@@ -102,7 +102,7 @@ const MainCard: React.FC<MainCardProp> = forwardRef(
         )}
 
         {/* card content */}
-        {content && <CardContent sx={contentSX}>{children}</CardContent>}
+        {content && <CardContent sx={contentSX} id="scrollContainer">{children}</CardContent>}
         {!content && children}
       </Card>
     );

--- a/src/components/MainCard.tsx
+++ b/src/components/MainCard.tsx
@@ -37,7 +37,7 @@ const MainCard: React.FC<MainCardProp> = forwardRef(
       boxShadow,
       children,
       content = true,
-      contentSX = {height: '70vh', overflow: 'auto'}, 
+      contentSX = {height: '70vh', overflow: 'auto', padding: 0}, 
       darkTitle,
       elevation,
       secondary,
@@ -59,7 +59,6 @@ const MainCard: React.FC<MainCardProp> = forwardRef(
         ref={ref as any}
         {...others}
         sx={{
-          height: '100%',
           border: border ? '1px solid' : 'none',
           borderRadius: 2,
           borderColor:

--- a/src/components/MainCard.tsx
+++ b/src/components/MainCard.tsx
@@ -37,7 +37,7 @@ const MainCard: React.FC<MainCardProp> = forwardRef(
       boxShadow,
       children,
       content = true,
-      contentSX = {height: '70vh', overflow: 'auto', padding: 0}, 
+      contentSX = {}, 
       darkTitle,
       elevation,
       secondary,

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -115,6 +115,7 @@ const CheckoutPage = () => {
   const scrollToCategory = (id: string) => {
     const element = document.getElementById(id);
     if (element) {
+      // margin added to the scroll position, to account for the sticky nav
       element.style.scrollMarginTop = "150px";
       element?.scrollIntoView({ behavior: 'smooth', block: 'start' })
     }
@@ -179,6 +180,7 @@ const CheckoutPage = () => {
 
   return (
     <>
+    {/* Container for the sticky nav */}
     <Box sx={{
       position: 'sticky', 
       top: 0, 
@@ -193,101 +195,101 @@ const CheckoutPage = () => {
       {!searchActive && <Navbar filteredData={filteredData} scrollToCategory={scrollToCategory} />}
     </Box>
 
-      <Box sx={{ backgroundColor: '#F0F0F0', borderRadius: '15px', paddingBottom: '20px', minHeight: '100vh' }}>
-        {searchActive ? (
-          <Grid container spacing={2} sx={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', paddingLeft: '5%', paddingRight: '5%', paddingY: '2.5%' }}>
-            {searchData.map((section: CategoryProps) => {
-              const matchingCategory =
-                checkoutItems.find((cat) => cat.category === section.category) || {
-                  id: 0,
-                  category: '',
-                  items: [],
-                  checkout_limit: 0,
-                  categoryCount: 0,
-                };
+    <Box sx={{ backgroundColor: '#F0F0F0', borderRadius: '15px', paddingBottom: '20px', minHeight: '100vh' }}>
+      {searchActive ? (
+        <Grid container spacing={2} sx={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', paddingLeft: '5%', paddingRight: '5%', paddingY: '2.5%' }}>
+          {searchData.map((section: CategoryProps) => {
+            const matchingCategory =
+              checkoutItems.find((cat) => cat.category === section.category) || {
+                id: 0,
+                category: '',
+                items: [],
+                checkout_limit: 0,
+                categoryCount: 0,
+              };
 
-              return section.items.map((item: CheckoutItemProp) => (
-                <Grid item xs={12} sm={6} md={4} xl={3} key={item.id}>
-                  <CheckoutCard
-                    item={item}
-                    categoryCheckout={matchingCategory}
-                    addItemToCart={(item, quantity) => {
-                      const sectionType = section.category === 'Welcome Basket' ? 'welcomeBasket' : 'general';
-                      addItemToCart(item, quantity, section.category, sectionType);
-                    }}
-                    activeSection={activeSection}
-                    removeItemFromCart={removeItemFromCart}
-                    removeButton={false}
-                    categoryLimit={section.checkout_limit}
-                    categoryName={section.category}
-                  />
-                </Grid>
-              ));
-            })}
-
-          </Grid>
-        ) :
-
-          <Box>
-            <Typography id="Welcome Basket" sx={{ paddingLeft: '5%', paddingTop: '5%', fontSize: '24px', fontWeight: 'bold' }}>Welcome Basket</Typography>
-
-            {/* Filters for welcome basket  */}
-            {welcomeBasketData.map((category) => {
-              const matchingCategory = checkoutItems.find(
-                (cat) => cat.category === category.category
-              ) || { id: 0, category: '', items: [], checkout_limit: 0, categoryCount: 0 };
-              return (
-                <CategorySection
-                  key={category.id}
-                  category={category}
+            return section.items.map((item: CheckoutItemProp) => (
+              <Grid item xs={12} sm={6} md={4} xl={3} key={item.id}>
+                <CheckoutCard
+                  item={item}
                   categoryCheckout={matchingCategory}
-                  addItemToCart={(item, quantity) =>
-                    addItemToCart(item, quantity, category.category, 'welcomeBasket')}
+                  addItemToCart={(item, quantity) => {
+                    const sectionType = section.category === 'Welcome Basket' ? 'welcomeBasket' : 'general';
+                    addItemToCart(item, quantity, section.category, sectionType);
+                  }}
+                  activeSection={activeSection}
                   removeItemFromCart={removeItemFromCart}
                   removeButton={false}
-                  disabled={searchActive || (activeSection !== '' && activeSection !== 'welcomeBasket')}
+                  categoryLimit={section.checkout_limit}
+                  categoryName={section.category}
                 />
-              );
-            })}
+              </Grid>
+            ));
+          })}
 
-            <Typography sx={{ paddingLeft: '5%', paddingTop: '5%', fontSize: '24px', fontWeight: 'bold' }}>General</Typography>
+        </Grid>
+      ) :
 
-            {/* Filters for general items */}
-            {filteredData.map((category) => {
-              const matchingCategory = checkoutItems.find(
-                (cat) => cat.category === category.category
-              ) || { id: 0, category: '', items: [], checkout_limit: 0, categoryCount: 0 };
-              return (
-                <CategorySection
-                  key={category.id}
-                  category={category}
-                  categoryCheckout={matchingCategory}
-                  addItemToCart={(item, quantity) =>
-                    addItemToCart(item, quantity, category.category, 'general')}
-                  removeItemFromCart={removeItemFromCart}
-                  removeButton={false}
-                  disabled={searchActive || (activeSection !== '' && activeSection !== 'general')}
-                />
-              );
-            })}
-          </Box>}
+        <Box>
+          <Typography id="Welcome Basket" sx={{ paddingLeft: '5%', paddingTop: '5%', fontSize: '24px', fontWeight: 'bold' }}>Welcome Basket</Typography>
 
-        <CheckoutFooter checkoutItems={checkoutItems} setOpenSummary={setOpenSummary} selectedBuildingCode={selectedBuildingCode} />
+          {/* Filters for welcome basket  */}
+          {welcomeBasketData.map((category) => {
+            const matchingCategory = checkoutItems.find(
+              (cat) => cat.category === category.category
+            ) || { id: 0, category: '', items: [], checkout_limit: 0, categoryCount: 0 };
+            return (
+              <CategorySection
+                key={category.id}
+                category={category}
+                categoryCheckout={matchingCategory}
+                addItemToCart={(item, quantity) =>
+                  addItemToCart(item, quantity, category.category, 'welcomeBasket')}
+                removeItemFromCart={removeItemFromCart}
+                removeButton={false}
+                disabled={searchActive || (activeSection !== '' && activeSection !== 'welcomeBasket')}
+              />
+            );
+          })}
 
-        <ScrollToTopButton showAfter={300} />
-        <CheckoutDialog
-          open={openSummary}
-          onClose={() => setOpenSummary(false)}
-          checkoutItems={checkoutItems}
-          welcomeBasketData={welcomeBasketData}
-          addItemToCart={(item, quantity, category) => addItemToCart(item, quantity, category, activeSection)}
-          setCheckoutItems={setCheckoutItems}
-          removeItemFromCart={removeItemFromCart}
-          selectedBuildingCode={selectedBuildingCode}
-          setActiveSection={setActiveSection}
-          fetchData={fetchData}
-        />
-      </Box>
+          <Typography sx={{ paddingLeft: '5%', paddingTop: '5%', fontSize: '24px', fontWeight: 'bold' }}>General</Typography>
+
+          {/* Filters for general items */}
+          {filteredData.map((category) => {
+            const matchingCategory = checkoutItems.find(
+              (cat) => cat.category === category.category
+            ) || { id: 0, category: '', items: [], checkout_limit: 0, categoryCount: 0 };
+            return (
+              <CategorySection
+                key={category.id}
+                category={category}
+                categoryCheckout={matchingCategory}
+                addItemToCart={(item, quantity) =>
+                  addItemToCart(item, quantity, category.category, 'general')}
+                removeItemFromCart={removeItemFromCart}
+                removeButton={false}
+                disabled={searchActive || (activeSection !== '' && activeSection !== 'general')}
+              />
+            );
+          })}
+        </Box>}
+
+      <CheckoutFooter checkoutItems={checkoutItems} setOpenSummary={setOpenSummary} selectedBuildingCode={selectedBuildingCode} />
+
+      <ScrollToTopButton showAfter={300} />
+      <CheckoutDialog
+        open={openSummary}
+        onClose={() => setOpenSummary(false)}
+        checkoutItems={checkoutItems}
+        welcomeBasketData={welcomeBasketData}
+        addItemToCart={(item, quantity, category) => addItemToCart(item, quantity, category, activeSection)}
+        setCheckoutItems={setCheckoutItems}
+        removeItemFromCart={removeItemFromCart}
+        selectedBuildingCode={selectedBuildingCode}
+        setActiveSection={setActiveSection}
+        fetchData={fetchData}
+      />
+    </Box>
     </>
   );
 };

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -178,7 +178,7 @@ const CheckoutPage = () => {
 
   return (
     <>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'end' }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'end', p: 1 }}>
         <BuildingCodeSelect buildings={buildings} selectedBuildingCode={selectedBuildingCode} setSelectedBuildingCode={setSelectedBuildingCode} />
         <SearchBar data={data} setSearchData={setSearchData} setSearchActive={setSearchActive} />
       </Box>

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -195,7 +195,7 @@ const CheckoutPage = () => {
 
       <Box sx={{ backgroundColor: '#F0F0F0', borderRadius: '15px', paddingBottom: '20px', minHeight: '100vh' }}>
         {searchActive ? (
-          <Grid container spacing={2} sx={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', paddingLeft: '5%', paddingRight: '5%' }}>
+          <Grid container spacing={2} sx={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', paddingLeft: '5%', paddingRight: '5%', paddingY: '2.5%' }}>
             {searchData.map((section: CategoryProps) => {
               const matchingCategory =
                 checkoutItems.find((cat) => cat.category === section.category) || {

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -115,6 +115,7 @@ const CheckoutPage = () => {
   const scrollToCategory = (id: string) => {
     const element = document.getElementById(id);
     if (element) {
+      element.style.scrollMarginTop = "150px";
       element?.scrollIntoView({ behavior: 'smooth', block: 'start' })
     }
   }

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -182,7 +182,7 @@ const CheckoutPage = () => {
     <Box sx={{
       position: 'sticky', 
       top: 0, 
-      zIndex: 2002,
+      zIndex: 2,
       p: 1,
       background: 'white',
     }}>

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -178,15 +178,20 @@ const CheckoutPage = () => {
 
   return (
     <>
+    <Box sx={{
+      position: 'sticky', 
+      top: 0, 
+      zIndex: 2002,
+      p: 1,
+      background: 'white',
+    }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'end', p: 1 }}>
         <BuildingCodeSelect buildings={buildings} selectedBuildingCode={selectedBuildingCode} setSelectedBuildingCode={setSelectedBuildingCode} />
         <SearchBar data={data} setSearchData={setSearchData} setSearchActive={setSearchActive} />
       </Box>
-      <Box>
-        {searchActive && <Box sx={{ display: 'flex', overflowX: 'auto', gap: 2, p: 1, height: '64px' }}
-        ></Box>}
-      </Box>
       {!searchActive && <Navbar filteredData={filteredData} scrollToCategory={scrollToCategory} />}
+    </Box>
+
       <Box sx={{ backgroundColor: '#F0F0F0', borderRadius: '15px', paddingBottom: '20px', minHeight: '100vh' }}>
         {searchActive ? (
           <Grid container spacing={2} sx={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', paddingLeft: '5%', paddingRight: '5%' }}>

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -177,15 +177,18 @@ const CheckoutPage = () => {
   }, [data])
 
   return (
-    <Box>
+    <>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'end' }}>
         <BuildingCodeSelect buildings={buildings} selectedBuildingCode={selectedBuildingCode} setSelectedBuildingCode={setSelectedBuildingCode} />
         <SearchBar data={data} setSearchData={setSearchData} setSearchActive={setSearchActive} />
       </Box>
       <Box>
         {searchActive ? <Box sx={{ display: 'flex', overflowX: 'auto', gap: 2, p: 1, height: '64px' }}
-        ></Box> : <Navbar filteredData={filteredData} scrollToCategory={scrollToCategory} />}
+        ></Box> : <></>}
       </Box>
+      <Box className="boogaloo" sx={{position: 'sticky', top: 0, background: 'cyan', height: '64px', zIndex: 2002}}>
+            <Navbar filteredData={filteredData} scrollToCategory={scrollToCategory} />
+        </Box>
       <Box sx={{ backgroundColor: '#F0F0F0', borderRadius: '15px', paddingBottom: '20px', minHeight: '100vh' }}>
         {searchActive ? (
           <Grid container spacing={2} sx={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', paddingLeft: '5%', paddingRight: '5%' }}>
@@ -281,7 +284,7 @@ const CheckoutPage = () => {
           fetchData={fetchData}
         />
       </Box>
-    </Box>
+    </>
   );
 };
 

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -183,12 +183,10 @@ const CheckoutPage = () => {
         <SearchBar data={data} setSearchData={setSearchData} setSearchActive={setSearchActive} />
       </Box>
       <Box>
-        {searchActive ? <Box sx={{ display: 'flex', overflowX: 'auto', gap: 2, p: 1, height: '64px' }}
-        ></Box> : <></>}
+        {searchActive && <Box sx={{ display: 'flex', overflowX: 'auto', gap: 2, p: 1, height: '64px' }}
+        ></Box>}
       </Box>
-      <Box className="boogaloo" sx={{position: 'sticky', top: 0, background: 'cyan', height: '64px', zIndex: 2002}}>
-            <Navbar filteredData={filteredData} scrollToCategory={scrollToCategory} />
-        </Box>
+      {!searchActive && <Navbar filteredData={filteredData} scrollToCategory={scrollToCategory} />}
       <Box sx={{ backgroundColor: '#F0F0F0', borderRadius: '15px', paddingBottom: '20px', minHeight: '100vh' }}>
         {searchActive ? (
           <Grid container spacing={2} sx={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', paddingLeft: '5%', paddingRight: '5%' }}>

--- a/src/pages/routes.tsx
+++ b/src/pages/routes.tsx
@@ -46,7 +46,7 @@ const routes = [
       {
         path: 'checkout',
         element: (
-          <MainCard title="Checkout">
+          <MainCard title="Checkout" contentSX={{height: '75vh', padding: 0, overflow: 'auto'}}>
             <CheckoutPage />
           </MainCard>
         ),

--- a/src/pages/routes.tsx
+++ b/src/pages/routes.tsx
@@ -46,6 +46,8 @@ const routes = [
       {
         path: 'checkout',
         element: (
+          // checkout card content is given a fixed height and scrollbar
+          // to work with the sticky nav inside it
           <MainCard title="Checkout" contentSX={{height: '75vh', padding: 0, overflow: 'auto'}}>
             <CheckoutPage />
           </MainCard>


### PR DESCRIPTION
## Description

On the checkout page, the navbar is now stuck to the top of the main content window, making it easy to jump to categories, search, or input the building code without having to scroll the top every time.

Key things for achieving the sticky navbar:
- The sticky element has to be the immediate child of the container that it is to be 'stuck' to, which required some restructuring of the jsx.
- The parent of the sticky NavBar (which is `CardContent` inside `MainCard`) needs a defined (non-auto) height. Since it's a long div of unknowable height, it made sense to make it scrollable with `overflow: auto`.

Note that this approach makes the card element scrollable, rather than the entire page like it has been. With the rules of sticky positioning, it's easier to implement it this way. 
To me the downside of this is that the card feels like a small window to traverse, especially when you start adding things to the cart. So I'll see if I can make it sticky to that whole window instead of just the card.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

_Link user story from projects.digitalaidseattle.org_

https://das-ph-inventory-tracker.atlassian.net/browse/PIT-242
- Closes #242

## QA Instructions, Screenshots, Recordings

Top of page:
![image](https://github.com/user-attachments/assets/7360e108-8bac-4ef1-b5dc-381069e09050)

After clicking on 'clothing':
![image](https://github.com/user-attachments/assets/ccdc6733-6434-49f7-955c-f536992c778f)

With some items checked out:
![image](https://github.com/user-attachments/assets/00315836-ade1-4090-bb4b-7932467bd20b)

