### PR TITLE
feat: show absolute dates in transaction history (PIT-449)

### DIFF
--- a/src/components/History/TransactionsList.tsx
+++ b/src/components/History/TransactionsList.tsx
@@ -4,10 +4,7 @@ import { Building, User, CheckoutTransaction, InventoryTransaction } from '../..
 import GeneralCheckoutCard from './GeneralCheckoutCard';
 import WelcomeBasketCard from './WelcomeBasketCard';
 import InventoryCard from './InventoryCard';
-import {
-  createHowLongAgoString,
-  calculateTimeDifference,
-} from './historyUtils';
+import { formatTransactionDate } from './historyUtils';
 
 interface TransactionsListProps {
   transactionsByUser: Array<{
@@ -64,14 +61,7 @@ const TransactionsList: React.FC<TransactionsListProps> = ({
           >
             {user.transactions.map(
               (t: CheckoutTransaction | InventoryTransaction) => {
-                const { minutes, hours, days } = calculateTimeDifference(
-                  t.transaction_date,
-                );
-                const howLongAgoString = createHowLongAgoString(
-                  minutes,
-                  hours,
-                  days,
-                );
+                const howLongAgoString = formatTransactionDate(t.transaction_date);
                 const checkoutTransaction = t as CheckoutTransaction;
                 if (
                   historyType === 'checkout' &&

--- a/src/components/History/historyUtils.test.ts
+++ b/src/components/History/historyUtils.test.ts
@@ -1,4 +1,6 @@
-import { describe, test, expect, vi, afterEach } from 'vitest';
+import { describe, test, expect, vi, afterEach, beforeAll, afterAll } from 'vitest';
+
+process.env.TZ = 'UTC';
 import {
   formatTransactionDate,
   formatDateRange,
@@ -108,5 +110,30 @@ describe('formatBuildingInfo', () => {
 
   test('returns empty string when buildings is null', () => {
     expect(formatBuildingInfo(1, null)).toBe('');
+  });
+});
+
+describe('formatTransactionDate - America/New_York timezone', () => {
+  const savedTZ = process.env.TZ;
+
+  beforeAll(() => {
+    process.env.TZ = 'America/New_York';
+  });
+
+  afterAll(() => {
+    process.env.TZ = savedTZ;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('timestamp just after UTC midnight shows previous local date in New York', () => {
+    vi.useFakeTimers();
+    // "now" is Jun 15 at 2 PM UTC = Jun 15 at 10 AM EDT
+    vi.setSystemTime(new Date('2025-06-15T14:00:00Z'));
+    // 00:30Z on Jun 15 = 8:30 PM EDT on Jun 14 — a different local date
+    const result = formatTransactionDate('2025-06-15T00:30:00Z');
+    expect(result).toMatch(/^Created Jun 14, 2025 at /);
   });
 });

--- a/src/components/History/historyUtils.test.ts
+++ b/src/components/History/historyUtils.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import {
+  formatTransactionDate,
+  formatDateRange,
+  formatFullDate,
+  findBuildingById,
+  formatBuildingInfo,
+} from './historyUtils';
+import { Building } from '../../types/interfaces';
+
+describe('formatTransactionDate', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('returns "Created today at ..." for a timestamp from today', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-06-15T14:00:00Z'));
+    const result = formatTransactionDate('2025-06-15T14:00:00Z');
+    expect(result).toMatch(/^Created today at /);
+  });
+
+  test('returns date string for a past day', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-06-15T14:00:00Z'));
+    const result = formatTransactionDate('2025-06-10T09:00:00Z');
+    expect(result).toMatch(/^Created Jun 10, 2025 at /);
+  });
+
+  test('Z and +00:00 resolve to the same date (no double timezone)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-06-15T14:00:00Z'));
+    const withZ = formatTransactionDate('2025-06-15T14:00:00Z');
+    const withOffset = formatTransactionDate('2025-06-15T14:00:00+00:00');
+    expect(withZ).toBe(withOffset);
+  });
+
+  test('bare timestamp (no timezone) is treated as UTC', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-06-15T14:00:00Z'));
+    const withZ = formatTransactionDate('2025-06-15T14:00:00Z');
+    const bare = formatTransactionDate('2025-06-15T14:00:00');
+    expect(bare).toBe(withZ);
+  });
+
+  test('handles timestamp with -05:00 offset', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-06-15T20:00:00Z'));
+    // 15:00-05:00 = 20:00Z, same day
+    const result = formatTransactionDate('2025-06-15T15:00:00-05:00');
+    expect(result).toMatch(/^Created today at /);
+  });
+});
+
+describe('formatDateRange', () => {
+  test('formats start and end date as readable range', () => {
+    const start = new Date('2025-01-01T00:00:00Z');
+    const end = new Date('2025-01-31T00:00:00Z');
+    const result = formatDateRange(start, end);
+    expect(result).toContain(' - ');
+    expect(result).toMatch(/Jan/);
+    expect(result).toMatch(/2025/);
+  });
+});
+
+describe('formatFullDate', () => {
+  test('includes weekday, month, day, year', () => {
+    const date = new Date('2025-01-06T12:00:00Z');
+    const result = formatFullDate(date);
+    expect(result).toMatch(/2025/);
+    expect(result).toMatch(/Jan/);
+  });
+});
+
+describe('findBuildingById', () => {
+  const buildings: Building[] = [
+    { id: 1, code: 'A', name: 'Main St' },
+    { id: 2, code: 'B', name: 'Oak Ave' },
+  ];
+
+  test('returns matching building', () => {
+    expect(findBuildingById(1, buildings)).toEqual({
+      id: 1,
+      code: 'A',
+      name: 'Main St',
+    });
+  });
+
+  test('returns undefined for unknown id', () => {
+    expect(findBuildingById(99, buildings)).toBeUndefined();
+  });
+
+  test('returns undefined when buildings list is null', () => {
+    expect(findBuildingById(1, null)).toBeUndefined();
+  });
+});
+
+describe('formatBuildingInfo', () => {
+  const buildings: Building[] = [{ id: 1, code: 'A', name: 'Main St' }];
+
+  test('formats building as "CODE - Name"', () => {
+    expect(formatBuildingInfo(1, buildings)).toBe('A - Main St');
+  });
+
+  test('returns empty string for unknown building', () => {
+    expect(formatBuildingInfo(99, buildings)).toBe('');
+  });
+
+  test('returns empty string when buildings is null', () => {
+    expect(formatBuildingInfo(1, null)).toBe('');
+  });
+});

--- a/src/components/History/historyUtils.test.ts
+++ b/src/components/History/historyUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, vi, afterEach, beforeAll, afterAll } from 'vitest';
 
+const savedTZ = process.env.TZ;
 process.env.TZ = 'UTC';
 import {
   formatTransactionDate,
@@ -9,6 +10,10 @@ import {
   formatBuildingInfo,
 } from './historyUtils';
 import { Building } from '../../types/interfaces';
+
+afterAll(() => {
+  process.env.TZ = savedTZ;
+});
 
 describe('formatTransactionDate', () => {
   afterEach(() => {
@@ -114,14 +119,12 @@ describe('formatBuildingInfo', () => {
 });
 
 describe('formatTransactionDate - America/New_York timezone', () => {
-  const savedTZ = process.env.TZ;
-
   beforeAll(() => {
     process.env.TZ = 'America/New_York';
   });
 
   afterAll(() => {
-    process.env.TZ = savedTZ;
+    process.env.TZ = 'UTC';
   });
 
   afterEach(() => {

--- a/src/components/History/historyUtils.ts
+++ b/src/components/History/historyUtils.ts
@@ -20,7 +20,7 @@ const DATE_FORMATS = {
 
 
 export function formatTransactionDate(timestamp: string): string {
-  const hasTimezone = /(?:Z|[+\-]\d{2}:\d{2})$/i.test(timestamp);
+  const hasTimezone = /(?:Z|[+-]\d{2}:\d{2})$/i.test(timestamp);
   const dateCreated = new Date(hasTimezone ? timestamp : timestamp + 'Z');
   const now = new Date();
 

--- a/src/components/History/historyUtils.ts
+++ b/src/components/History/historyUtils.ts
@@ -20,7 +20,8 @@ const DATE_FORMATS = {
 
 
 export function formatTransactionDate(timestamp: string): string {
-  const dateCreated = new Date(timestamp.endsWith('Z') ? timestamp : timestamp + 'Z');
+  const hasTimezone = /(?:Z|[+\-]\d{2}:\d{2})$/i.test(timestamp);
+  const dateCreated = new Date(hasTimezone ? timestamp : timestamp + 'Z');
   const now = new Date();
 
   const isToday =

--- a/src/components/History/historyUtils.ts
+++ b/src/components/History/historyUtils.ts
@@ -19,36 +19,32 @@ const DATE_FORMATS = {
 };
 
 
-export function createHowLongAgoString(
-  minutes: number,
-  hours: number,
-  days: number,
-): string {
-  const getTimeUnit = (): string => {
-    if (days > 0) {
-      return days === 1 ? '1 day' : `${days} days`;
-    }
-    if (hours > 0) {
-      return hours === 1 ? '1 hour' : `${hours} hours`;
-    }
-    return `${minutes} min`;
-  };
-  return `Created ${getTimeUnit()} ago`;
-}
-
-export function calculateTimeDifference(timestamp: string): {
-  minutes: number;
-  hours: number;
-  days: number;
-} {
+export function formatTransactionDate(timestamp: string): string {
   const dateCreated = new Date(timestamp.endsWith('Z') ? timestamp : timestamp + 'Z');
   const now = new Date();
-  const seconds = (now.getTime() - dateCreated.getTime()) / 1000;
-  const minutes = Math.floor(seconds / 60);
-  const hours = Math.floor(minutes / 60);
-  const days = Math.floor(hours / 24);
 
-  return { minutes, hours, days };
+  const isToday =
+    dateCreated.getFullYear() === now.getFullYear() &&
+    dateCreated.getMonth() === now.getMonth() &&
+    dateCreated.getDate() === now.getDate();
+
+  const timeStr = dateCreated.toLocaleString('en-us', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+
+  if (isToday) {
+    return `Created today at ${timeStr}`;
+  }
+
+  const dateStr = dateCreated.toLocaleString('en-us', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  return `Created ${dateStr} at ${timeStr}`;
 }
 
 export function formatDateRange(startDate: Date, endDate: Date): string {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    env: { TZ: 'UTC' },
   },
   build: {
     rollupOptions: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,23 +5,22 @@ import { visualizer } from 'rollup-plugin-visualizer';
 export default defineConfig({
   plugins: [
     react(),
-    visualizer({ open: false, filename: 'bundle-visualization.html' })
+    visualizer({ open: false, filename: 'bundle-visualization.html' }),
   ],
   test: {
     globals: true,
     environment: 'jsdom',
-    env: { TZ: 'UTC' },
   },
   build: {
     rollupOptions: {
-      treeshake: true,  
+      treeshake: true,
       output: {
         manualChunks: {
           'react-vendor': ['react', 'react-dom'],
         },
       },
     },
-    chunkSizeWarningLimit: 1000, 
+    chunkSizeWarningLimit: 1000,
   },
   server: {
     host: true, // Needed for running on devcontainers.


### PR DESCRIPTION
## Description

Replaces relative timestamps (e.g., "Created 3 days ago") in the transaction history with absolute dates (e.g., "Created Feb 28, 2026 at 2:34 PM"). For transactions created on the current calendar day, the label reads "Created today at [time]". Dates are displayed in the user's local timezone.

## Jira Ticket
- Closes: [PIT-449](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-449)

## Type of Change
**Type:** New feature

## Changes Made
- Replaced `createHowLongAgoString` + `calculateTimeDifference` in `historyUtils.ts` with a single `formatTransactionDate` function
- Updated `TransactionsList.tsx` to use the new function

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have run [prettier](https://github.com/digitalaidseattle/plymouth-housing#code-formatting) on the code
- [x] I have performed a self-review of my code
- [x] I have commented my code only in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings in Chrome Dev Tools
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## QA Instructions

1. Navigate to the History page
2. Verify transactions from today show "Created today at [time]" (e.g., "Created today at 2:34 PM")
3. Verify transactions from previous days show "Created [Month D, YYYY] at [time]" (e.g., "Created Feb 28, 2026 at 10:30 AM")
4. Confirm times reflect your local timezone (not UTC)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined history timestamps: same-day entries show "Created today at [time]"; older entries use "Created Mon D, YYYY at HH:MM". Handles various timestamp formats and timezones for consistent display.

* **Tests**
  * Added extensive tests for date/time formatting, date ranges, building lookups, and timezone behavior.

* **Chores**
  * Minor formatting cleanup in build config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->