### PR TITLE
Tzeng/295-Reset-active-section-after-emptying-cart

### DIFF
--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -99,8 +99,8 @@ const CheckoutPage = () => {
   };
 
   const removeItemFromCart = (itemId: number, categoryName: string) => {
-    setCheckoutItems((prevCheckoutItems) =>
-      prevCheckoutItems.map((category) => {
+    setCheckoutItems((prevCheckoutItems) => {
+      const updatedCheckoutItems = prevCheckoutItems.map((category) => {
         if (category.category === categoryName) {
           const updatedItems = category.items.filter(
             (addedItem: CheckoutItemProp) => addedItem.id !== itemId
@@ -118,8 +118,16 @@ const CheckoutPage = () => {
           };
         }
         return category;
-      })
-    );
+      });
+
+      // Check if all categories are empty
+      const isCartEmpty = updatedCheckoutItems.every(category => category.items.length === 0);
+      if (isCartEmpty) {
+        setActiveSection('');
+      }
+
+      return updatedCheckoutItems;
+    });
   };
 
 


### PR DESCRIPTION
## Description

Emptying the cart by clicking 'Remove' in the checkout cart did not reset the activeSection of either Welcome Basket or General Items. Because of this, Users were unable to add items from a different section after clearing the cart. This PR adds a logic step to check if the cart is empty each time 'Remove' is clicked. If cart is empty, it will reset activeSection to nothing so that either sections can be interacted with.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

https://das-ph-inventory-tracker.atlassian.net/jira/core/projects/PIT/board?groupBy=status&selectedIssue=PIT-295

- Related Issue #295
- Closes #

## QA Instructions, Screenshots, Recordings

