### PR TITLE
Misty/261 bug fix on Inventory page: unable to input negatives on tablet/mobile

### DIFF
--- a/src/components/inventory/AddItemModal.tsx
+++ b/src/components/inventory/AddItemModal.tsx
@@ -1,9 +1,10 @@
-import { Modal, Box, Typography, Select, MenuItem, TextField, Button, Autocomplete, FormControl, FormControlLabel, Radio, RadioGroup, } from '@mui/material';
+import { Modal, Box, Typography, Select, MenuItem, TextField, Button, Autocomplete } from '@mui/material';
 import { useContext, useState } from 'react';
 import { InventoryItem } from '../../types/interfaces.ts';
 import SnackbarAlert from '../SnackbarAlert.tsx';
 import { ENDPOINTS, API_HEADERS } from '../../types/constants.ts';
 import { getRole, UserContext } from '../contexts/UserContext.ts';
+import { Add, Remove } from '@mui/icons-material';
 
 type FormData = {
   type: string;
@@ -153,21 +154,16 @@ const AddItemModal = ({ addModal, handleAddClose, fetchData, originalData }: Add
           </Box>
 
 
-            <Box id="add-item-quantity" sx={{ width: '30%' }}>
+            <Box id="add-item-quantity">
                 <Typography fontWeight='bold'>
                   Value
                 </Typography>
-                <TextField sx={{ width: '100%' }} value={formData.quantity} type="number" onChange={(e) => handleInputChange('quantity', e.target.value)}></TextField>
+                <Box sx={{ display: 'flex' }}>
+                  <Button  onClick={() => handleInputChange('quantity', Number(formData.quantity) - 1)}><Remove/></Button>
+                  <TextField inputProps={{style: { textAlign: 'center', width: '5rem' }}} value={formData.quantity} type="number" onChange={(e) => handleInputChange('quantity', e.target.value)}></TextField>
+                  <Button onClick={() => handleInputChange('quantity', Number(formData.quantity) + 1)}><Add/></Button>
+                </Box>
             </Box>
-
-            <FormControl>
-              <RadioGroup
-                name="row-radio-buttons-group"
-              >
-                <FormControlLabel value="add" control={<Radio />} label="Add To Total Quantity" />
-                <FormControlLabel value="subtract" control={<Radio />} label="Subtract From Total Quantity" />
-              </RadioGroup>
-            </FormControl>
 
           {errorMessage.length > 0 ? <SnackbarAlert open={true} onClose={() => setErrorMessage('')}  severity={'error'}> {errorMessage} </SnackbarAlert> : null}
           <Box id="modal-buttons" sx={{ display: 'flex', width: '100%', justifyContent: 'end' }}>

--- a/src/components/inventory/AddItemModal.tsx
+++ b/src/components/inventory/AddItemModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, Box, Typography, Select, MenuItem, TextField, Button, Autocomplete, } from '@mui/material';
+import { Modal, Box, Typography, Select, MenuItem, TextField, Button, Autocomplete, FormControl, FormControlLabel, Radio, RadioGroup, } from '@mui/material';
 import { useContext, useState } from 'react';
 import { InventoryItem } from '../../types/interfaces.ts';
 import SnackbarAlert from '../SnackbarAlert.tsx';
@@ -100,10 +100,10 @@ const AddItemModal = ({ addModal, handleAddClose, fetchData, originalData }: Add
       onClose={resetInputsHandler}
     >
       {/* Title Section */}
-      <Box sx={{ position: 'fixed', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', minWidth: '500px', width: '30%', height: '400px', minHeight: '30%', backgroundColor: 'white', borderRadius: '8px', overflow: 'auto' }}>
-        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'start', justifyContent: 'space-evenly', width: '70%', margin: 'auto', height: '100%' }}>
+      <Box sx={{ position: 'fixed', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', minWidth: '500px', width: '30%', minHeight: '30vh', backgroundColor: 'white', borderRadius: '8px', overflow: 'auto', paddingY: '1.5rem' }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'start', gap: '1rem', width: '70%', margin: 'auto', height: '100%' }}>
           <Typography sx={{ fontSize: '20px', }}>
-            Add Item
+            Edit Item Quantity
           </Typography>
 
           {/* Item Type */}
@@ -121,49 +121,58 @@ const AddItemModal = ({ addModal, handleAddClose, fetchData, originalData }: Add
             </Select>
           </Box>
 
-          <Box sx={{ display: 'flex', width: '100%', justifyContent: 'space-between' }}>
             {/* Item Name */}
-            <Box id="add-item-name" sx={{ width: '65%' }}>
-              <Typography fontWeight='bold'>
-                Item Name
-              </Typography>
-              <Autocomplete
-                onChange={(_, value) => onChangeHandler(value)}
-                options={nameSearch} // Pass the full array of objects
-                getOptionLabel={(option) => option.name}
-                renderOption={(props, option) => (
-                  <li {...props} style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
-                    <span>
-                      {option.name}
+          <Box id="add-item-name" sx={{ width: '100%' }}>
+            <Typography fontWeight='bold'>
+              Item Name
+            </Typography>
+            <Autocomplete
+              onChange={(_, value) => onChangeHandler(value)}
+              options={nameSearch} // Pass the full array of objects
+              getOptionLabel={(option) => option.name}
+              renderOption={(props, option) => (
+                <li {...props} style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
+                  <span>
+                    {option.name}
+                  </span>
+                  {option.category && (
+                    <span style={{ fontSize: '0.8rem', color: 'gray' }}>
+                      {option.category}
                     </span>
-                    {option.category && (
-                      <span style={{ fontSize: '0.8rem', color: 'gray' }}>
-                        {option.category}
-                      </span>
-                    )}
-                  </li>
-                )}
-                filterOptions={(options, { inputValue }) => { //This filter function details the rules for how the autocomplete should filter the dropdown options
-                  return options.filter((option) =>
-                    option.name?.toLowerCase().includes(inputValue.toLowerCase()) ||
-                    option.description?.toLowerCase().includes(inputValue.toLowerCase())
-                  );
-                }}
-                renderInput={(params) => <TextField {...params} />}
-              />
-            </Box>
+                  )}
+                </li>
+              )}
+              filterOptions={(options, { inputValue }) => { //This filter function details the rules for how the autocomplete should filter the dropdown options
+                return options.filter((option) =>
+                  option.name?.toLowerCase().includes(inputValue.toLowerCase()) ||
+                  option.description?.toLowerCase().includes(inputValue.toLowerCase())
+                );
+              }}
+              renderInput={(params) => <TextField {...params} />}
+            />
+          </Box>
+
 
             <Box id="add-item-quantity" sx={{ width: '30%' }}>
-              <Typography fontWeight='bold'>
-                Quantity
-              </Typography>
-              <TextField sx={{ width: '100%' }} value={formData.quantity} type="number" onChange={(e) => handleInputChange('quantity', e.target.value)}></TextField>
+                <Typography fontWeight='bold'>
+                  Value
+                </Typography>
+                <TextField sx={{ width: '100%' }} value={formData.quantity} type="number" onChange={(e) => handleInputChange('quantity', e.target.value)}></TextField>
             </Box>
-          </Box>
+
+            <FormControl>
+              <RadioGroup
+                name="row-radio-buttons-group"
+              >
+                <FormControlLabel value="add" control={<Radio />} label="Add To Total Quantity" />
+                <FormControlLabel value="subtract" control={<Radio />} label="Subtract From Total Quantity" />
+              </RadioGroup>
+            </FormControl>
+
           {errorMessage.length > 0 ? <SnackbarAlert open={true} onClose={() => setErrorMessage('')}  severity={'error'}> {errorMessage} </SnackbarAlert> : null}
           <Box id="modal-buttons" sx={{ display: 'flex', width: '100%', justifyContent: 'end' }}>
             <Button sx={{ mr: '20px', color: 'black' }} onClick={resetInputsHandler}>Cancel</Button>
-            <Button sx={{ color: 'black' }} onClick={updateItemHandler}>Add</Button>
+            <Button sx={{ color: 'black' }} onClick={updateItemHandler}>Submit</Button>
           </Box>
         </Box>
       </Box>


### PR DESCRIPTION
## Description

Users have been unable to input negative values on the Inventory page, due to how Samsung devices render the default html number input, where the up/down arrows are missing, and the keypad that appears has no negative option.

To work around this issue, I added on-screen plus and minus buttons, so tablet users can input negatives.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

https://das-ph-inventory-tracker.atlassian.net/jira/core/projects/PIT/board?filter=assignee%20%3D%20currentUser%28%29&groupBy=status&selectedIssue=PIT-261

## QA Instructions, Screenshots, Recordings

![image](https://github.com/user-attachments/assets/d0dcce74-1b5e-4812-b527-41f2166af748)