### PR TITLE
Misty/311 - confirmation messages after checkout and inventory add

### DIFF
--- a/src/components/inventory/AddItemModal.tsx
+++ b/src/components/inventory/AddItemModal.tsx
@@ -14,11 +14,12 @@ type FormData = {
 type AddItemModalProps = {
   addModal: boolean;
   handleAddClose: () => void;
+  handleSnackbar: (message: string) => void;
   fetchData: () => void;
   originalData: InventoryItem[];
 }
 
-const AddItemModal = ({ addModal, handleAddClose, fetchData, originalData }: AddItemModalProps) => {
+const AddItemModal = ({ addModal, handleAddClose, handleSnackbar, fetchData, originalData }: AddItemModalProps) => {
   const { user, loggedInUserId } = useContext(UserContext);
   const [updateItem, setUpdateItem] = useState<InventoryItem | null>(null);
   const [formData, setFormData] = useState<FormData>({
@@ -91,6 +92,7 @@ const AddItemModal = ({ addModal, handleAddClose, fetchData, originalData }: Add
         } else {
           setErrorMessage('');
           fetchData();
+          handleSnackbar(`${formData.quantity} ${updateItem.name} in ${updateItem.category} have been added.`);
           handleAddClose();
           resetInputsHandler();
         }

--- a/src/pages/VolunteerHome/VolunteerHome.test.tsx
+++ b/src/pages/VolunteerHome/VolunteerHome.test.tsx
@@ -5,11 +5,18 @@ import { describe, test, expect, vi, beforeEach } from 'vitest';
 import VolunteerHome from './index';
 import { UserContext } from '../../components/contexts/UserContext';
 
-// Mock useXxxx and return a mock function
-const mockHooks = vi.fn();
-  vi.mock('react-router-dom', () => ({
-  useNavigate: () => mockHooks,
-  useLocation: () => mockHooks,
+const mockNavigate = vi.fn();
+const mockLocation = {
+  pathname: '/volunteer-home',
+  search: '',
+  hash: '',
+  state: { checkoutSuccess: true, message: "1 item has been checked out" },
+  key: 'default'
+};
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useLocation: () => mockLocation,
 }));
 
 // Mock AddItemModal so we can control its display state using a test id
@@ -18,6 +25,15 @@ vi.mock('../../components/inventory/AddItemModal.tsx', () => ({
     <div data-testid="add-item-modal">
       {addModal ? "Modal Open" : "Modal Closed"} - {originalData.length} items
       <button onClick={handleAddClose}>Close Modal</button>
+    </div>
+  ),
+}));
+
+// Mock SnackbarAlert
+vi.mock('../../components/SnackbarAlert.tsx', () => ({
+  default: ({ children }: any) => (
+    <div data-testid="snackbar-alert">
+      {children}
     </div>
   ),
 }));
@@ -75,7 +91,7 @@ describe('VolunteerHome Component', () => {
     const checkOutButton = screen.getByRole('button', { name: /Check Out/i });
     fireEvent.click(checkOutButton);
 
-    expect(mockHooks).toHaveBeenCalledWith('/checkout');
+    expect(mockNavigate).toHaveBeenCalledWith('/checkout');
   });
 
   test('opens and closes AddItemModal when Add Item button is clicked', async () => {
@@ -161,4 +177,17 @@ describe('VolunteerHome Component', () => {
     // Check if the state is updated with fetched data
     expect(screen.getByTestId('add-item-modal')).toHaveTextContent('2 items');
   });
+
+  test('render snackbar', async () => {
+    render(
+      <Wrapper>
+        <VolunteerHome />
+      </Wrapper>
+    );
+
+    expect(screen.queryByTestId('snackbar-alert')).toBeInTheDocument();  
+    // snackbar should take message from the location object
+    expect(screen.queryByTestId('snackbar-alert')).toHaveTextContent(mockLocation.state.message);  
+  })
+
 });

--- a/src/pages/VolunteerHome/VolunteerHome.test.tsx
+++ b/src/pages/VolunteerHome/VolunteerHome.test.tsx
@@ -5,10 +5,11 @@ import { describe, test, expect, vi, beforeEach } from 'vitest';
 import VolunteerHome from './index';
 import { UserContext } from '../../components/contexts/UserContext';
 
-// Mock useNavigate and return a mock function
-const mockNavigate = vi.fn();
-vi.mock('react-router-dom', () => ({
-  useNavigate: () => mockNavigate,
+// Mock useXxxx and return a mock function
+const mockHooks = vi.fn();
+  vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockHooks,
+  useLocation: () => mockHooks,
 }));
 
 // Mock AddItemModal so we can control its display state using a test id
@@ -74,7 +75,7 @@ describe('VolunteerHome Component', () => {
     const checkOutButton = screen.getByRole('button', { name: /Check Out/i });
     fireEvent.click(checkOutButton);
 
-    expect(mockNavigate).toHaveBeenCalledWith('/checkout');
+    expect(mockHooks).toHaveBeenCalledWith('/checkout');
   });
 
   test('opens and closes AddItemModal when Add Item button is clicked', async () => {

--- a/src/pages/VolunteerHome/index.tsx
+++ b/src/pages/VolunteerHome/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useContext, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+import {useLocation} from 'react-router-dom';
 import { Box, Typography, Button, Grid } from '@mui/material';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import AddIcon from '@mui/icons-material/Add';
@@ -7,6 +8,7 @@ import AddItemModal from '../../components/inventory/AddItemModal.tsx';
 import { getRole, UserContext } from '../../components/contexts/UserContext';
 import { ENDPOINTS, API_HEADERS } from '../../types/constants';
 import { InventoryItem } from '../../types/interfaces.ts';
+import SnackbarAlert from '../../components/SnackbarAlert.tsx';
 
 const VolunteerHome: React.FC = () => {
   const { user } = useContext(UserContext);
@@ -14,6 +16,18 @@ const VolunteerHome: React.FC = () => {
   const [addModal, setAddModal] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [originalData, setOriginalData] = useState<InventoryItem[]>([]);
+  
+  const location = useLocation();
+  const showSnackbar = location.state && location.state.message;
+  const [snackbarOpen, setSnackbarOpen] = useState<boolean>(showSnackbar);
+
+  const handleSnackbarClose = (
+    _event?: React.SyntheticEvent | Event,
+    reason?: string,
+  ) => {
+    if (reason === 'clickaway') return;
+    setSnackbarOpen(false);
+  };
 
   const fetchData = useCallback(async () => {
     try {
@@ -49,6 +63,7 @@ const VolunteerHome: React.FC = () => {
   if (isLoading) {
     return <p>Loading ...</p>;
   }
+
   return (
     <Box sx={{ paddingX: 20, paddingY: 5, height: '75vh' }}>
       {/* Header */}
@@ -139,6 +154,16 @@ const VolunteerHome: React.FC = () => {
           />
         </Grid>
       </Grid>
+
+    {showSnackbar &&
+        <SnackbarAlert
+          open={snackbarOpen}
+          onClose={handleSnackbarClose}
+          severity={'success'}
+        >
+          {location.state.message}
+        </SnackbarAlert>
+      }
     </Box>
   );
 };

--- a/src/pages/VolunteerHome/index.tsx
+++ b/src/pages/VolunteerHome/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import {useLocation} from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { Box, Typography, Button, Grid } from '@mui/material';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import AddIcon from '@mui/icons-material/Add';

--- a/src/pages/VolunteerHome/index.tsx
+++ b/src/pages/VolunteerHome/index.tsx
@@ -19,15 +19,21 @@ const VolunteerHome: React.FC = () => {
   
   const location = useLocation();
 
-  const [snackBarMessage, setSnackBarMessage] = useState<string>(location.state ? location.state.message : '');
-  const [snackbarOpen, setSnackbarOpen] = useState<boolean>(location.state && location.state.message);
+  const [snackbarState, setSnackbarState] = useState<{
+    open: boolean;
+    message: string;
+    severity: 'success' | 'warning';
+  }>({ 
+    open: location.state && location.state.message, 
+    message: location.state ? location.state.message : '', 
+    severity: 'success' });
 
   const handleSnackbarClose = (
     _event?: React.SyntheticEvent | Event,
     reason?: string,
   ) => {
     if (reason === 'clickaway') return;
-    setSnackbarOpen(false);
+    setSnackbarState({...snackbarState, open: false });
   };
 
   const fetchData = useCallback(async () => {
@@ -151,22 +157,20 @@ const VolunteerHome: React.FC = () => {
             addModal={addModal}
             handleAddClose={handleAddClose}
             handleSnackbar={(message: string) => {     
-              setSnackBarMessage(message);
-              setSnackbarOpen(true);
+              setSnackbarState({ open: true, message: message, severity: 'success' });
             }}
             fetchData={fetchData}
             originalData={originalData}
           />
         </Grid>
       </Grid>
-
     
       <SnackbarAlert
-          open={snackbarOpen}
+          open={snackbarState.open}
           onClose={handleSnackbarClose}
-          severity={'success'}
+          severity={snackbarState.severity}
         >
-          {snackBarMessage}
+          {snackbarState.message}
       </SnackbarAlert>
       
     </Box>

--- a/src/pages/VolunteerHome/index.tsx
+++ b/src/pages/VolunteerHome/index.tsx
@@ -19,12 +19,14 @@ const VolunteerHome: React.FC = () => {
   
   const location = useLocation();
 
+    console.log('locationobj', location);
+
   const [snackbarState, setSnackbarState] = useState<{
     open: boolean;
     message: string;
     severity: 'success' | 'warning';
   }>({ 
-    open: location.state && location.state.message, 
+    open: location.state && location.state.message.length > 0, 
     message: location.state ? location.state.message : '', 
     severity: 'success' });
 

--- a/src/pages/VolunteerHome/index.tsx
+++ b/src/pages/VolunteerHome/index.tsx
@@ -18,8 +18,9 @@ const VolunteerHome: React.FC = () => {
   const [originalData, setOriginalData] = useState<InventoryItem[]>([]);
   
   const location = useLocation();
-  const showSnackbar = location.state && location.state.message;
-  const [snackbarOpen, setSnackbarOpen] = useState<boolean>(showSnackbar);
+
+  const [snackBarMessage, setSnackBarMessage] = useState<string>(location.state ? location.state.message : '');
+  const [snackbarOpen, setSnackbarOpen] = useState<boolean>(location.state && location.state.message);
 
   const handleSnackbarClose = (
     _event?: React.SyntheticEvent | Event,
@@ -149,21 +150,25 @@ const VolunteerHome: React.FC = () => {
           <AddItemModal
             addModal={addModal}
             handleAddClose={handleAddClose}
+            handleSnackbar={(message: string) => {     
+              setSnackBarMessage(message);
+              setSnackbarOpen(true);
+            }}
             fetchData={fetchData}
             originalData={originalData}
           />
         </Grid>
       </Grid>
 
-    {showSnackbar &&
-        <SnackbarAlert
+    
+      <SnackbarAlert
           open={snackbarOpen}
           onClose={handleSnackbarClose}
           severity={'success'}
         >
-          {location.state.message}
-        </SnackbarAlert>
-      }
+          {snackBarMessage}
+      </SnackbarAlert>
+      
     </Box>
   );
 };

--- a/src/pages/VolunteerHome/index.tsx
+++ b/src/pages/VolunteerHome/index.tsx
@@ -16,11 +16,7 @@ const VolunteerHome: React.FC = () => {
   const [addModal, setAddModal] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [originalData, setOriginalData] = useState<InventoryItem[]>([]);
-  
   const location = useLocation();
-
-    console.log('locationobj', location);
-
   const [snackbarState, setSnackbarState] = useState<{
     open: boolean;
     message: string;

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -26,6 +26,7 @@ const CheckoutPage = () => {
   const [selectedBuildingCode, setSelectedBuildingCode] = useState<string>('');
   const [activeSection, setActiveSection] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
+
   const [snackbarState, setSnackbarState] = useState<{
     open: boolean;
     message: string;
@@ -232,10 +233,18 @@ const CheckoutPage = () => {
 
   const handleCheckoutSuccess = () => {
     const numberOfItems = checkoutItems.reduce((accumulator, category) => accumulator + category.categoryCount, 0);
-    navigate('/volunteer-home', {state: {
+    
+    const userRole = user ? getRole(user) : null;
+    const navigateState = {state: {
       checkoutSuccess: true, 
       message: `${numberOfItems} ${numberOfItems === 1 ? 'item has been' : 'items have been'} checked out`
-    }});
+    }}
+
+    if (userRole === 'volunteer') {
+      navigate('/volunteer-home', navigateState);
+    } else {
+      navigate('/inventory', navigateState)
+    }
   };
 
   return (

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -231,7 +231,11 @@ const CheckoutPage = () => {
   }, [data])
 
   const handleCheckoutSuccess = () => {
-    navigate('/volunteer-home');
+    const numberOfItems = checkoutItems.reduce((accumulator, category) => accumulator + category.categoryCount, 0);
+    navigate('/volunteer-home', {state: {
+      checkoutSuccess: true, 
+      message: `${numberOfItems} ${numberOfItems === 1 ? 'item has been' : 'items have been'} checked out`
+    }});
   };
 
   return (

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -233,7 +233,6 @@ const CheckoutPage = () => {
 
   const handleCheckoutSuccess = () => {
     const numberOfItems = checkoutItems.reduce((accumulator, category) => accumulator + category.categoryCount, 0);
-    
     const userRole = user ? getRole(user) : null;
     const navigateState = {state: {
       checkoutSuccess: true, 

--- a/src/pages/inventory/index.tsx
+++ b/src/pages/inventory/index.tsx
@@ -13,7 +13,6 @@ import { useLocation } from 'react-router-dom';
 const Inventory = () => {
   const { user } = useContext(UserContext);
   const location = useLocation();
-
   const [originalData, setOriginalData] = useState<InventoryItem[]>([]);
   const [displayData, setDisplayData] = useState<InventoryItem[]>([]);
   const [categoryData, setCategoryData] = useState<CategoryItem[]>([]);

--- a/src/pages/inventory/index.tsx
+++ b/src/pages/inventory/index.tsx
@@ -249,6 +249,9 @@ const Inventory = () => {
         handleAddClose={handleAddClose}
         fetchData={fetchData}
         originalData={originalData}
+        handleSnackbar={(message: string) => {     
+          setSnackbarState({ open: true, message: message, severity: 'success' });
+        }}
       />
 
       {/* Inventory Filter */}

--- a/src/pages/inventory/index.tsx
+++ b/src/pages/inventory/index.tsx
@@ -8,9 +8,12 @@ import { getRole, UserContext } from '../../components/contexts/UserContext';
 import { CategoryItem, InventoryItem } from '../../types/interfaces.ts';
 import { ENDPOINTS, API_HEADERS, SETTINGS } from "../../types/constants";
 import SnackbarAlert from '../../components/SnackbarAlert';
+import { useLocation } from 'react-router-dom';
 
 const Inventory = () => {
   const { user } = useContext(UserContext);
+  const location = useLocation();
+
   const [originalData, setOriginalData] = useState<InventoryItem[]>([]);
   const [displayData, setDisplayData] = useState<InventoryItem[]>([]);
   const [categoryData, setCategoryData] = useState<CategoryItem[]>([]);
@@ -34,7 +37,10 @@ const Inventory = () => {
     open: boolean;
     message: string;
     severity: 'success' | 'warning';
-  }>({ open: false, message: '', severity: 'warning' });
+  }>({ 
+    open: location.state && location.state.message, 
+    message: location.state ? location.state.message : '', 
+    severity: 'success' });
   const [itemsPerPage, setItemsPerPage] = useState(SETTINGS.itemsPerPage);
   const tableContainerRef = useRef<HTMLElement | null>(null);
 


### PR DESCRIPTION
## Description

Addresses [PIT-311](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-311).

A small popup message (called a snackbar in MUI) is shown upon a successful checkout or inventory add.

Works for both admin and volunteer roles, so the popup shows whether you add to inventory from the inventory page or volunteer home.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## QA Instructions, Screenshots, Recordings

After checkout: 
![image](https://github.com/user-attachments/assets/40794a3f-1caf-43a3-ad4c-a4c6b0f60b4e)

After inventory update:
![image](https://github.com/user-attachments/assets/d4c15cfe-48d2-45d4-a7da-63987643058e)


