### PR TITLE
Misty/359: add resident name and unit number to checkout summary

### DIFF
--- a/src/components/Checkout/CheckoutDialog.tsx
+++ b/src/components/Checkout/CheckoutDialog.tsx
@@ -245,8 +245,13 @@ export const CheckoutDialog: React.FC<CheckoutDialogProps> = ({
           }}
         >
           <Typography>
-            <strong>Building code: </strong>
-            {selectedBuildingCode}
+            <strong>Building code: </strong>{selectedBuildingCode}
+          </Typography>
+          <Typography>
+            <strong>Unit number: </strong>{residentInfo.unit.unit_number}
+          </Typography>
+          <Typography>
+            <strong>Resident name: </strong>{residentInfo.name}
           </Typography>
           <Typography
             sx={{
@@ -256,9 +261,8 @@ export const CheckoutDialog: React.FC<CheckoutDialogProps> = ({
                   : 'black',
             }}
           >
-            <strong>Total Items Checked Out: </strong>
-            {allItems.reduce((acc, item) => acc + item.quantity, 0)} / 10
-            allowed
+            <strong>Total Items: </strong>
+            {allItems.reduce((acc, item) => acc + item.quantity, 0)}
           </Typography>
 
           {/* Display category limit errors */}


### PR DESCRIPTION
## Description

Quick fix to add the resident name and unit number to the checkout summary dialog.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents
https://das-ph-inventory-tracker.atlassian.net/browse/PIT-359?atlOrigin=eyJpIjoiNmRlODI5NzQxY2IwNDJmM2I3YTEzZGUzM2NhYTU4N2IiLCJwIjoiaiJ9

## QA Instructions, Screenshots, Recordings
<img width="1920" height="880" alt="image" src="https://github.com/user-attachments/assets/4e279410-f393-47c1-ab9b-bfc5242287b5" />