### PR TITLE
Pin DAB schema to version 1.6.68

### DIFF
--- a/dab/dab-config.json
+++ b/dab/dab-config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://github.com/Azure/data-api-builder/releases/latest/download/dab.draft.schema.json",
+  "$schema": "https://github.com/Azure/data-api-builder/releases/download/v1.6.68/dab.draft.schema.json",
   "data-source": {
     "database-type": "mssql",
     "connection-string": "@env('DATABASE_CONNECTION_STRING')"


### PR DESCRIPTION
## Description

This PR pins the Data API Builder (DAB) schema version to v1.6.68 instead of using the "latest" release. Pinning to a specific version ensures schema stability and prevents unexpected breaking changes when new DAB versions are released.

This change updates the `$schema` reference in `dab-config.json` from the floating "latest" version to the fixed v1.6.68 release.

## Jira Ticket
- Closes: [PIT-???](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-???)

## Type of Change
**Type:** Configuration

## Changes Made
- Updated `dab-config.json` to reference DAB schema version v1.6.68 instead of "latest"
- Ensures consistent schema validation across environments and deployments

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have run [prettier](https://github.com/digitalaidseattle/plymouth-housing#code-formatting) on the code
- [x] I have performed a self-review of my code
- [x] I have commented my code only in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings in Chrome Dev Tools
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## QA Instructions, Screenshots, Recordings

To verify this change:
1. Check that `dab-config.json` now references the specific schema version `v1.6.68`
2. Ensure the application starts and DAB functionality works as expected
3. Verify schema validation is working correctly with the pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to pin the data schema to a specific version, ensuring improved consistency and preventing unexpected changes from automatic version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->