### PR TITLE
Clear out volunteer on log out

### DIFF
--- a/src/components/Checkout/CheckoutDialog.tsx
+++ b/src/components/Checkout/CheckoutDialog.tsx
@@ -154,7 +154,7 @@ export const CheckoutDialog: React.FC<CheckoutDialogProps> = ({ open, onClose, c
         }}>
           {checkoutItems.map((section: CategoryProps) => {
             if (section.categoryCount > 0) {
-              return <CategorySection category={section} categoryCheckout={section} addItemToCart={(item, quantity) => {
+              return <CategorySection key={section.id} category={section} categoryCheckout={section} addItemToCart={(item, quantity) => {
                 addItemToCart(item, quantity, section.category, section.category);
               }} removeItemFromCart={removeItemFromCart} removeButton={true} disabled={false} />
             }

--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, forwardRef } from 'react';
+import { ForwardedRef, ReactNode, forwardRef } from 'react';
 
 // material-ui
 import PageHeading from './PageHeading';
@@ -19,10 +19,13 @@ const MainContainer: React.FC<MainContainerProp> = forwardRef(
       content = true,
       title,
     },
+    ref: ForwardedRef<HTMLDivElement>
   ) => {
 
     return (
-      <Box sx={{
+      <Box 
+        ref={ref}
+        sx={{
         padding: '1rem',
         height: '100vh',
       }}>

--- a/src/layout/MainLayout/Header/HeaderContent/Profile/index.tsx
+++ b/src/layout/MainLayout/Header/HeaderContent/Profile/index.tsx
@@ -84,6 +84,7 @@ const Profile = () => {
   }, [user]);
 
   const handleLogout = async () => {
+    localStorage.clear();
     window.location.href = "/.auth/logout?post_logout_redirect_uri=/login.html";
   };
 

--- a/src/layout/MainLayout/index.tsx
+++ b/src/layout/MainLayout/index.tsx
@@ -34,8 +34,10 @@ const MainLayout: React.FC = () => {
 
   // Add inactivity timer
   const resetTimer = useInactivityTimer({
-    onInactivity: () => window.location.href = "/.auth/logout?post_logout_redirect_uri=/login.html",
-    timeout: SETTINGS.inactivity_timeout
+    onInactivity: () => {
+      localStorage.clear();
+      window.location.href = "/.auth/logout?post_logout_redirect_uri=/login.html";
+    },    timeout: SETTINGS.inactivity_timeout
   });
 
   useEffect(() => {

--- a/src/pages/VolunteerHome/index.tsx
+++ b/src/pages/VolunteerHome/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useEffect, useCallback } from 'react';
+import React, { useState, useContext, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Box, Typography, Button, Grid } from '@mui/material';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';

--- a/src/pages/VolunteerHome/index.tsx
+++ b/src/pages/VolunteerHome/index.tsx
@@ -33,11 +33,8 @@ const VolunteerHome: React.FC = () => {
     setIsLoading(false);
   }, [user]);
 
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
-
-  const handleAddOpen = () => {
+  const handleAddOpen = async () => {
+    await fetchData();
     setAddModal(true);
   };
 

--- a/src/pages/people/useUsers.test.tsx
+++ b/src/pages/people/useUsers.test.tsx
@@ -58,7 +58,7 @@ describe('useUsers hook', () => {
     const { result } = renderHook(() => useUsers(), { wrapper });
     await waitFor(() => result.current.loading === false);
     expect(result.current.originalData).toEqual([]);
-  });
+      });
 
   it('updateUserStatus toggles active status successfully', async () => {
     const initialUsers = [
@@ -131,6 +131,8 @@ describe('useUsers hook', () => {
     const { result } = renderHook(() => useUsers(), { wrapper });
     await waitFor(() => result.current.loading === false);
 
-    await expect(result.current.updateUserStatus(1)).rejects.toThrow(`Error updating user: ${errorMsg}`);
+    await act(async () => {
+      await expect(result.current.updateUserStatus(1)).rejects.toThrow(`Error updating user: ${errorMsg}`);
+    });
   });
 });

--- a/src/pages/people/useUsers.ts
+++ b/src/pages/people/useUsers.ts
@@ -23,30 +23,30 @@ const useUsers = () => {
       if (!response.ok) {
         if (response.status === 500) {
           throw new Error('Database is likely starting up. Try again in 30 seconds.');
-        } else { 
-        throw new Error(response.statusText);
+        } else {
+          throw new Error(response.statusText);
+        }
       }
+      const data = await response.json();
+      setOriginalData(data.value);
+      setFilteredData(data.value);
+    } catch (error) {
+      setError('Could not get users. \r\n' + error);
+    } finally {
+      setLoading(false);
     }
-    const data = await response.json();
-    setOriginalData(data.value);
-    setFilteredData(data.value);
-  } catch (error) {
-    setError('Could not get users. \r\n' + error);
-  } finally {
-    setLoading(false);
-  }
-}, [user]);
+  }, [user]);
 
-useEffect(() => {
-  fetchData();
-}, [user, fetchData]);
+  useEffect(() => {
+    fetchData();
+  }, [user, fetchData]);
 
-const updateUserStatus = async (userId: number) => {
-  try {
-    const userToUpdate = originalData.find((v) => v.id === userId);
-    if (!userToUpdate) throw new Error('User not found');
+  const updateUserStatus = async (userId: number) => {
+    try {
+      const userToUpdate = originalData.find((v) => v.id === userId);
+      if (!userToUpdate) throw new Error('User not found');
 
-    const updatedStatus = !userToUpdate.active;
+      const updatedStatus = !userToUpdate.active;
 
       const requestUrl = `${ENDPOINTS.USERS}/id/${userId}`;
       API_HEADERS['X-MS-API-ROLE'] = getRole(user);
@@ -57,37 +57,37 @@ const updateUserStatus = async (userId: number) => {
         body: JSON.stringify({ active: updatedStatus }),
       });
 
-    if (!response.ok) {
-      // Parse error details
-      const errorData = await response.json();
-      const errorMessage = errorData.error?.message || response.statusText;
-      throw new Error(`Error updating user: ${errorMessage}`);
+      if (!response.ok) {
+        // Parse error details
+        const errorData = await response.json();
+        const errorMessage = errorData.error?.message || response.statusText;
+        throw new Error(`Error updating user: ${errorMessage}`);
+      }
+
+      // Update the local data
+      const updatedUser = { ...userToUpdate, active: updatedStatus };
+
+      const updatedOriginalData = originalData.map((user) =>
+        user.id === userId ? updatedUser : user,
+      );
+
+      setOriginalData(updatedOriginalData);
+      setFilteredData(updatedOriginalData);
+    } catch (error) {
+      console.error('Error updating user:', error);
+      throw error;
     }
+  };
 
-    // Update the local data
-    const updatedUser = { ...userToUpdate, active: updatedStatus };
-
-    const updatedOriginalData = originalData.map((user) =>
-      user.id === userId ? updatedUser : user,
-    );
-
-    setOriginalData(updatedOriginalData);
-    setFilteredData(updatedOriginalData);
-  } catch (error) {
-    console.error('Error updating user:', error);
-    throw error;
-  }
-};
-
-return {
-  originalData,
-  filteredData,
-  setFilteredData,
-  loading,
-  error,
-  refetch: fetchData,
-  updateUserStatus,
-};
+  return {
+    originalData,
+    filteredData,
+    setFilteredData,
+    loading,
+    error,
+    refetch: fetchData,
+    updateUserStatus,
+  };
 };
 
 export default useUsers;

--- a/src/pages/routes.tsx
+++ b/src/pages/routes.tsx
@@ -3,7 +3,6 @@ import MainLayout from '../layout/MainLayout';
 import MinimalLayout from '../layout/MinimalLayout';
 import EnterPin from './authentication/EnterPinPage';
 import PickYourNamePage from './authentication/PickNamePage';
-import DashboardDefault from './dashboard';
 import Page404 from './error/404';
 import Inventory from './inventory';
 import VolunteerHome from './VolunteerHome';
@@ -17,7 +16,7 @@ const routes = [
     children: [
       {
         path: '',
-        element: <DashboardDefault />,
+        element: <VolunteerHome />,
       },
       {
         path: 'inventory',


### PR DESCRIPTION
## Description

While full logout is still broken, this PR clears the state of the volunteer. So when the main user logs out of the app, and subsequently comes back in, the volunteer should go through the pickname page again. 

(This is difficult to test in emulator so fingers crossed) 


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

#291

## QA Instructions, Screenshots, Recordings


