### PR TITLE
Tzeng/301-wb-search-crash

### DIFF
--- a/src/components/inventory/AddItemModal.tsx
+++ b/src/components/inventory/AddItemModal.tsx
@@ -145,8 +145,8 @@ const AddItemModal = ({ addModal, handleAddClose, fetchData, originalData }: Add
                 )}
                 filterOptions={(options, { inputValue }) => { //This filter function details the rules for how the autocomplete should filter the dropdown options
                   return options.filter((option) =>
-                    option.name.toLowerCase().includes(inputValue.toLowerCase()) ||
-                    option.description.toLowerCase().includes(inputValue.toLowerCase())
+                    option.name?.toLowerCase().includes(inputValue.toLowerCase()) ||
+                    option.description?.toLowerCase().includes(inputValue.toLowerCase())
                   );
                 }}
                 renderInput={(params) => <TextField {...params} />}


### PR DESCRIPTION
## Description

When adding an item to the Welcome Basket type on the inventory page, typing in a search entry would cause the page to crash. This was due to a typescript error where if a definition returns null, the filter function was filtering through null, causing it to error. 

I added the case where if the definition was not present, to continue with the filtering. Simple '?' next to description.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

https://das-ph-inventory-tracker.atlassian.net/jira/core/projects/PIT/board?atlOrigin=eyJwIjoiaiIsImkiOiIzMTBhMzYyZTI3ZGQ0ZWJjYTUxM2U5ODMzYzNmYmI5OCJ9&cloudId=c9daa5cb-2a47-4508-84ff-17a03d2ec13c&groupBy=status&selectedIssue=PIT-301

- Related Issue 301
- Closes #

## QA Instructions, Screenshots, Recordings
