### PR TITLE
Misty/306: remove error that blocks negative quantities, show a warning instead

### DIFF
--- a/src/components/inventory/AddItemModal.tsx
+++ b/src/components/inventory/AddItemModal.tsx
@@ -15,7 +15,7 @@ type FormData = {
 type AddItemModalProps = {
   addModal: boolean;
   handleAddClose: () => void;
-  handleSnackbar: (message: string) => void;
+  handleSnackbar: (message: string, severity: 'warning' | 'success') => void;
   fetchData: () => void;
   originalData: InventoryItem[];
 }
@@ -74,9 +74,6 @@ const AddItemModal = ({ addModal, handleAddClose, handleSnackbar, fetchData, ori
     if (formData.type === '' || formData.name === '' || formData.quantity === 0 || !updateItem) {
       setErrorMessage('Missing Information or Quantity cannot be 0')
       return;
-    } else if (newQuantity < 0) {
-      setErrorMessage('Item quantity cannot go below 0.')
-      return;
     } else {
       try {
         API_HEADERS['X-MS-API-ROLE'] = getRole(user);
@@ -93,7 +90,11 @@ const AddItemModal = ({ addModal, handleAddClose, handleSnackbar, fetchData, ori
         } else {
           setErrorMessage('');
           fetchData();
-          handleSnackbar(`${formData.quantity} ${updateItem.name} in ${updateItem.category} have been added.`);
+          if (newQuantity <= 0) {
+            handleSnackbar(`The total quantity for ${updateItem.name} is now ${newQuantity}.`, 'warning')
+          } else {
+            handleSnackbar(`${formData.quantity} ${updateItem.name} in ${updateItem.category} have been added.`, 'success');
+          }
           handleAddClose();
           resetInputsHandler();
         }

--- a/src/pages/inventory/index.tsx
+++ b/src/pages/inventory/index.tsx
@@ -254,8 +254,8 @@ const Inventory = () => {
         handleAddClose={handleAddClose}
         fetchData={fetchData}
         originalData={originalData}
-        handleSnackbar={(message: string) => {     
-          setSnackbarState({ open: true, message: message, severity: 'success' });
+        handleSnackbar={(message: string, severity: 'warning' | 'success') => {     
+          setSnackbarState({ open: true, message: message, severity: severity });
         }}
       />
 


### PR DESCRIPTION
## Description

Currently on the inventory page, any additions/subtractions that lead to a negative total count results in an error that prevents users from proceeding. This has caused some confusion on Plymouth's end, since it is not immediately clear to the user if a quantity was already in the negatives. 

As a quick fix, this error popup has been removed. Instead, a warning popup alerts users if the resulting quantity is 0 or negative, but does not prevent the transaction from going through.

For the long haul, Bai has been working on a new inventory flow to make the process more clear ([see PIT-321](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-321?atlOrigin=eyJpIjoiZGU0MDBhN2EyMTM0NGZlODk0YzIwNDBlYzMyNjJkMWUiLCJwIjoiaiJ9)).


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

https://das-ph-inventory-tracker.atlassian.net/browse/PIT-306?atlOrigin=eyJpIjoiY2VkMzAwNmQwNWU4NDE0ZmFlMjc2YWYyMjA5NzY1YmUiLCJwIjoiaiJ9

## QA Instructions, Screenshots, Recordings

<img width="1920" height="881" alt="image" src="https://github.com/user-attachments/assets/2c7f3e01-3fd1-41d0-b847-7282a0ba92ef" />

