### PR TITLE
adding clarity to project

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,5 @@
 VITE_REACT_APP_VERSION=18.2.0
 VITE_APPLICATION_NAME=Plymouth Housing
+#this variable needs to be set in github environment variables for both production and staging environments
+#You will find the Clarity Project ID in the Clarity dashboard
+VITE_CLARITY_PROJECT_ID= 

--- a/.github/workflows/azure-static-web-apps-CD.yml
+++ b/.github/workflows/azure-static-web-apps-CD.yml
@@ -9,7 +9,7 @@ jobs:
   build_and_deploy_job:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
-    environment: staging
+    environment: staging # this is a reference to the github environment and determines the env: location below
     steps:
       - name: Check out source
         uses: actions/checkout@v3
@@ -24,12 +24,14 @@ jobs:
             ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_SALMON_ISLAND_01BE9BF1E }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
           action: 'upload'
-          deployment_environment: 'staging'
+          deployment_environment: 'staging' # this is a reference to the Azure environment for deployment
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: '/' # App source code path
           api_location: '' # Api source code path - optional
           output_location: 'dist' # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
+        env:
+          VITE_CLARITY_PROJECT_ID: ${{ secrets.VITE_CLARITY_PROJECT_ID }}
       - name: Post URL
         run: |
           echo "App deployed :rocket:" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/azure-static-web-apps-prod.yml
+++ b/.github/workflows/azure-static-web-apps-prod.yml
@@ -61,7 +61,7 @@ jobs:
     if: needs.sync-tag.outputs.tag_exists == 'false'
     runs-on: ubuntu-latest
     name: Build and Deploy Job
-    environment: production
+    environment: production # this is a reference to the github environment and determines the env: location below
     steps:
       - name: Check out source
         uses: actions/checkout@v3
@@ -86,6 +86,8 @@ jobs:
           api_location: '' # Api source code path - optional
           output_location: 'dist' # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
+        env:
+          VITE_CLARITY_PROJECT_ID: ${{ secrets.VITE_CLARITY_PROJECT_ID }}
 
       - name: Post URL
         run: |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,33 @@
+# Observability with Microsoft Clarity
+
+This project uses **Microsoft Clarity** for observability and user interaction tracking.
+
+## How It Works
+
+- **Microsoft Clarity** is initialized in [`App.tsx`](../src/App.tsx) using the project ID.
+- The Clarity project ID is stored securely as a GitHub environment secret (`VITE_CLARITY_PROJECT_ID`).
+- During deployment, the project ID is injected into the build via the GitHub Actions workflow (see `.github/workflows/azure-static-web-apps-CD.yml`).
+- The initialization code ensures Clarity is only enabled when a project ID is present, typically in staging and production environments.
+
+## Initialization Code
+
+In [`App.tsx`](../src/App.tsx):
+
+```tsx
+useEffect(() => {
+  const projectId = import.meta.env.VITE_CLARITY_PROJECT_ID;
+  if (projectId) {
+    Clarity.init(projectId);
+  }
+}, []);
+```
+
+## Secrets Management
+- The Clarity project ID is not hardcoded in the repository.
+- It is stored as a secret in the GitHub environment and referenced in the workflow as ```${{ secrets.VITE_CLARITY_PROJECT_ID }}```.
+
+## Deployment
+- The GitHub Actions workflow passes the secret to the build environment, making it available as an environment variable for the app.
+
+## Summary
+This setup ensures that user tracking and observability are enabled securely and only in the appropriate environments, with sensitive keys managed via GitHub secrets. ``````

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@ant-design/icons": "^5.5.2",
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
+        "@microsoft/clarity": "^1.0.0",
         "@mui/icons-material": "^7.1.0",
         "@mui/material": "^7.1.0",
         "lodash": "^4.17.21",
@@ -1903,6 +1904,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@microsoft/clarity": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/clarity/-/clarity-1.0.0.tgz",
+      "integrity": "sha512-2QY6SmXnqRj6dWhNY8NYCN3e53j4zCFebH4wGnNhdGV1mqAsQwql2fT0w8TISxCvwwfVp8idsWLIdrRHOms1PQ==",
+      "license": "MIT"
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "7.1.1",
@@ -11592,6 +11599,11 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "@microsoft/clarity": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/clarity/-/clarity-1.0.0.tgz",
+      "integrity": "sha512-2QY6SmXnqRj6dWhNY8NYCN3e53j4zCFebH4wGnNhdGV1mqAsQwql2fT0w8TISxCvwwfVp8idsWLIdrRHOms1PQ=="
     },
     "@mui/core-downloads-tracker": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@ant-design/icons": "^5.5.2",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
+    "@microsoft/clarity": "^1.0.0",
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
     "lodash": "^4.17.21",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@
  *  @copyright 2024 Digital Aid Seattle
  *
  */
-import React from 'react';
+import React, { useEffect} from 'react';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import { routes } from './pages/routes';
 import ThemeCustomization from './themes/themeCustomization';
@@ -13,6 +13,7 @@ import { ClientPrincipal, User } from './types/interfaces';
 import usePersistentState from './hooks/usePersistentState';
 import useAuthorization from './hooks/useAuthorization';
 import { USER_ROLES } from './types/constants';
+import Clarity from '@microsoft/clarity';
 
 const router = createBrowserRouter(routes);
 
@@ -22,6 +23,15 @@ const App: React.FC = () => {
   const [activeVolunteers, setActiveVolunteers] = usePersistentState<User[]>('activeVolunteers', []);
 
   useAuthorization(user, Object.values(USER_ROLES));
+
+  // Clarity is used for observability in Staging and Production environments. (See documentation)
+  // We should igore it in development.
+  useEffect(() => {
+    const projectId = import.meta.env.VITE_CLARITY_PROJECT_ID;
+    if (projectId) {
+      Clarity.init(projectId);
+    }
+  }, []);
 
   return (
     <UserContext.Provider
@@ -42,3 +52,4 @@ const App: React.FC = () => {
 };
 
 export default App;
+


### PR DESCRIPTION
## Description

Added Clarity to the project for observability. There will be two projects in https://clarity.microsoft.com/ that the team will get access to: production and staging. I am not familiar with Clarity but it looks like you can get a lot of info. 

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

- Closes #339

## QA Instructions, Screenshots, Recordings

This is tricky to test. If you really want to, you can
- create a project in https://clarity.microsoft.com/. You need a public URL, but it doesn't really care what it is. I think you can put in http://msn.com
- copy the key over and create a local env var ```VITE_CLARITY_PROJECT_ID={copied key}```
- run the app as normal with ```swa start```
- things will start showing up on the dashboard in clarity. 
