### PR TITLE
Tzeng/294 add item button disabled

### DIFF
--- a/database/data_seed/category_data.sql
+++ b/database/data_seed/category_data.sql
@@ -18,7 +18,7 @@ INSERT INTO Categories (id, Name, Checkout_Limit) VALUES
 (12, 'Cleaning', 4),
 (13, 'Garments', 2),
 (14, 'Jacket', 1),
-(15, 'Welcome Basket', 1);
+(15, 'Welcome Basket', 5);
 
 SET IDENTITY_INSERT Categories OFF;
 GO

--- a/src/components/Checkout/CategorySection.tsx
+++ b/src/components/Checkout/CategorySection.tsx
@@ -9,7 +9,7 @@ type CategorySectionProps = {
   removeItemFromCart: (itemId: number, categoryName: string) => void;
   removeButton: boolean;
   disabled: boolean;
-  activeSection: string;
+  activeSection?: string;
 };
 
 const CategorySection = ({ category, categoryCheckout, addItemToCart, removeItemFromCart, removeButton, disabled, activeSection }: CategorySectionProps) => {

--- a/src/components/Checkout/CategorySection.tsx
+++ b/src/components/Checkout/CategorySection.tsx
@@ -9,9 +9,10 @@ type CategorySectionProps = {
   removeItemFromCart: (itemId: number, categoryName: string) => void;
   removeButton: boolean;
   disabled: boolean;
+  activeSection: string;
 };
 
-const CategorySection = ({ category, categoryCheckout, addItemToCart, removeItemFromCart, removeButton, disabled }: CategorySectionProps) => {
+const CategorySection = ({ category, categoryCheckout, addItemToCart, removeItemFromCart, removeButton, disabled, activeSection }: CategorySectionProps) => {
 
   return (
     <Box sx={{ paddingX: removeButton ? '0%' : '5%', paddingBottom: '3%', opacity: disabled ? 0.5 : 1, pointerEvents: disabled ? 'none' : 'auto' }}>
@@ -20,7 +21,7 @@ const CategorySection = ({ category, categoryCheckout, addItemToCart, removeItem
           <Typography sx={{ fontSize: { xs: '14px', md: '20px' }, marginY: '3%', marginRight: '30px' }} id={category.category}>{category.category}</Typography>
           {removeButton ? null : <Typography sx={{ fontSize: { xs: '12px', md: '16px' }, color: '#666666' }}>{category.items.length} items</Typography>}
         </Box>
-        <Typography sx={{ fontSize: {xs: '12px', md: '16px'}, backgroundColor: '#ECECEC', borderRadius: '20px', paddingY: '4px', paddingX: '12px' }}>
+        <Typography sx={{ fontSize: { xs: '12px', md: '16px' }, backgroundColor: '#ECECEC', borderRadius: '20px', paddingY: '4px', paddingX: '12px' }}>
           {categoryCheckout?.categoryCount} of {category.checkout_limit}
         </Typography>
 
@@ -34,14 +35,14 @@ const CategorySection = ({ category, categoryCheckout, addItemToCart, removeItem
       >
         {category.items.map((item) => (
           <Grid
-          item
-          xs={removeButton ? 12 : 12}
-          sm={removeButton ? 12 : 6}
-          md={removeButton ? 12 : 4}
-          xl={removeButton ? 12 : 3}
-          key={item.id}
-        >
-            <CheckoutCard item={item} categoryCheckout={categoryCheckout} addItemToCart={addItemToCart} removeItemFromCart={removeItemFromCart} removeButton={removeButton} categoryLimit={category.checkout_limit} categoryName={category.category} />
+            item
+            xs={removeButton ? 12 : 12}
+            sm={removeButton ? 12 : 6}
+            md={removeButton ? 12 : 4}
+            xl={removeButton ? 12 : 3}
+            key={item.id}
+          >
+            <CheckoutCard item={item} categoryCheckout={categoryCheckout} addItemToCart={addItemToCart} removeItemFromCart={removeItemFromCart} removeButton={removeButton} categoryLimit={category.checkout_limit} categoryName={category.category} activeSection={activeSection} />
           </Grid>
         ))}
       </Grid>

--- a/src/components/Checkout/CategorySection.tsx
+++ b/src/components/Checkout/CategorySection.tsx
@@ -9,7 +9,7 @@ type CategorySectionProps = {
   removeItemFromCart: (itemId: number, categoryName: string) => void;
   removeButton: boolean;
   disabled: boolean;
-  activeSection?: string;
+  activeSection: string;
 };
 
 const CategorySection = ({ category, categoryCheckout, addItemToCart, removeItemFromCart, removeButton, disabled, activeSection }: CategorySectionProps) => {

--- a/src/components/Checkout/CheckoutCard.tsx
+++ b/src/components/Checkout/CheckoutCard.tsx
@@ -13,37 +13,34 @@ const CheckoutCard = ({ item, categoryCheckout, addItemToCart, removeItemFromCar
       return;
     }
 
-    if (categoryName === 'Welcome Basket' && categoryCheckout.items[0] && categoryCheckout.items[0].name) {
+    if (activeSection === '') {
+      setDisableAdd(false);
+      return;
+    }
+
+    if (activeSection === 'general') {
+      setDisableAdd(categoryName === 'Welcome Basket');
+      return;
+    }
+
+    if (activeSection === 'welcomeBasket') {
+      if (categoryName !== 'Welcome Basket') {
+        setDisableAdd(true);
+        return;
+      }
+
       const itemName = categoryCheckout.items[0].name.toLowerCase();
       if (itemName === item.name.toLowerCase()) {
         setDisableAdd(false);
       } else {
         setDisableAdd(true);
       }
-    } else {
-      setDisableAdd(false);
     }
-  }, [categoryCheckout, categoryLimit, categoryName, item.name]);
-
-
-  const checkActiveSection = useCallback(() => {
-    if (activeSection === '') {
-      setDisableAdd(false);
-    }
-    if (activeSection === 'welcomeBasket') {
-      setDisableAdd(categoryName !== 'Welcome Basket');
-    } else if (activeSection === 'general') {
-      setDisableAdd(categoryName === 'Welcome Basket');
-    }
-  }, [activeSection, categoryName]);
+  }, [categoryCheckout, categoryLimit, categoryName, item.name, activeSection]);
 
   useEffect(() => {
     checkConditions();
   }, [categoryCheckout.categoryCount, checkConditions])
-
-  useEffect(() => {
-    checkActiveSection();
-  }, [checkActiveSection])
 
   return (
     <Card key={item.name} variant='outlined'

--- a/src/components/Checkout/CheckoutCard.tsx
+++ b/src/components/Checkout/CheckoutCard.tsx
@@ -17,6 +17,9 @@ const CheckoutCard = ({ item, categoryCheckout, addItemToCart, removeItemFromCar
   }, [categoryCheckout?.categoryCount, categoryLimit]);
 
   const checkActiveSection = useCallback(() => {
+    if (activeSection === '') {
+      setDisableAdd(false);
+    }
     if (activeSection === 'welcomeBasket') {
       setDisableAdd(categoryName !== 'Welcome Basket');
     } else if (activeSection === 'general') {

--- a/src/components/Checkout/CheckoutCard.tsx
+++ b/src/components/Checkout/CheckoutCard.tsx
@@ -7,14 +7,24 @@ const CheckoutCard = ({ item, categoryCheckout, addItemToCart, removeItemFromCar
 
   const [disableAdd, setDisableAdd] = useState<boolean>(false);
 
-  const checkLimit = useCallback(() => {
+  const checkConditions = useCallback(() => {
     if ((categoryCheckout?.categoryCount ?? 0) >= categoryLimit) {
       setDisableAdd(true);
+      return;
+    }
+
+    if (categoryName === 'Welcome Basket' && categoryCheckout.items[0] && categoryCheckout.items[0].name) {
+      const itemName = categoryCheckout.items[0].name.toLowerCase();
+      if (itemName === item.name.toLowerCase()) {
+        setDisableAdd(false);
+      } else {
+        setDisableAdd(true);
+      }
     } else {
       setDisableAdd(false);
     }
+  }, [categoryCheckout, categoryLimit, categoryName, item.name]);
 
-  }, [categoryCheckout?.categoryCount, categoryLimit]);
 
   const checkActiveSection = useCallback(() => {
     if (activeSection === '') {
@@ -28,8 +38,8 @@ const CheckoutCard = ({ item, categoryCheckout, addItemToCart, removeItemFromCar
   }, [activeSection, categoryName]);
 
   useEffect(() => {
-    checkLimit();
-  }, [categoryCheckout?.categoryCount, checkLimit])
+    checkConditions();
+  }, [categoryCheckout.categoryCount, checkConditions])
 
   useEffect(() => {
     checkActiveSection();

--- a/src/components/Checkout/CheckoutDialog.tsx
+++ b/src/components/Checkout/CheckoutDialog.tsx
@@ -27,9 +27,10 @@ type CheckoutDialogProps = {
   setActiveSection: (s: string) => void;
   fetchData: () => void;
   setSelectedBuildingCode: (building: string) => void;
+  activeSection: string;
 };
 
-export const CheckoutDialog: React.FC<CheckoutDialogProps> = ({ open, onClose, checkoutItems, welcomeBasketData, setCheckoutItems, removeItemFromCart, addItemToCart, selectedBuildingCode, setActiveSection, fetchData, setSelectedBuildingCode, onSuccess }) => {
+export const CheckoutDialog: React.FC<CheckoutDialogProps> = ({ open, onClose, checkoutItems, welcomeBasketData, setCheckoutItems, removeItemFromCart, addItemToCart, selectedBuildingCode, setActiveSection, fetchData, setSelectedBuildingCode, onSuccess, activeSection }) => {
   const { user, loggedInUserId } = useContext(UserContext);
   const [originalCheckoutItems, setOriginalCheckoutItems] = useState<CategoryProps[]>([]);
   const [statusMessage, setStatusMessage] = useState<string>('');
@@ -142,7 +143,7 @@ export const CheckoutDialog: React.FC<CheckoutDialogProps> = ({ open, onClose, c
             if (section.categoryCount > 0) {
               return <CategorySection key={section.id} category={section} categoryCheckout={section} addItemToCart={(item, quantity) => {
                 addItemToCart(item, quantity, section.category, section.category);
-              }} removeItemFromCart={removeItemFromCart} removeButton={true} disabled={false} />
+              }} removeItemFromCart={removeItemFromCart} removeButton={true} disabled={false} activeSection={activeSection} />
             }
           })}
         </DialogContent>

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -328,6 +328,7 @@ const CheckoutPage = () => {
         setActiveSection={setActiveSection}
         fetchData={fetchData}
         setSelectedBuildingCode={setSelectedBuildingCode}
+        activeSection={activeSection}
       />
       <SnackbarAlert
         open={snackbarState.open}

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -34,7 +34,8 @@ const CheckoutPage = () => {
 
 
   const theme = useTheme();
-  const navigate = useNavigate(); 
+  const navigate = useNavigate();
+
   const addItemToCart = (
     item: CheckoutItemProp,
     quantity: number,
@@ -138,7 +139,7 @@ const CheckoutPage = () => {
       if (!response.ok) {
         if (response.status === 500) {
           throw new Error('Database is likely starting up. Try again in 30 seconds.');
-        } else { 
+        } else {
           throw new Error(response.statusText);
         }
       }
@@ -216,8 +217,8 @@ const CheckoutPage = () => {
     <>
     {/* Container for the sticky nav */}
     <Box sx={{
-      position: 'sticky', 
-      top: '3.5rem', 
+      position: 'sticky',
+      top: '3.5rem',
       zIndex: 2,
       p: 1,
       background: theme.palette.common.white,

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -283,6 +283,7 @@ const CheckoutPage = () => {
                 removeItemFromCart={removeItemFromCart}
                 removeButton={false}
                 disabled={searchActive || (activeSection !== '' && activeSection !== 'welcomeBasket')}
+                activeSection={activeSection}
               />
             );
           })}
@@ -304,6 +305,7 @@ const CheckoutPage = () => {
                 removeItemFromCart={removeItemFromCart}
                 removeButton={false}
                 disabled={searchActive || (activeSection !== '' && activeSection !== 'general')}
+                activeSection={activeSection}
               />
             );
           })}


### PR DESCRIPTION
## Description

When adding a welcome basket item after searching, the non-welcome basket item buttons will be disabled. After removing the welcome basket item from the search, the non-welcome basket item buttons will be re-enabled.

Welcome basket max has been increased to 5.

Only twin-size sheet or full-size sheet can be added to the cart, not both.


## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

https://das-ph-inventory-tracker.atlassian.net/jira/core/projects/PIT/board?atlOrigin=eyJwIjoiaiIsImkiOiIzMTBhMzYyZTI3ZGQ0ZWJjYTUxM2U5ODMzYzNmYmI5OCJ9&cloudId=c9daa5cb-2a47-4508-84ff-17a03d2ec13c&selectedIssue=PIT-294

- Related Issue #294
- Closes #

## QA Instructions, Screenshots, Recordings


