### PR TITLE
Brian/297 add items bypasses transactions

### DIFF
--- a/database/cleanup/cleanup.sql
+++ b/database/cleanup/cleanup.sql
@@ -10,6 +10,7 @@ DROP PROCEDURE IF EXISTS LogTransaction;
 DROP PROCEDURE IF EXISTS LogTransactionItem;
 DROP PROCEDURE IF EXISTS GetRecentTransactions;
 DROP PROCEDURE IF EXISTS VerifyVolunteerPin;
+DROP PROCEDURE IF EXISTS ProcessInventoryChange;
 
 DROP TYPE IF EXISTS CartItemsType;
 

--- a/database/procedures/log_transaction.sql
+++ b/database/procedures/log_transaction.sql
@@ -6,8 +6,8 @@ CREATE PROCEDURE LogTransaction
     @user_id INT,
     @transaction_type NVARCHAR(50),
     @building_id INT = NULL,
-    @unit_number NVARCHAR(10),
-    @resident_name NVARCHAR(50),
+    @unit_number NVARCHAR(10) = NULL,
+    @resident_name NVARCHAR(50) = NULL,
     @new_transaction_id UNIQUEIDENTIFIER OUTPUT
 AS
 BEGIN

--- a/database/procedures/log_transaction.sql
+++ b/database/procedures/log_transaction.sql
@@ -5,7 +5,7 @@ GO
 CREATE PROCEDURE LogTransaction
     @user_id INT,
     @transaction_type NVARCHAR(50),
-    @building_id INT,
+    @building_id INT = NULL,
     @unit_number NVARCHAR(10),
     @resident_name NVARCHAR(50),
     @new_transaction_id UNIQUEIDENTIFIER OUTPUT

--- a/database/procedures/process_inventory_change.sql
+++ b/database/procedures/process_inventory_change.sql
@@ -1,0 +1,108 @@
+DROP PROCEDURE IF EXISTS [dbo].[ProcessInventoryChange];
+GO
+
+CREATE PROCEDURE ProcessInventoryChange
+    @user_id INT,
+    @item NVARCHAR(MAX),
+    @building_code NVARCHAR(50),
+    @message NVARCHAR(MAX) = NULL OUTPUT,
+    @unit_number NVARCHAR(10),
+    @resident_name NVARCHAR(50)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    print @user_id
+    print @item
+
+    -- Validate JSON
+    IF ISJSON(@item) = 0
+    BEGIN
+        THROW 51002, 'Invalid JSON format', 1;
+    END
+    
+    -- Create a table variable to hold our parsed JSON items
+    DECLARE @CartItems CartItemsType
+
+    -- Parse the JSON array into our table variable
+    INSERT INTO @CartItems (ItemId, Quantity, AdditionalNotes)
+    SELECT 
+        ItemId = JSON_VALUE([value], '$.id'),
+        Quantity = JSON_VALUE([value], '$.quantity'),
+        AdditionalNotes = JSON_VALUE([value], '$.additional_notes')
+    FROM OPENJSON(@item, '$')
+    
+    BEGIN TRANSACTION
+    
+    BEGIN TRY        
+        -- After transaction ID is obtained, set up cursor
+        DECLARE @CurrentItemId INT
+        DECLARE @CurrentQuantity INT
+        DECLARE @CurrentAdditionalNotes NVARCHAR(255)
+        
+        DECLARE item_cursor CURSOR FOR
+        SELECT ItemId, Quantity, AdditionalNotes FROM @CartItems
+        
+        OPEN item_cursor
+        FETCH NEXT FROM item_cursor INTO @CurrentItemId, @CurrentQuantity, @CurrentAdditionalNotes
+
+        -- First, create the transaction ID
+        DECLARE @new_transaction_id UNIQUEIDENTIFIER;
+
+        -- Log to Transaction Table 
+        EXEC LogTransaction
+            @user_id = @user_id,
+            @transaction_type = 1,
+            @new_transaction_id = @new_transaction_id OUTPUT;
+        
+        -- Log to Transaction Item Table
+        WHILE @@FETCH_STATUS = 0
+        BEGIN
+            EXEC LogTransactionItem
+                @transaction_id = @new_transaction_id,
+                @item_id = @CurrentItemId,
+                @quantity = @CurrentQuantity,
+                @additional_notes = @CurrentAdditionalNotes;
+                
+            FETCH NEXT FROM item_cursor INTO @CurrentItemId, @CurrentQuantity, @CurrentAdditionalNotes
+        END
+
+        -- Update inventory
+        UPDATE i
+        SET i.quantity = i.quantity + ci.Quantity
+        FROM Items i
+        JOIN @CartItems ci ON i.id = ci.ItemId
+        
+        CLOSE item_cursor
+        DEALLOCATE item_cursor
+        
+        COMMIT TRANSACTION
+        
+        -- Return success status with transaction ID
+        SELECT 
+            'Success' as Status,
+            @new_transaction_id AS message
+        
+    END TRY
+    BEGIN CATCH
+        -- Rollback transaction if any error occurs
+        IF @@TRANCOUNT > 0
+            ROLLBACK TRANSACTION
+            
+        -- Clean up cursor if still open
+        IF CURSOR_STATUS('local', 'item_cursor') >= 0
+        BEGIN
+            CLOSE item_cursor
+            DEALLOCATE item_cursor
+        END
+        
+        SELECT 
+            'Error' AS Status,
+            CONCAT(
+                'Error: ', ERROR_MESSAGE(),
+                ', Error Number: ', ERROR_NUMBER(),
+                ', State: ', ERROR_STATE()
+            ) AS message;
+            
+    END CATCH
+END

--- a/database/procedures/process_inventory_change.sql
+++ b/database/procedures/process_inventory_change.sql
@@ -45,7 +45,7 @@ BEGIN
         -- Log to Transaction Table 
         EXEC LogTransaction
             @user_id = @user_id,
-            @transaction_type = 1,
+            @transaction_type = 2,
             @building_id = NULL,
             @resident_name = NULL,
             @unit_number = NULL, 

--- a/database/procedures/process_inventory_change.sql
+++ b/database/procedures/process_inventory_change.sql
@@ -3,16 +3,10 @@ GO
 
 CREATE PROCEDURE ProcessInventoryChange
     @user_id INT,
-    @item NVARCHAR(MAX),
-    @building_code NVARCHAR(50) = NULL,
-    @unit_number NVARCHAR(10) = NULL,
-    @resident_name NVARCHAR(50) = NULL
+    @item NVARCHAR(MAX)
 AS
 BEGIN
     SET NOCOUNT ON;
-
-    print @user_id
-    print @item
 
     -- Validate JSON
     IF ISJSON(@item) = 0
@@ -33,14 +27,7 @@ BEGIN
     
     BEGIN TRANSACTION
     
-    BEGIN TRY 
-        -- Look up building_id if building_code is provided
-        DECLARE @building_id INT = NULL
-        IF @building_code IS NOT NULL
-        BEGIN
-            SELECT @building_id = id FROM Buildings WHERE code = @building_code
-        END    
-           
+    BEGIN TRY            
         -- After transaction ID is obtained, set up cursor
         DECLARE @CurrentItemId INT
         DECLARE @CurrentQuantity INT
@@ -59,9 +46,9 @@ BEGIN
         EXEC LogTransaction
             @user_id = @user_id,
             @transaction_type = 1,
-            @building_id = @building_id,
-            @resident_name = @resident_name,
-            @unit_number = @unit_number, 
+            @building_id = NULL,
+            @resident_name = NULL,
+            @unit_number = NULL, 
             @new_transaction_id = @new_transaction_id OUTPUT;
         
         -- Log to Transaction Item Table

--- a/database/tables/transaction.sql
+++ b/database/tables/transaction.sql
@@ -6,7 +6,7 @@ CREATE TABLE Transactions (
     user_id INT NOT NULL,
     transaction_type INT NOT NULL,
     transaction_date DATETIME DEFAULT GETDATE() NOT NULL,
-    building_id INT NOT NULL,
+    building_id INT,
     unit_number NVARCHAR(10),
     resident_name NVARCHAR(50),
 );

--- a/database/tests/test_inventory_change.sql
+++ b/database/tests/test_inventory_change.sql
@@ -1,0 +1,30 @@
+-- Simple test file to test inventory change. 
+print 'Current inventory'
+select * from Transactions
+select * from TransactionItems
+select name, quantity from Items where id = 2
+
+
+print 'Test add inventory'
+exec ProcessInventoryChange @user_id = 1, @item = N'[
+      {
+        "id": 2,
+        "quantity": 3
+      }
+    ]'
+
+select * from Transactions
+select * from TransactionItems
+select name, quantity from Items where id = 2
+
+print 'Test reduce inventory'
+exec ProcessInventoryChange @user_id = 1, @item = N'[
+      {
+        "id": 2,
+        "quantity": -3
+      }
+    ]'
+
+select * from Transactions
+select * from TransactionItems
+select name, quantity from Items where id = 2

--- a/src/components/inventory/AddItemModal.tsx
+++ b/src/components/inventory/AddItemModal.tsx
@@ -83,11 +83,10 @@ const AddItemModal = ({ addModal, handleAddClose, fetchData, originalData }: Add
           headers: API_HEADERS, 
           body: JSON.stringify({ 
             user_id: loggedInUserId,
-            item: [{ id: updateItem.id, quantity: updateItem.quantity }],
+            item: [{ id: updateItem.id, quantity: formData.quantity }],
             building_code: "",
             unit_number: "",
             resident_name: "",
-            message: "",
           }) 
         });
         if (!response.ok) {

--- a/src/components/inventory/AddItemModal.tsx
+++ b/src/components/inventory/AddItemModal.tsx
@@ -84,9 +84,6 @@ const AddItemModal = ({ addModal, handleAddClose, fetchData, originalData }: Add
           body: JSON.stringify({ 
             user_id: loggedInUserId,
             item: [{ id: updateItem.id, quantity: formData.quantity }],
-            building_code: "",
-            unit_number: "",
-            resident_name: "",
           }) 
         });
         if (!response.ok) {

--- a/src/components/inventory/AddItemModal.tsx
+++ b/src/components/inventory/AddItemModal.tsx
@@ -19,7 +19,7 @@ type AddItemModalProps = {
 }
 
 const AddItemModal = ({ addModal, handleAddClose, fetchData, originalData }: AddItemModalProps) => {
-  const { user } = useContext(UserContext);
+  const { user, loggedInUserId } = useContext(UserContext);
   const [updateItem, setUpdateItem] = useState<InventoryItem | null>(null);
   const [formData, setFormData] = useState<FormData>({
     type: '',
@@ -68,16 +68,28 @@ const AddItemModal = ({ addModal, handleAddClose, fetchData, originalData }: Add
   }
 
   const updateItemHandler = async () => {
+    const newQuantity = Number(updateItem?.quantity) + Number(formData.quantity);
     if (formData.type === '' || formData.name === '' || formData.quantity === 0 || !updateItem) {
       setErrorMessage('Missing Information or Quantity cannot be 0')
       return;
-    } else if (Number(updateItem.quantity) + Number(formData.quantity) < 0) {
+    } else if (newQuantity < 0) {
       setErrorMessage('Item quantity cannot go below 0.')
       return;
     } else {
       try {
         API_HEADERS['X-MS-API-ROLE'] = getRole(user);
-        const response = await fetch(`${ENDPOINTS.ITEMS}/id/${updateItem.id}`, { method: "PATCH", headers: API_HEADERS, body: JSON.stringify({ quantity: Number(updateItem.quantity) + Number(formData.quantity) }) });
+        const response = await fetch(ENDPOINTS.PROCESS_INVENTORY_CHANGE, { 
+          method: "POST", 
+          headers: API_HEADERS, 
+          body: JSON.stringify({ 
+            user_id: loggedInUserId,
+            item: [{ id: updateItem.id, quantity: updateItem.quantity }],
+            building_code: "",
+            unit_number: "",
+            resident_name: "",
+            message: "",
+          }) 
+        });
         if (!response.ok) {
           throw new Error(response.statusText);
         } else {

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -14,6 +14,7 @@ export const ENDPOINTS = {
   VERIFY_PIN: '/data-api/rest/verify-pin',
   CHECKOUT_GENERAL_ITEMS: '/data-api/rest/checkout-general-items',
   CHECKOUT_WELCOME_BASKET: '/data-api/rest/checkout-welcome-basket',
+  PROCESS_INVENTORY_CHANGE: '/data-api/rest/process-inventory-change',
   RECENT_TRANSACTIONS: '/data-api/rest/recent-transactions',
   //Views
   EXPANDED_ITEMS: '/data-api/rest/itemswithcategory',

--- a/swa-db-connections/staticwebapp.database.config.json
+++ b/swa-db-connections/staticwebapp.database.config.json
@@ -190,6 +190,26 @@
         }
       ]
     },
+    "ProcessInventoryChange": {
+      "source": {
+        "object": "dbo.ProcessInventoryChange",
+        "type": "stored-procedure"
+      },
+      "rest": {
+        "enabled": true,
+        "path": "/process-inventory-change"
+      },
+      "permissions": [
+        {
+          "actions": ["execute"],
+          "role": "admin"
+        },
+        {
+          "actions": ["execute"],
+          "role": "volunteer"
+        }
+      ]
+    },
     "ProcessWelcomeBasket": {
       "source": {
         "object": "dbo.ProcessWelcomeBasketCheckout",


### PR DESCRIPTION
## Description

Inventory updates bypass transactions table and that is not good for the analytics and history tracking. 
Updates to inventory should be logged in transactions table, using the log_transaction and log_transaction_item stored procedure before finally updates inventory items. 

Added stored procedure process_inventory_change.sql to tackle logging changes before inventory updates. 
Updated REST endpoints in AddItemModal.tsx to use the new stored procedures. 
Added test for process_inventory_change.sql stored procedure. 
Updated other configurations to enable usage of the new stored procedure. 

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

https://das-ph-inventory-tracker.atlassian.net/browse/PIT-297?atlOrigin=eyJpIjoiYWQ0OGM1YmEyYWI5NDA1Mjk4YTMxMjNiNzc2NWM1YzYiLCJwIjoiaiJ9

- Related Issue #297
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well as any relevant images for UI changes._

