### PR TITLE
added loading to fix race condition in user state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,10 @@ const App: React.FC = () => {
         setLoggedInUserId,
         activeVolunteers,
         setActiveVolunteers,
+        // There is a race condition where user is null at the start
+        // Consider loading until user state is determined. 
+        // It is used in RootRedirect to show a loading state.
+        isLoading: user === null, 
       }}
     >
       <ThemeCustomization>

--- a/src/components/RootRedirect.test.tsx
+++ b/src/components/RootRedirect.test.tsx
@@ -43,7 +43,7 @@ const GenericRedirectPage = ({ source }: { source: string }) => (
 );
 
 
-const mockUserContextValue = (role: 'admin' | 'volunteer' | null, isLoading: boolean): UserContextType => ({
+const mockUserContextValue = (role: 'admin' | 'volunteer' | null | undefined, isLoading: boolean): UserContextType => ({
   user: role ? {
     userRoles: [role],
     userID: 'test-user-id',
@@ -161,6 +161,15 @@ describe('RootRedirect - invalid userRole handling', () => {
     const contextValue = mockUserContextValue(null, false);
 
     renderWithRouter(contextValue, { route: '/volunteer-home' });
+
+    expect(mockLocalStorageClear).toHaveBeenCalledTimes(1);
+    expect(window.location.href).toBe('/.auth/logout?post_logout_redirect_uri=/login.html');
+  });
+
+  it('clears localStorage and redirects to logout when userRole is undefined', () => {
+    const contextValue = mockUserContextValue(undefined, false);
+
+    renderWithRouter(contextValue, { route: '/people' });
 
     expect(mockLocalStorageClear).toHaveBeenCalledTimes(1);
     expect(window.location.href).toBe('/.auth/logout?post_logout_redirect_uri=/login.html');

--- a/src/components/RootRedirect.test.tsx
+++ b/src/components/RootRedirect.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { RootRedirect } from './RootRedirect';
+import { UserContext } from './contexts/UserContext';
+import { UserContextType } from '../types/interfaces';
+
+// Mock the Page404 component
+vi.mock('../pages/error/404', () => ({
+  default: () => <div>404 Page</div>,
+}));
+
+const mockUserContextValue = (role: 'admin' | 'volunteer' | null, isLoading: boolean): UserContextType => ({
+  user: role ? {
+    userRoles: [role],
+    userID: 'test-user-id',
+    userDetails: 'test-user-details'
+  } : null,
+  isLoading,
+  setUser: vi.fn(),
+  loggedInUserId: null,
+  setLoggedInUserId: vi.fn(),
+  activeVolunteers: [],
+  setActiveVolunteers: vi.fn(),
+});
+
+const renderWithRouter = (ui: React.ReactElement, { route = '/' } = {}) => {
+  window.history.pushState({}, 'Test page', route);
+
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <Routes>
+        <Route path="/:source" element={ui} />
+        <Route path="/" element={<div>Home Page</div>} />
+        <Route path="/inventory" element={<div>Inventory Page</div>} />
+        <Route path="/checkout" element={<div>Checkout Page</div>} />
+        <Route path="/people" element={<div>People Page</div>} />
+        <Route path="/volunteer-home" element={<div>Volunteer Home Page</div>} />
+        <Route path="/404" element={<div data-testid="page-404">404 Page</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe('RootRedirect', () => {
+  it('shows loading message when isLoading is true', () => {
+    const contextValue = mockUserContextValue('admin', true);
+    render(
+      <UserContext.Provider value={contextValue}>
+        <RootRedirect source="inventory">
+          <div>Child Content</div>
+        </RootRedirect>
+      </UserContext.Provider>
+    );
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('redirects to /inventory if user has no role', () => {
+    const contextValue = mockUserContextValue(null, false);
+    renderWithRouter(
+      <UserContext.Provider value={contextValue}>
+        <RootRedirect source="some-page">
+          <div>Child Content</div>
+        </RootRedirect>
+      </UserContext.Provider>,
+      { route: '/some-page' }
+    );
+    expect(screen.getByText('Inventory Page')).toBeInTheDocument();
+  });
+
+  it('renders children if user has permission for the source page', () => {
+    const contextValue = mockUserContextValue('admin', false);
+    render(
+        <UserContext.Provider value={contextValue}>
+            <RootRedirect source="people">
+                <div>People Page Content</div>
+            </RootRedirect>
+        </UserContext.Provider>
+    );
+    expect(screen.getByText('People Page Content')).toBeInTheDocument();
+  });
+
+  it('redirects to the first permitted page if user does not have permission', () => {
+    const contextValue = mockUserContextValue('volunteer', false);
+    renderWithRouter(
+      <UserContext.Provider value={contextValue}>
+        <RootRedirect source="people">
+          <div>Child Content</div>
+        </RootRedirect>
+      </UserContext.Provider>,
+      { route: '/people' }
+    );
+    // volunteer's first page is 'volunteer-home'
+    expect(screen.getByText('Volunteer Home Page')).toBeInTheDocument();
+  });
+
+  it('admin redirects to the first permitted page if they access volunteer page', () => {
+    const contextValue = mockUserContextValue('admin', false);
+    renderWithRouter(
+      <UserContext.Provider value={contextValue}>
+        <RootRedirect source="volunteer-home">
+          <div>Child Content</div>
+        </RootRedirect>
+      </UserContext.Provider>,
+      { route: '/volunteer-home' }
+    );
+    // admin's first page is 'inventory'
+    expect(screen.getByText('Inventory Page')).toBeInTheDocument();
+  });
+
+  it('renders 404 for a non-existent page', () => {
+    const contextValue = mockUserContextValue('admin', false);
+     renderWithRouter(
+      <UserContext.Provider value={contextValue}>
+        <RootRedirect source="non-existent-page">
+          <div>Child Content</div>
+        </RootRedirect>
+      </UserContext.Provider>,
+      { route: '/non-existent-page' }
+    );
+    expect(screen.getByText('404 Page')).toBeInTheDocument();
+  });
+
+  it('allows volunteer to access shared page', () => {
+    const contextValue = mockUserContextValue('volunteer', false);
+    render(
+        <UserContext.Provider value={contextValue}>
+            <RootRedirect source="inventory">
+                <div>Inventory Page Content</div>
+            </RootRedirect>
+        </UserContext.Provider>
+    );
+    expect(screen.getByText('Inventory Page Content')).toBeInTheDocument();
+  });
+});

--- a/src/components/RootRedirect.test.tsx
+++ b/src/components/RootRedirect.test.tsx
@@ -165,13 +165,4 @@ describe('RootRedirect - invalid userRole handling', () => {
     expect(mockLocalStorageClear).toHaveBeenCalledTimes(1);
     expect(window.location.href).toBe('/.auth/logout?post_logout_redirect_uri=/login.html');
   });
-
-  it('clears localStorage and redirects to logout when userRole is undefined', () => {
-    const contextValue = mockUserContextValue(undefined, false);
-
-    renderWithRouter(contextValue, { route: '/people' });
-
-    expect(mockLocalStorageClear).toHaveBeenCalledTimes(1);
-    expect(window.location.href).toBe('/.auth/logout?post_logout_redirect_uri=/login.html');
-  });
 });

--- a/src/components/RootRedirect.tsx
+++ b/src/components/RootRedirect.tsx
@@ -10,8 +10,12 @@ interface RootRedirectProps {
 }
 
 export const RootRedirect: React.FC<RootRedirectProps> = ({ source, children }) => {
-  const { user } = React.useContext(UserContext);
+  const { user, isLoading } = React.useContext(UserContext);
   const userRole = user ? getRole(user) : null;
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
   if (!userRole) {
     // Redirect to inventory page if no role (yet)
     return <Navigate to='/inventory' replace />;

--- a/src/components/RootRedirect.tsx
+++ b/src/components/RootRedirect.tsx
@@ -10,19 +10,20 @@ interface RootRedirectProps {
 }
 
 export const RootRedirect: React.FC<RootRedirectProps> = ({ source, children }) => {
-  console.log(`RootRedirect: Entered with source=${source}`);
   const { user, isLoading } = React.useContext(UserContext);
   const userRole = user ? getRole(user) : null;
 
-  console.log(`RootRedirect: userRole=${userRole}, source=${source}, isLoading=${isLoading}`);
-
+  // This handles the situation when the userContext does not have a user set yet. 
   if (isLoading) {
     return <div>Loading...</div>;
   }
-  if (!userRole) {
-    // Redirect to inventory page if no role (yet)
-    return <Navigate to='/inventory' replace />;
+
+  if (!userRole) {//This is an invalid state. User can't do anything in the app. Get out. 
+    localStorage.clear();
+    window.location.href = "/.auth/logout?post_logout_redirect_uri=/login.html";
+    return;
   }
+
   const alternateRole = userRole === 'admin' ? 'volunteer' : 'admin';
   // Pages that are accessible by this role
   const permittedPages: readonly string[] = userRole ? ROLE_PAGES[userRole as keyof typeof ROLE_PAGES] : [];

--- a/src/components/RootRedirect.tsx
+++ b/src/components/RootRedirect.tsx
@@ -11,17 +11,16 @@ interface RootRedirectProps {
 
 export const RootRedirect: React.FC<RootRedirectProps> = ({ source, children }) => {
   const { user, isLoading } = React.useContext(UserContext);
-  const userRole = user ? getRole(user) : null;
 
   // This handles the situation when the userContext does not have a user set yet. 
   if (isLoading) {
     return <div>Loading...</div>;
   }
 
-  if (!userRole) {//This is an invalid state. User can't do anything in the app. Get out. 
-    localStorage.clear();
-    window.location.href = "/.auth/logout?post_logout_redirect_uri=/login.html";
-    return;
+  const userRole = user ? getRole(user) : null;
+
+  if (!userRole) { // invalid state; log out
+    return <LogoutRedirect />;
   }
 
   const alternateRole = userRole === 'admin' ? 'volunteer' : 'admin';
@@ -46,3 +45,12 @@ export const RootRedirect: React.FC<RootRedirectProps> = ({ source, children }) 
     }
   }
 };
+
+function LogoutRedirect() {
+  React.useEffect(() => {
+    // remove only our keys; avoid nuking unrelated storage (e.g., analytics)
+    ['user', 'loggedInUserId', 'activeVolunteers'].forEach((k) => localStorage.removeItem(k));
+    window.location.href = "/.auth/logout?post_logout_redirect_uri=/login.html";
+  }, []);
+  return null;
+}

--- a/src/components/RootRedirect.tsx
+++ b/src/components/RootRedirect.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
-import { UserContext, getRole } from './contexts/UserContext'; 
+import { UserContext, getRole } from './contexts/UserContext';
 import { ROLE_PAGES } from '../types/constants';
 import Page404 from '../pages/error/404';
 
@@ -10,8 +10,11 @@ interface RootRedirectProps {
 }
 
 export const RootRedirect: React.FC<RootRedirectProps> = ({ source, children }) => {
+  console.log(`RootRedirect: Entered with source=${source}`);
   const { user, isLoading } = React.useContext(UserContext);
   const userRole = user ? getRole(user) : null;
+
+  console.log(`RootRedirect: userRole=${userRole}, source=${source}, isLoading=${isLoading}`);
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -25,7 +28,7 @@ export const RootRedirect: React.FC<RootRedirectProps> = ({ source, children }) 
   const permittedPages: readonly string[] = userRole ? ROLE_PAGES[userRole as keyof typeof ROLE_PAGES] : [];
   // Pages that are only accessible by another role 
   const nonPermittedPages: readonly string[] = ROLE_PAGES[alternateRole as keyof typeof ROLE_PAGES]
-    .filter(page => 
+    .filter(page =>
       !(ROLE_PAGES[userRole as keyof typeof ROLE_PAGES] as readonly string[]).includes(page)
     );
 

--- a/src/components/RootRedirect.tsx
+++ b/src/components/RootRedirect.tsx
@@ -24,7 +24,9 @@ export const RootRedirect: React.FC<RootRedirectProps> = ({ source, children }) 
     } catch {  
       return <LogoutRedirect />;  
     }  
-  }  
+  }else{
+      return <LogoutRedirect />;  
+  }
 
   const alternateRole = userRole === 'admin' ? 'volunteer' : 'admin';
   // Pages that are accessible by this role

--- a/src/components/RootRedirect.tsx
+++ b/src/components/RootRedirect.tsx
@@ -17,11 +17,14 @@ export const RootRedirect: React.FC<RootRedirectProps> = ({ source, children }) 
     return <div>Loading...</div>;
   }
 
-  const userRole = user ? getRole(user) : null;
-
-  if (!userRole) { // invalid state; log out
-    return <LogoutRedirect />;
-  }
+  let userRole: string | null = null;  
+  if (user) {  
+    try {  
+      userRole = getRole(user);  
+    } catch {  
+      return <LogoutRedirect />;  
+    }  
+  }  
 
   const alternateRole = userRole === 'admin' ? 'volunteer' : 'admin';
   // Pages that are accessible by this role

--- a/src/components/RootRedirect.tsx
+++ b/src/components/RootRedirect.tsx
@@ -48,8 +48,7 @@ export const RootRedirect: React.FC<RootRedirectProps> = ({ source, children }) 
 
 function LogoutRedirect() {
   React.useEffect(() => {
-    // remove only our keys; avoid nuking unrelated storage (e.g., analytics)
-    ['user', 'loggedInUserId', 'activeVolunteers'].forEach((k) => localStorage.removeItem(k));
+    localStorage.clear();
     window.location.href = "/.auth/logout?post_logout_redirect_uri=/login.html";
   }, []);
   return null;

--- a/src/components/contexts/UserContext.ts
+++ b/src/components/contexts/UserContext.ts
@@ -15,6 +15,7 @@ export const UserContext = createContext<UserContextType>({
   setLoggedInUserId: () => {},
   activeVolunteers: [],
   setActiveVolunteers: () => {},
+  isLoading: true,
 });
 
 export function getRole(user: ClientPrincipal | null): string {

--- a/src/pages/VolunteerHome/VolunteerHome.test.tsx
+++ b/src/pages/VolunteerHome/VolunteerHome.test.tsx
@@ -55,7 +55,8 @@ const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
     loggedInUserId: 1,
     setLoggedInUserId: vi.fn(),
     activeVolunteers: [],
-    setActiveVolunteers: vi.fn()
+    setActiveVolunteers: vi.fn(),
+    isLoading: false
   }}>
     {children}
   </UserContext.Provider>

--- a/src/pages/authentication/EnterPinPage.test.tsx
+++ b/src/pages/authentication/EnterPinPage.test.tsx
@@ -29,6 +29,7 @@ const createUserContextValue = (overrides = {}) => ({
   setLoggedInUserId: vi.fn(),
   activeVolunteers: [],
   setActiveVolunteers: vi.fn(),
+  isLoading: false,
   ...overrides,
 });
 

--- a/src/pages/authentication/PickNamePage.test.tsx
+++ b/src/pages/authentication/PickNamePage.test.tsx
@@ -30,6 +30,7 @@ const createUserContextValue = (overrides = {}) => ({
   activeVolunteers: [],
   setActiveVolunteers: vi.fn(),
   setUser: vi.fn(),
+  isLoading: false,
   ...overrides,
 });
 

--- a/src/pages/checkout/CheckoutPage.test.tsx
+++ b/src/pages/checkout/CheckoutPage.test.tsx
@@ -13,6 +13,7 @@ const mockUserContext = {
   setLoggedInUserId: vi.fn(),
   activeVolunteers: [],
   setActiveVolunteers: vi.fn(),
+  isLoading: false
 };
 
 describe('CheckoutPage', async () => {

--- a/src/pages/people/useUsers.test.tsx
+++ b/src/pages/people/useUsers.test.tsx
@@ -21,6 +21,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
       setLoggedInUserId: vi.fn(),
       activeVolunteers: [],
       setActiveVolunteers: vi.fn(),
+      isLoading: false
     }}
   >
     {children}

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -54,6 +54,7 @@ export interface UserContextType {
   setLoggedInUserId: (loggedInVolunteer: number | null) => void;
   activeVolunteers: User[];
   setActiveVolunteers: (activeVolunteers: User[]) => void;
+  isLoading: boolean;
 }
 
 export type InventoryItem = {


### PR DESCRIPTION
## Description

When a user logs off, and then back in, he is routed to the inventory page, and the Volunteer selection is skipped. This was caused by a race condition in setting the user in the UserContext. When the RootRedirect logic was running the userRole was not yet available. By default it would go to Inventory. 

I added an isLoading state to the UserContext to reroute when the userRole becomes available. 

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

- Closes #369

## QA Instructions, Screenshots, Recordings

Make sure to log off and back in switching between the admin and volunteer roles. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App shows a startup loading state ("Loading...") while user data is resolved.

* **Bug Fixes**
  * Prevents premature redirects and page flashes during initial user detection.
  * Clears session and redirects to logout/login when a detected user lacks a valid role.

* **Refactor**
  * Loading status exposed in the shared user context for consistent behavior.

* **Tests**
  * Comprehensive RootRedirect tests added; mocks updated to include the loading flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->