### PR TITLE
Misty/333 - Checkout page: use Autocomplete component for unit and building selection

### DIFF
--- a/src/components/Checkout/BuildingCodeSelect.tsx
+++ b/src/components/Checkout/BuildingCodeSelect.tsx
@@ -7,6 +7,7 @@ interface BuildingCodeSelectProps {
   selectedBuilding: Building;
   setSelectedBuilding: (building: Building) => void;
   setSelectedUnit: (unit: Unit) => void;
+  setNameInput: (name: string) => void;
   fetchUnitNumbers: (buildingId: number) => void;
   error: boolean;
 }
@@ -16,6 +17,7 @@ const BuildingCodeSelect: React.FC<BuildingCodeSelectProps> = ({
   selectedBuilding,
   setSelectedBuilding,
   setSelectedUnit,
+  setNameInput,
   fetchUnitNumbers,
   error
 }) => {
@@ -30,6 +32,7 @@ const BuildingCodeSelect: React.FC<BuildingCodeSelectProps> = ({
             if (newValue) { 
               setSelectedBuilding(newValue);
               setSelectedUnit({id: 0, unit_number: ''});
+              setNameInput('');
               fetchUnitNumbers(newValue.id);
             }
           }}

--- a/src/components/Checkout/BuildingCodeSelect.tsx
+++ b/src/components/Checkout/BuildingCodeSelect.tsx
@@ -27,11 +27,11 @@ const BuildingCodeSelect: React.FC<BuildingCodeSelectProps> = ({
           options={buildings}
           value={selectedBuilding}
           onChange={(event: any, newValue: Building | null) => {             
-              if (newValue) { 
-                setSelectedBuilding(newValue);
-                setUnitNumberInput({id: 0, unit_number: ''});
-                fetchUnitNumbers(newValue.id);
-              }
+            if (newValue) { 
+              setSelectedBuilding(newValue);
+              setUnitNumberInput({id: 0, unit_number: ''});
+              fetchUnitNumbers(newValue.id);
+            }
           }}
           getOptionLabel={(option: Building) => {
             if (option.id === 0) return '';

--- a/src/components/Checkout/BuildingCodeSelect.tsx
+++ b/src/components/Checkout/BuildingCodeSelect.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { FormControl, FormHelperText, InputLabel, MenuItem, Select } from '@mui/material';
+import { Autocomplete, FormControl, FormHelperText, InputLabel, MenuItem, Select, TextField } from '@mui/material';
 import { Building, Unit } from '../../types/interfaces';
 
 interface BuildingCodeSelectProps {
   buildings: Building[];
-  selectedBuildingCode: string;
+  selectedBuilding: Building;
   setSelectedBuilding: (building: Building) => void;
   setUnitNumberInput: (unit: Unit) => void;
   fetchUnitNumbers: (buildingId: number) => void;
@@ -13,36 +13,34 @@ interface BuildingCodeSelectProps {
 
 const BuildingCodeSelect: React.FC<BuildingCodeSelectProps> = ({
   buildings,
-  selectedBuildingCode,
+  selectedBuilding,
   setSelectedBuilding,
   setUnitNumberInput,
   fetchUnitNumbers,
   error
 }) => {
   return (
-    <FormControl error={error}>
-      <InputLabel id="select-building-code-label">Building Code</InputLabel>
-      <Select
-        labelId="select-building-code-label"
-        id="select-building-code"
-        data-testid="test-id-select-building-code"
-        label="Building Code"
-        value={selectedBuildingCode || ''}
-        onChange={(event) => {
-          const building = buildings.filter((b) => b.code == event.target.value)[0];
-          setSelectedBuilding(building);
-          setUnitNumberInput({id: 0, unit_number: ''});
-          fetchUnitNumbers(building.id);
-        }}
-      >
-        {buildings.map((building) => (
-          <MenuItem key={building.code} value={building.code}>
-            {building.code} ({building.name})
-          </MenuItem>
-        ))}
-      </Select>
+    <FormControl error={error} >
+       <Autocomplete
+          id="select-unit-number"
+          data-testid="test-id-select-unit-number"
+          options={buildings}
+          value={selectedBuilding}
+          onChange={(event: any, newValue: Building | null) => {             
+              if (newValue) { 
+                setSelectedBuilding(newValue);
+                setUnitNumberInput({id: 0, unit_number: ''});
+                fetchUnitNumbers(newValue.id);
+              }
+          }}
+          getOptionLabel={(option: Building) => {
+            if (option.id === 0) return '';
+            return `${option.code} - ${option.name}`;
+          }}
+          renderInput={(params) => <TextField {...params} label="Building" />}
+      />
       {error && <FormHelperText>Please select a building code</FormHelperText>}
-    </FormControl>
+    </FormControl> 
   );
 };
 

--- a/src/components/Checkout/BuildingCodeSelect.tsx
+++ b/src/components/Checkout/BuildingCodeSelect.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { Autocomplete, FormControl, FormHelperText, InputLabel, MenuItem, Select, TextField } from '@mui/material';
+import { Autocomplete, FormControl, FormHelperText, TextField } from '@mui/material';
 import { Building, Unit } from '../../types/interfaces';
 
 interface BuildingCodeSelectProps {
   buildings: Building[];
   selectedBuilding: Building;
   setSelectedBuilding: (building: Building) => void;
-  setUnitNumberInput: (unit: Unit) => void;
+  setSelectedUnit: (unit: Unit) => void;
   fetchUnitNumbers: (buildingId: number) => void;
   error: boolean;
 }
@@ -15,12 +15,12 @@ const BuildingCodeSelect: React.FC<BuildingCodeSelectProps> = ({
   buildings,
   selectedBuilding,
   setSelectedBuilding,
-  setUnitNumberInput,
+  setSelectedUnit,
   fetchUnitNumbers,
   error
 }) => {
   return (
-    <FormControl error={error} >
+    <FormControl>
        <Autocomplete
           id="select-unit-number"
           data-testid="test-id-select-unit-number"
@@ -29,7 +29,7 @@ const BuildingCodeSelect: React.FC<BuildingCodeSelectProps> = ({
           onChange={(event: any, newValue: Building | null) => {             
             if (newValue) { 
               setSelectedBuilding(newValue);
-              setUnitNumberInput({id: 0, unit_number: ''});
+              setSelectedUnit({id: 0, unit_number: ''});
               fetchUnitNumbers(newValue.id);
             }
           }}
@@ -37,9 +37,14 @@ const BuildingCodeSelect: React.FC<BuildingCodeSelectProps> = ({
             if (option.id === 0) return '';
             return `${option.code} - ${option.name}`;
           }}
-          renderInput={(params) => <TextField {...params} label="Building" />}
+          renderInput={(params) => 
+            <TextField {...params} 
+              label="Building" 
+              error={error} 
+              helperText={error ? "Please select a building" : ""}
+            />
+          }
       />
-      {error && <FormHelperText>Please select a building code</FormHelperText>}
     </FormControl> 
   );
 };

--- a/src/components/Checkout/ResidentDetailDialog.tsx
+++ b/src/components/Checkout/ResidentDetailDialog.tsx
@@ -54,7 +54,7 @@ const ResidentDetailDialog = ({
     }
 
     useEffect(() => {
-        if (!selectedUnit.id) return;
+        setNameInput('');
         const fetchResidents = async () => {
             const response = await getResidents(selectedUnit.id);
             if (response.value.length > 0) {
@@ -64,8 +64,7 @@ const ResidentDetailDialog = ({
             }
         }
         fetchResidents();
-    }, [selectedUnit])
-
+    }, [selectedUnit, selectedBuilding])
 
     async function handleSubmit(e: FormEvent) {
         e.preventDefault();

--- a/src/components/Checkout/ResidentDetailDialog.tsx
+++ b/src/components/Checkout/ResidentDetailDialog.tsx
@@ -144,6 +144,7 @@ const ResidentDetailDialog = ({
                     />
                 </FormControl>}
 
+                {selectedUnit.id !== 0 && 
                 <FormControl>
                     <Autocomplete 
                         value={nameInput}
@@ -192,7 +193,7 @@ const ResidentDetailDialog = ({
                             <li key={key} {...optionProps}>
                             {option.name}
                             </li>
-                        );
+                            );
                         }}
                         freeSolo
                         renderInput={(params) => (
@@ -202,7 +203,7 @@ const ResidentDetailDialog = ({
                             helperText={showError && !nameInput ? "Please enter the resident's name" : ""}/>
                         )}
                     />
-                </FormControl>                    
+                </FormControl>}                  
             </Box>
         </DialogTemplate>
     );

--- a/src/components/Checkout/ResidentDetailDialog.tsx
+++ b/src/components/Checkout/ResidentDetailDialog.tsx
@@ -123,28 +123,23 @@ const ResidentDetailDialog = ({
                         fetchUnitNumbers={fetchUnitNumbers}
                         error={showError && !buildingInput}/>
                 </FormControl>
+
                 {unitNumberValues.length > 1 && 
                 <FormControl error={showError && !unitNumberInput}>
-                    <InputLabel id="select-unit-number-label">Unit Number</InputLabel>
-                    <Select
-                        labelId="select-unit-number-label"
+                    <Autocomplete
                         id="select-unit-number"
                         data-testid="test-id-select-unit-number"
-                        label="Unit Number"
+                        options={unitNumberValues.map(u => u.unit_number)}
                         value={unitNumberInput.unit_number}
-                        onChange={(event) => {
-                            const matchingUnit = unitNumberValues.find(unit => unit.unit_number == event.target.value);
+                        onChange={(event: any) => {
+                            const matchingUnit = unitNumberValues.find(unit => unit.unit_number == event.target.textContent);
                             if (matchingUnit) setUnitNumberInput(matchingUnit);
                         }}
-                    >
-                    {unitNumberValues.map((unit) => (
-                        <MenuItem key={unit.id} value={unit.unit_number}>
-                        {unit.unit_number} 
-                        </MenuItem>
-                    ))}
-                    </Select>
+                        renderInput={(params) => <TextField {...params} label="Unit Number" />}
+                    />
                     {showError && !unitNumberInput && <FormHelperText>Please select a unit number</FormHelperText>}
                 </FormControl>}
+
                 <FormControl>
                     <Autocomplete 
                         value={nameInput}
@@ -167,10 +162,6 @@ const ResidentDetailDialog = ({
                             const isExisting = options.some((option) => inputValue === option.name);
                             if (inputValue !== '' && !isExisting) {
                                 setNameInput(inputValue);
-                                // filtered.push({
-                                //     inputValue,
-                                //     name: `Add "${inputValue}"`
-                                // });
                             }
                             return filtered;
                         }}

--- a/src/components/Checkout/ResidentDetailDialog.tsx
+++ b/src/components/Checkout/ResidentDetailDialog.tsx
@@ -63,6 +63,8 @@ const ResidentDetailDialog = ({
             const response = await getResidents(unitNumberInput.id);
             if (response.value.length > 0) {
                 setExistingResidents(response.value.map((resident: ResidentNameOption) => ({ name: resident.name })));
+            } else {
+                setExistingResidents([]);
             }
         }
         fetchResidents();

--- a/src/components/Checkout/ResidentDetailDialog.tsx
+++ b/src/components/Checkout/ResidentDetailDialog.tsx
@@ -129,11 +129,14 @@ const ResidentDetailDialog = ({
                     <Autocomplete
                         id="select-unit-number"
                         data-testid="test-id-select-unit-number"
-                        options={unitNumberValues.map(u => u.unit_number)}
-                        value={unitNumberInput.unit_number}
-                        onChange={(event: any) => {
-                            const matchingUnit = unitNumberValues.find(unit => unit.unit_number == event.target.textContent);
-                            if (matchingUnit) setUnitNumberInput(matchingUnit);
+                        options={unitNumberValues}
+                        value={unitNumberInput}
+                        onChange={(event: any, newValue: Unit | null) => {
+                            if (newValue) setUnitNumberInput(newValue);
+                        }}
+                        getOptionLabel={(option: Unit) => {
+                            if (option.id === 0) return '';
+                            return `${option.unit_number}`;
                         }}
                         renderInput={(params) => <TextField {...params} label="Unit Number" />}
                     />
@@ -144,7 +147,7 @@ const ResidentDetailDialog = ({
                     <Autocomplete 
                         value={nameInput}
                         onChange={(_event, newValue) => {
-                                if (typeof newValue === 'string') {
+                            if (typeof newValue === 'string') {
                                 setNameInput(newValue);
                             } else if (newValue && (newValue as ResidentNameOption).inputValue) {
                                 setNameInput((newValue as ResidentNameOption).inputValue!);
@@ -190,7 +193,6 @@ const ResidentDetailDialog = ({
                             </li>
                         );
                         }}
-                        sx={{ width: 300 }}
                         freeSolo
                         renderInput={(params) => (
                         <TextField {...params} label="Resident Name" 

--- a/src/components/Checkout/ResidentDetailDialog.tsx
+++ b/src/components/Checkout/ResidentDetailDialog.tsx
@@ -117,7 +117,7 @@ const ResidentDetailDialog = ({
                 <FormControl>
                     <BuildingCodeSelect 
                         buildings={buildings} 
-                        selectedBuildingCode={buildingInput.code} 
+                        selectedBuilding={buildingInput} 
                         setSelectedBuilding={setBuildingInput} 
                         setUnitNumberInput={setUnitNumberInput}
                         fetchUnitNumbers={fetchUnitNumbers}

--- a/src/components/Checkout/ResidentDetailDialog.tsx
+++ b/src/components/Checkout/ResidentDetailDialog.tsx
@@ -54,7 +54,6 @@ const ResidentDetailDialog = ({
     }
 
     useEffect(() => {
-        setNameInput('');
         const fetchResidents = async () => {
             const response = await getResidents(selectedUnit.id);
             if (response.value.length > 0) {
@@ -73,9 +72,7 @@ const ResidentDetailDialog = ({
             setShowError(true);
             return;
         }
-
         let residentId;
-
         // try submitting to db
         try {
             // first check if the resident already exists
@@ -117,6 +114,7 @@ const ResidentDetailDialog = ({
                         selectedBuilding={selectedBuilding} 
                         setSelectedBuilding={setSelectedBuilding} 
                         setSelectedUnit={setSelectedUnit}
+                        setNameInput={setNameInput}
                         fetchUnitNumbers={fetchUnitNumbers}
                         error={showError && !selectedBuilding.id}/>
                 </FormControl>
@@ -130,6 +128,7 @@ const ResidentDetailDialog = ({
                         value={selectedUnit}
                         onChange={(event: any, newValue: Unit | null) => {
                             if (newValue) setSelectedUnit(newValue);
+                            setNameInput('');
                         }}
                         getOptionLabel={(option: Unit) => {
                             if (option.id === 0) return '';

--- a/src/components/Checkout/ResidentDetailDialog.tsx
+++ b/src/components/Checkout/ResidentDetailDialog.tsx
@@ -166,10 +166,11 @@ const ResidentDetailDialog = ({
                             // Suggest the creation of a new value
                             const isExisting = options.some((option) => inputValue === option.name);
                             if (inputValue !== '' && !isExisting) {
-                            filtered.push({
-                                inputValue,
-                                name: `Add "${inputValue}"`
-                            });
+                                setNameInput(inputValue);
+                                // filtered.push({
+                                //     inputValue,
+                                //     name: `Add "${inputValue}"`
+                                // });
                             }
                             return filtered;
                         }}


### PR DESCRIPTION
## Description

[Link to PIT-333](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-333?atlOrigin=eyJpIjoiN2FiZTZhNWE1OTg0NDU0MmI5YzRlZTAxYjVmZTllNDMiLCJwIjoiaiJ9)

On the resident info dialog on the checkout page, the building and unit inputs now use the Autocomplete component from MUI.
So the user can type the first few letters or numbers to find an option a little quicker, instead of having to scroll the options.

Additionally, the resident name field will now get cleared if the building or unit fields change. 

There's a lot of little nuances in this form, so let me know if anything does not work as expected! 


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
