### PR TITLE
fixed add item api inconsistency

### DIFF
--- a/src/components/Checkout/SearchBar.tsx
+++ b/src/components/Checkout/SearchBar.tsx
@@ -49,10 +49,9 @@ const SearchBar: React.FC<SearchBarProps> = ({ data, setSearchData, setSearchAct
       variant="standard"
       placeholder={'Search...'}
       type="search" 
-      sx={{'input[type="search"]::-webkit-search-cancel-button ': {display: 'none'}}}
+      sx={{'input[type="search"]::-webkit-search-cancel-button ': {display: 'none'}, width: '30%'}}
       value={searchTerm}
       onChange={searchChangeHandler}
-      sx={{ width: '30%' }}
       inputProps={{ sx: { fontSize: { xs: '24px', md: '20px', lg: '16px'} } }} // font size of input text
       InputLabelProps={{ sx: { xs: '24px', md: '20px', lg: '16px'}}} // font size of input label
       InputProps={{

--- a/src/pages/VolunteerHome/index.tsx
+++ b/src/pages/VolunteerHome/index.tsx
@@ -18,7 +18,7 @@ const VolunteerHome: React.FC = () => {
   const fetchData = useCallback(async () => {
     try {
       API_HEADERS['X-MS-API-ROLE'] = getRole(user);
-      const response = await fetch(ENDPOINTS.ITEMS, {
+      const response = await fetch(ENDPOINTS.EXPANDED_ITEMS + '?$first=10000', {
         headers: API_HEADERS,
         method: 'GET',
       });


### PR DESCRIPTION
## Description

Currently, if you click on Add Item from Volunteer Home, you get an incomplete list back. If you click on Add Item from Inventory page, you get the right list. I have fixed the VolunteerHome side API to fetch via EXPANDED_ITEMS endpoint instead of the original ITEMS endpoint, mimicking the inventory side which was identified as correct. 

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

https://das-ph-inventory-tracker.atlassian.net/browse/PIT-293?atlOrigin=eyJpIjoiOWU4NTdhYTgxZjMyNDY1OTk0YjQ3YmMyMmM5ZTlmNWIiLCJwIjoiaiJ9

- Related Issue #293
- Closes #

## QA Instructions, Screenshots, Recordings


