### PR TITLE
Remove all instances of modifying global API_HEADERS

### DIFF
--- a/src/components/AddVolunteerModal/AddVolunteerModal.tsx
+++ b/src/components/AddVolunteerModal/AddVolunteerModal.tsx
@@ -65,10 +65,10 @@ const AddVolunteerModal = ({
     }
 
     try {
-      API_HEADERS['X-MS-API-ROLE'] = getRole(user);
+      const headers = { ...API_HEADERS, 'X-MS-API-ROLE': getRole(user) };
       const response = await fetch(ENDPOINTS.USERS, {
         method: 'POST',
-        headers: API_HEADERS,
+        headers: headers,
         body: JSON.stringify({ ...formData, active: true, role: 'volunteer' }),
       });
       if (!response.ok) {

--- a/src/components/fetchWithRetry.ts
+++ b/src/components/fetchWithRetry.ts
@@ -16,12 +16,12 @@ export const fetchWithRetry = async <T>(
   attempt: number = 1
 ): Promise<FetchResponse<T>> => {
   try {
-    API_HEADERS['X-MS-API-ROLE'] = role;
+    const headers = { ...API_HEADERS, 'X-MS-API-ROLE': role };
     const response = await fetch(
       url,
       {
         method: 'GET',
-        headers: API_HEADERS,
+        headers: headers,
       }
     );
     

--- a/src/components/inventory/AddItemModal.tsx
+++ b/src/components/inventory/AddItemModal.tsx
@@ -92,10 +92,10 @@ const AddItemModal = ({ addModal, handleAddClose, fetchData, originalData, showR
       return;
     } else {
       try {
-        API_HEADERS['X-MS-API-ROLE'] = getRole(user);
+        const headers = { ...API_HEADERS, 'X-MS-API-ROLE': getRole(user) };
         const response = await fetch(ENDPOINTS.PROCESS_INVENTORY_CHANGE, { 
           method: "POST", 
-          headers: API_HEADERS, 
+          headers: headers, 
           body: JSON.stringify({ 
             user_id: loggedInUserId,
             item: [{ id: updateItem.id, quantity: formData.quantity }],

--- a/src/components/inventory/UpdateItemModal.tsx
+++ b/src/components/inventory/UpdateItemModal.tsx
@@ -111,8 +111,8 @@ const UpdateItemModal = ({ addModal, handleAddClose, fetchData, categoryData, or
       setErrorMessage('Missing Information')
     } else {
       try {
-        API_HEADERS['X-MS-API-ROLE'] = getRole(user);
-        const response = await fetch(ENDPOINTS.ITEMS, { method: "POST", headers: API_HEADERS, body: JSON.stringify(formData) });
+        const headers = { ...API_HEADERS, 'X-MS-API-ROLE': getRole(user) };
+        const response = await fetch(ENDPOINTS.ITEMS, { method: "POST", headers: headers, body: JSON.stringify(formData) });
         if (!response.ok) {
           throw new Error(response.statusText);
         } else {
@@ -134,8 +134,8 @@ const UpdateItemModal = ({ addModal, handleAddClose, fetchData, categoryData, or
       setErrorMessage('Missing Information')
     } else {
       try {
-        API_HEADERS['X-MS-API-ROLE'] = getRole(user);
-        const response = await fetch(`${ENDPOINTS.ITEMS}/id/${updateId}`, { method: "PATCH", headers: API_HEADERS, body: JSON.stringify(formData) });
+        const headers = { ...API_HEADERS, 'X-MS-API-ROLE': getRole(user) };
+        const response = await fetch(`${ENDPOINTS.ITEMS}/id/${updateId}`, { method: "PATCH", headers: headers, body: JSON.stringify(formData) });
         if (!response.ok) {
           throw new Error(response.statusText);
         } else {

--- a/src/layout/MainLayout/index.tsx
+++ b/src/layout/MainLayout/index.tsx
@@ -56,7 +56,6 @@ const MainLayout: React.FC = () => {
         }
 
         if (userClaims?.userRoles?.includes('admin')) {
-          API_HEADERS['X-MS-API-ROLE'] = 'admin';
           try {
             const createdOrUpdatedAdmin = await upsertAdminUser({
               name: userClaims.userDetails ?? '',
@@ -90,6 +89,7 @@ const MainLayout: React.FC = () => {
 
   const upsertAdminUser = async (adminInfo: { name: string; email: string }): Promise<User> => {
     const cacheKey = adminInfo.email; // Use email as the unique cache key
+    const headers = { ...API_HEADERS, 'X-MS-API-ROLE': 'admin' };
 
     // Prevent duplicate requests using a cache
     if (requestCache.has(cacheKey)) {
@@ -113,7 +113,7 @@ const MainLayout: React.FC = () => {
 
           const patchResp = await fetch(`${ENDPOINTS.USERS}/id/${userId}`, {
             method: 'PATCH',
-            headers: API_HEADERS,
+            headers: headers,
             body: JSON.stringify({ last_signed_in: new Date().toISOString() }),
           });
 
@@ -124,7 +124,7 @@ const MainLayout: React.FC = () => {
           // Re-fetch updated record to ensure it reflects the latest state
           const updatedRecordResp = await fetch(`${ENDPOINTS.USERS}?$filter=id eq ${userId}`, {
             method: 'GET',
-            headers: API_HEADERS,
+            headers: headers,
           });
 
           if (!updatedRecordResp.ok) {
@@ -139,7 +139,7 @@ const MainLayout: React.FC = () => {
           // No record found, create a new admin entry
           const createResp = await fetch(ENDPOINTS.USERS, {
             method: 'POST',
-            headers: API_HEADERS,
+            headers: headers,
             body: JSON.stringify({
               name: adminInfo.name,
               email: adminInfo.email,

--- a/src/pages/VolunteerHome/index.tsx
+++ b/src/pages/VolunteerHome/index.tsx
@@ -37,9 +37,9 @@ const VolunteerHome: React.FC = () => {
 
   const fetchData = useCallback(async () => {
     try {
-      API_HEADERS['X-MS-API-ROLE'] = getRole(user);
+      const headers = { ...API_HEADERS, 'X-MS-API-ROLE': getRole(user) };
       const response = await fetch(ENDPOINTS.EXPANDED_ITEMS + '?$first=10000', {
-        headers: API_HEADERS,
+        headers: headers,
         method: 'GET',
       });
       if (!response.ok) {

--- a/src/pages/authentication/EnterPinPage.tsx
+++ b/src/pages/authentication/EnterPinPage.tsx
@@ -34,10 +34,10 @@ const EnterPinPage: React.FC = () => {
 
   const verifyPin = async (id: number, enteredPin: string) => {
     try {
-      API_HEADERS['X-MS-API-ROLE'] = getRole(user);
+      const headers = { ...API_HEADERS, 'X-MS-API-ROLE': getRole(user) };
       const response = await fetch(ENDPOINTS.VERIFY_PIN, {
         method: 'POST',
-        headers: API_HEADERS,
+        headers: headers,
         body: JSON.stringify({
           VolunteerId: id,
           EnteredPin: enteredPin,
@@ -63,10 +63,10 @@ const EnterPinPage: React.FC = () => {
 
   const updateLastSignedIn = async (id: number) => {
     try {
-      API_HEADERS['X-MS-API-ROLE'] = getRole(user);
+      const headers = { ...API_HEADERS, 'X-MS-API-ROLE': getRole(user) };
       const response = await fetch(`${ENDPOINTS.USERS}/id/${id}`, {
         method: 'PATCH',
-        headers: API_HEADERS,
+        headers: headers,
         body: JSON.stringify({ last_signed_in: new Date().toISOString() }),
       });
 

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -259,9 +259,9 @@ const CheckoutPage = () => {
         setBuildings(JSON.parse(cachedBuildings));
         return;
       }
-      API_HEADERS['X-MS-API-ROLE'] = getRole(user);
+      const headers = { ...API_HEADERS, 'X-MS-API-ROLE': getRole(user) };
       const response = await fetch(ENDPOINTS.BUILDINGS, {
-        headers: API_HEADERS,
+        headers: headers,
         method: 'GET',
       });
       if (!response.ok) {
@@ -290,9 +290,9 @@ const CheckoutPage = () => {
       if (cachedCategorizedItems) {
         categorizedItems = JSON.parse(cachedCategorizedItems);
       } else {
-        API_HEADERS['X-MS-API-ROLE'] = getRole(user);
+        const headers = { ...API_HEADERS, 'X-MS-API-ROLE': getRole(user) };
         const response = await fetch(ENDPOINTS.CATEGORIZED_ITEMS, {
-          headers: API_HEADERS,
+          headers: headers,
           method: 'GET',
         });
         if (!response.ok) {

--- a/src/pages/inventory/index.tsx
+++ b/src/pages/inventory/index.tsx
@@ -162,8 +162,8 @@ const Inventory = () => {
 
   const fetchData = useCallback(async () => {
     try {
-      API_HEADERS['X-MS-API-ROLE'] = getRole(user);
-      const response = await fetch(ENDPOINTS.EXPANDED_ITEMS + '?$first=10000', { headers: API_HEADERS, method: 'GET' });
+      const headers = { ...API_HEADERS, 'X-MS-API-ROLE': getRole(user) };
+      const response = await fetch(ENDPOINTS.EXPANDED_ITEMS + '?$first=10000', { headers: headers, method: 'GET' });
       if (!response.ok) {
         if (response.status === 500) {
           throw new Error('Database is likely starting up. Try again in 30 seconds.');
@@ -185,8 +185,8 @@ const Inventory = () => {
 
   const fetchCategories = useCallback(async () => {
     try {
-      API_HEADERS['X-MS-API-ROLE'] = getRole(user);
-      const response = await fetch(ENDPOINTS.CATEGORY, { headers: API_HEADERS, method: 'GET' });
+      const headers = { ...API_HEADERS, 'X-MS-API-ROLE': getRole(user) };
+      const response = await fetch(ENDPOINTS.CATEGORY, { headers: headers, method: 'GET' });
       if (!response.ok) {
         throw new Error(response.statusText);
       }

--- a/src/pages/people/useUsers.test.tsx
+++ b/src/pages/people/useUsers.test.tsx
@@ -46,7 +46,7 @@ describe('useUsers hook', () => {
 
     const { result } = renderHook(() => useUsers(), { wrapper });
     await waitFor(() => expect(result.current.loading).toBe(false));
- 
+
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result.current.error).toBeNull();
     expect(result.current.originalData).toEqual(mockUsers);
@@ -60,7 +60,7 @@ describe('useUsers hook', () => {
     const { result } = renderHook(() => useUsers(), { wrapper });
     await waitFor(() => result.current.loading === false);
     expect(result.current.originalData).toEqual([]);
-      });
+  });
 
   it('updateUserStatus toggles active status successfully', async () => {
     const initialUsers = [

--- a/src/pages/people/useUsers.ts
+++ b/src/pages/people/useUsers.ts
@@ -12,11 +12,11 @@ const useUsers = () => {
 
   const fetchData = useCallback(async () => {
     try {
-      API_HEADERS['X-MS-API-ROLE'] = getRole(user);
+      const headers = { ...API_HEADERS, 'X-MS-API-ROLE': getRole(user) };
       const response = await fetch(
         `${ENDPOINTS.USERS}`,
         {
-          headers: API_HEADERS,
+          headers: headers,
           method: 'GET',
         },
       );
@@ -49,11 +49,11 @@ const useUsers = () => {
       const updatedStatus = !userToUpdate.active;
 
       const requestUrl = `${ENDPOINTS.USERS}/id/${userId}`;
-      API_HEADERS['X-MS-API-ROLE'] = getRole(user);
+      const headers = { ...API_HEADERS, 'X-MS-API-ROLE': getRole(user) };
 
       const response = await fetch(requestUrl, {
         method: 'PATCH',
-        headers: API_HEADERS,
+        headers: headers,
         body: JSON.stringify({ active: updatedStatus }),
       });
 


### PR DESCRIPTION
## Description

Following the previous issues with the missing role on the API_HEADERS, this was a latent bug. 

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

#356 

## QA Instructions, Screenshots, Recordings

Considering the large impact, this needs to be tested thoroughly and specifically all the database interactions. 
- add, edit users
- checkout baskets, individual items, rugs, appliances
- add inventory. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unit numbers now load faster with session-based caching.
* **Bug Fixes**
  * Unit-number field always displays in resident details.
  * Improved error messages when loading unit numbers; empty suggestions are filtered out.
* **Chores**
  * Network requests made per-action now include correct role context to avoid cross-request side effects and improve request reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->