### PR TITLE
Misty/292 fix sticky header

### DIFF
--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -16,7 +16,8 @@ const MainContainer: React.FC<MainContainerProp> = forwardRef(
   (
     {
       children,
-      title
+      content = true,
+      title,
     },
   ) => {
 
@@ -29,7 +30,8 @@ const MainContainer: React.FC<MainContainerProp> = forwardRef(
           <PageHeading
             title={title}/>
         )}
-        {children}
+        {content && children}
+        {!content && children}
       </Box>
     );
   },

--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -24,7 +24,7 @@ const MainContainer: React.FC<MainContainerProp> = forwardRef(
     return (
       <Box sx={{
         padding: '1rem',
-        height: '100vh',
+        minHeight: '100vh',
       }}>
         {title && (
           <PageHeading

--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -16,8 +16,7 @@ const MainContainer: React.FC<MainContainerProp> = forwardRef(
   (
     {
       children,
-      content = true,
-      title,
+      title
     },
   ) => {
 
@@ -30,8 +29,7 @@ const MainContainer: React.FC<MainContainerProp> = forwardRef(
           <PageHeading
             title={title}/>
         )}
-        {content && children}
-        {!content && children}
+        {children}
       </Box>
     );
   },


### PR DESCRIPTION
## Description
Currently, the header is sticky until you scroll past the point of the page that exceeds your viewport’s height. 
The solution was to change the page container’s height: 100vh to min-height: 100vh.

Give it a test and let me know if it works as expected.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

_Link user story from projects.digitalaidseattle.org_

https://das-ph-inventory-tracker.atlassian.net/browse/PIT-292?atlOrigin=eyJpIjoiNTNkNzNkM2IxYTk4NGRlZTgzZWE3MGRiMjkwYTc3Y2UiLCJwIjoiaiJ9

