### PR TITLE
fix: exclude Welcome Basket items from general checkout search (hotfix)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,2 @@
+reviews:
+  request_changes_workflow: true

--- a/.github/workflows/azure-static-web-apps-dev.yml
+++ b/.github/workflows/azure-static-web-apps-dev.yml
@@ -5,15 +5,12 @@ on:
     branches:
       - dev
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
     branches:
       - dev
 
 jobs:
   ci:
-    if:
-      github.event_name == 'push' || (github.event_name == 'pull_request' &&
-      github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: CI
     steps:
@@ -34,52 +31,3 @@ jobs:
 
       - name: Build
         run: npm run build
-
-  build_and_deploy_job:
-    needs: ci
-    if:
-      github.event_name == 'push' || (github.event_name == 'pull_request' &&
-      github.event.action != 'closed')
-    runs-on: ubuntu-latest
-    name: Build and Deploy Job
-    steps:
-      - name: Check out source
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-          lfs: false
-
-      - name: Build And Deploy
-        id: builddeploy
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token:
-            ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_DEV }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
-          action: 'upload'
-          app_location: '/' # App source code path
-          api_location: '' # Api source code path - optional
-          output_location: 'dist' # Built app content directory - optional
-        # We are not using Clarity and App Insights in dev environment.
-        # env:
-        #   VITE_CLARITY_PROJECT_ID: ${{ secrets.VITE_CLARITY_PROJECT_ID }}
-        #   VITE_APPINSIGHTS_CONNECTION_STRING: ${{ secrets.VITE_APPINSIGHTS_CONNECTION_STRING }}
-
-      - name: Post URL
-        run: |
-          echo "App deployed :rocket:" >> $GITHUB_STEP_SUMMARY
-          echo ${{ steps.builddeploy.outputs.static_web_app_url }} >> $GITHUB_STEP_SUMMARY
-
-  close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request Job
-    steps:
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token:
-            ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_DEV }}
-          action: 'close'
-          app_location: '/'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,4 +62,4 @@ jobs:
 
       - name: Run smoke tests (headless)
         run: |
-          pytest -m smoke -n auto --maxfail=1 --disable-warnings -q
+          pytest -m smoke --maxfail=1 --disable-warnings -q

--- a/src/components/Checkout/BuildingCodeSelect.tsx
+++ b/src/components/Checkout/BuildingCodeSelect.tsx
@@ -14,6 +14,7 @@ interface BuildingCodeSelectProps {
   setSelectedUnit: (unit: Unit) => void;
   fetchUnitNumbers: (buildingId: number) => void;
   error: boolean;
+  resetError: () => void;
   disabled?: boolean;
 }
 
@@ -28,6 +29,7 @@ const BuildingCodeSelect: React.FC<BuildingCodeSelectProps> = ({
   setSelectedUnit,
   fetchUnitNumbers,
   error,
+  resetError,
   disabled = false,
 }) => {
   return (
@@ -46,6 +48,7 @@ const BuildingCodeSelect: React.FC<BuildingCodeSelectProps> = ({
             setSelectedBuilding(newValue);
             setSelectedUnit({ id: 0, unit_number: '' });
             fetchUnitNumbers(newValue.id);
+            resetError();
           }
         }}
         getOptionLabel={(option: Building) => {
@@ -57,7 +60,7 @@ const BuildingCodeSelect: React.FC<BuildingCodeSelectProps> = ({
             {...params}
             label="Building Code"
             error={error}
-            helperText={error ? 'Please select a building' : ''}
+            helperText={error ? 'Please select the building code' : ''}
           />
         )}
       />

--- a/src/components/Checkout/ResidentDetailDialog.test.tsx
+++ b/src/components/Checkout/ResidentDetailDialog.test.tsx
@@ -19,7 +19,7 @@ describe('ResidentDetailDialog', () => {
     id: 1,
     userDetails: 'Test User',
     userRoles: ['volunteer'],
-    userID: 'testuser'
+    userID: 'testuser',
   };
 
   const mockUserContext = {
@@ -44,10 +44,7 @@ describe('ResidentDetailDialog', () => {
   ];
 
   const mockResidents = {
-    value: [
-      { name: 'John Doe' },
-      { name: 'Jane Smith' },
-    ],
+    value: [{ name: 'John Doe' }, { name: 'Jane Smith' }],
   };
 
   const defaultProps = {
@@ -75,14 +72,16 @@ describe('ResidentDetailDialog', () => {
     return render(
       <UserContext.Provider value={mockUserContext}>
         <ResidentDetailDialog {...defaultProps} {...props} />
-      </UserContext.Provider>
+      </UserContext.Provider>,
     );
   };
 
   describe('Rendering', () => {
     test('renders dialog when showDialog is true', () => {
       renderComponent();
-      expect(screen.getByText('provide details to continue')).toBeInTheDocument();
+      expect(
+        screen.getByText('provide details to continue'),
+      ).toBeInTheDocument();
       expect(screen.getByLabelText('Building Code')).toBeInTheDocument();
       expect(screen.getByLabelText('Unit Number')).toBeInTheDocument();
       expect(screen.getByLabelText('Resident Name')).toBeInTheDocument();
@@ -90,12 +89,16 @@ describe('ResidentDetailDialog', () => {
 
     test('does not render dialog when showDialog is false', () => {
       renderComponent({ showDialog: false });
-      expect(screen.queryByText('provide details to continue')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('provide details to continue'),
+      ).not.toBeInTheDocument();
     });
 
     test('renders continue button', () => {
       renderComponent();
-      expect(screen.getByRole('button', { name: /continue/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /continue/i }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -112,14 +115,19 @@ describe('ResidentDetailDialog', () => {
       fireEvent.click(buildingOption);
 
       await waitFor(() => {
-        expect(CheckoutAPICalls.getUnitNumbers).toHaveBeenCalledWith(mockUser, 1);
+        expect(CheckoutAPICalls.getUnitNumbers).toHaveBeenCalledWith(
+          mockUser,
+          1,
+        );
       });
     });
 
     test('shows wait cursor while fetching units', async () => {
       (CheckoutAPICalls.getUnitNumbers as Mock).mockImplementation(() => {
         expect(document.body.style.cursor).toBe('wait');
-        return new Promise(resolve => setTimeout(() => resolve(mockUnits), 100));
+        return new Promise((resolve) =>
+          setTimeout(() => resolve(mockUnits), 100),
+        );
       });
 
       renderComponent();
@@ -148,13 +156,17 @@ describe('ResidentDetailDialog', () => {
       fireEvent.click(buildingOption);
 
       await waitFor(() => {
-        expect(screen.getByText(/Unable to load unit numbers/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/Unable to load unit numbers/i),
+        ).toBeInTheDocument();
       });
     });
 
     test('disables all fields while fetching units', async () => {
       (CheckoutAPICalls.getUnitNumbers as Mock).mockImplementation(() => {
-        return new Promise(resolve => setTimeout(() => resolve(mockUnits), 100));
+        return new Promise((resolve) =>
+          setTimeout(() => resolve(mockUnits), 100),
+        );
       });
 
       renderComponent();
@@ -212,14 +224,18 @@ describe('ResidentDetailDialog', () => {
       fireEvent.change(unitInput, { target: { value: '101' } });
 
       await waitFor(() => {
-        expect(screen.getByLabelText('Resident Name')).toHaveValue('Jane Smith');
+        expect(screen.getByLabelText('Resident Name')).toHaveValue(
+          'Jane Smith',
+        );
       });
     });
 
     test('shows wait cursor while fetching residents', async () => {
       (CheckoutAPICalls.getResidents as Mock).mockImplementation(() => {
         expect(document.body.style.cursor).toBe('wait');
-        return new Promise(resolve => setTimeout(() => resolve(mockResidents), 100));
+        return new Promise((resolve) =>
+          setTimeout(() => resolve(mockResidents), 100),
+        );
       });
 
       const propsWithUnits = {
@@ -252,13 +268,17 @@ describe('ResidentDetailDialog', () => {
       fireEvent.change(unitInput, { target: { value: '101' } });
 
       await waitFor(() => {
-        expect(screen.getByText(/Unable to load resident data/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/Unable to load resident data/i),
+        ).toBeInTheDocument();
       });
     });
 
     test('disables all fields while fetching residents', async () => {
       (CheckoutAPICalls.getResidents as Mock).mockImplementation(() => {
-        return new Promise(resolve => setTimeout(() => resolve(mockResidents), 100));
+        return new Promise((resolve) =>
+          setTimeout(() => resolve(mockResidents), 100),
+        );
       });
 
       const propsWithUnits = {
@@ -299,7 +319,9 @@ describe('ResidentDetailDialog', () => {
       fireEvent.change(unitInput, { target: { value: '101' } });
 
       await waitFor(() => {
-        expect(screen.getByLabelText('Resident Name')).toHaveValue('Jane Smith');
+        expect(screen.getByLabelText('Resident Name')).toHaveValue(
+          'Jane Smith',
+        );
       });
 
       // Then clear the unit
@@ -319,9 +341,15 @@ describe('ResidentDetailDialog', () => {
       fireEvent.click(continueButton);
 
       await waitFor(() => {
-        expect(screen.getByText(/Please select a building/i)).toBeInTheDocument();
-        expect(screen.getByText(/Please select a unit from the list/i)).toBeInTheDocument();
-        expect(screen.getByText(/Please enter the resident's name/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/Please select the building code/i),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(/Please select a unit from the list/i),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(/Please enter the name of the resident/i),
+        ).toBeInTheDocument();
       });
     });
 
@@ -346,7 +374,7 @@ describe('ResidentDetailDialog', () => {
         value: [{ id: 1, name: 'John Doe' }],
       });
       (CheckoutAPICalls.getLastResidentVisit as Mock).mockResolvedValue({
-        value: [{ transaction_date: '2025-01-15T10:30:00' }]
+        value: [{ transaction_date: '2025-01-15T10:30:00' }],
       });
       (CheckoutAPICalls.findResident as Mock).mockResolvedValue({
         value: [{ id: 5, name: 'John Doe' }],
@@ -395,7 +423,7 @@ describe('ResidentDetailDialog', () => {
         expect(CheckoutAPICalls.findResident).toHaveBeenCalledWith(
           mockUser,
           'John Doe',
-          1
+          1,
         );
       });
 
@@ -404,8 +432,8 @@ describe('ResidentDetailDialog', () => {
           expect.objectContaining({
             id: 5,
             name: 'John Doe',
-            lastVisitDate: '2025-01-15T10:30:00'
-          })
+            lastVisitDate: '2025-01-15T10:30:00',
+          }),
         );
         expect(handleShowDialog).toHaveBeenCalled();
       });
@@ -461,7 +489,7 @@ describe('ResidentDetailDialog', () => {
         expect(CheckoutAPICalls.findResident).toHaveBeenCalledWith(
           mockUser,
           'New Resident',
-          1
+          1,
         );
       });
 
@@ -469,7 +497,7 @@ describe('ResidentDetailDialog', () => {
         expect(CheckoutAPICalls.addResident).toHaveBeenCalledWith(
           mockUser,
           'New Resident',
-          1
+          1,
         );
       });
 
@@ -478,7 +506,7 @@ describe('ResidentDetailDialog', () => {
           expect.objectContaining({
             id: 10,
             name: 'New Resident',
-          })
+          }),
         );
         expect(handleShowDialog).toHaveBeenCalled();
       });
@@ -491,8 +519,8 @@ describe('ResidentDetailDialog', () => {
       });
       (CheckoutAPICalls.findResident as Mock).mockImplementation(() => {
         expect(document.body.style.cursor).toBe('wait');
-        return new Promise(resolve =>
-          setTimeout(() => resolve({ value: [{ id: 5 }] }), 100)
+        return new Promise((resolve) =>
+          setTimeout(() => resolve({ value: [{ id: 5 }] }), 100),
         );
       });
 
@@ -572,7 +600,9 @@ describe('ResidentDetailDialog', () => {
       fireEvent.click(continueButton);
 
       await waitFor(() => {
-        expect(screen.getByText(/Your system appears to be offline/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/Your system appears to be offline/i),
+        ).toBeInTheDocument();
       });
     });
 
@@ -581,7 +611,9 @@ describe('ResidentDetailDialog', () => {
       (CheckoutAPICalls.getResidents as Mock).mockResolvedValue({
         value: [{ name: 'John Doe' }],
       });
-      (CheckoutAPICalls.findResident as Mock).mockRejectedValue(new Error('Server error'));
+      (CheckoutAPICalls.findResident as Mock).mockRejectedValue(
+        new Error('Server error'),
+      );
 
       renderComponent({
         ...defaultProps,
@@ -615,7 +647,9 @@ describe('ResidentDetailDialog', () => {
       fireEvent.click(continueButton);
 
       await waitFor(() => {
-        expect(screen.getByText(/An error occurred while submitting/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/An error occurred while submitting/i),
+        ).toBeInTheDocument();
       });
     });
 
@@ -625,8 +659,8 @@ describe('ResidentDetailDialog', () => {
         value: [{ name: 'John Doe' }],
       });
       (CheckoutAPICalls.findResident as Mock).mockImplementation(() => {
-        return new Promise(resolve =>
-          setTimeout(() => resolve({ value: [{ id: 5 }] }), 200)
+        return new Promise((resolve) =>
+          setTimeout(() => resolve({ value: [{ id: 5 }] }), 200),
         );
       });
 
@@ -646,7 +680,9 @@ describe('ResidentDetailDialog', () => {
       });
 
       // Select unit
-      const unitInput = screen.getByTestId('test-id-select-unit-number').querySelector('input');
+      const unitInput = screen
+        .getByTestId('test-id-select-unit-number')
+        .querySelector('input');
       if (unitInput) {
         fireEvent.change(unitInput, { target: { value: '101' } });
       }
@@ -667,8 +703,12 @@ describe('ResidentDetailDialog', () => {
       // Fields should be disabled during submission
       // Use querySelector to avoid ambiguity with autocomplete dropdowns
       await waitFor(() => {
-        const buildingInputElement = screen.getByTestId('test-id-select-building').querySelector('input');
-        const unitInputElement = screen.getByTestId('test-id-select-unit-number').querySelector('input');
+        const buildingInputElement = screen
+          .getByTestId('test-id-select-building')
+          .querySelector('input');
+        const unitInputElement = screen
+          .getByTestId('test-id-select-unit-number')
+          .querySelector('input');
         const residentInputElement = screen.getByLabelText('Resident Name');
 
         expect(buildingInputElement).toBeDisabled();
@@ -680,7 +720,9 @@ describe('ResidentDetailDialog', () => {
 
     test('clears API error when starting new submission', async () => {
       // First, cause an error by selecting a building
-      (CheckoutAPICalls.getUnitNumbers as Mock).mockRejectedValue(new TypeError('Failed to fetch'));
+      (CheckoutAPICalls.getUnitNumbers as Mock).mockRejectedValue(
+        new TypeError('Failed to fetch'),
+      );
 
       renderComponent();
 
@@ -691,12 +733,16 @@ describe('ResidentDetailDialog', () => {
       fireEvent.click(buildingOption);
 
       await waitFor(() => {
-        expect(screen.getByText(/Unable to load unit numbers/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/Unable to load unit numbers/i),
+        ).toBeInTheDocument();
       });
 
       // Now set up the form with complete data and mock successful API calls
       (CheckoutAPICalls.getResidents as Mock).mockResolvedValue({ value: [] });
-      (CheckoutAPICalls.findResident as Mock).mockResolvedValue({ value: [{ id: 5 }] });
+      (CheckoutAPICalls.findResident as Mock).mockResolvedValue({
+        value: [{ id: 5 }],
+      });
 
       // Manually fill in the rest of the form
       const unitInput = screen.getByLabelText('Unit Number');
@@ -712,13 +758,15 @@ describe('ResidentDetailDialog', () => {
       // The old error should disappear once we start the submission
       // (even though submission will fail due to validation)
       await waitFor(() => {
-        expect(screen.queryByText(/Unable to load unit numbers/i)).not.toBeInTheDocument();
+        expect(
+          screen.queryByText(/Unable to load unit numbers/i),
+        ).not.toBeInTheDocument();
       });
     });
   });
 
   describe('Unit Helper Text', () => {
-    test('shows "Not a valid unit" when invalid unit is entered', async () => {
+    test('shows "Please select a unit from the list" when invalid unit is entered', async () => {
       const propsWithUnits = {
         ...defaultProps,
         unitNumberValues: mockUnits,
@@ -734,7 +782,9 @@ describe('ResidentDetailDialog', () => {
       fireEvent.click(continueButton);
 
       await waitFor(() => {
-        expect(screen.getByText(/Not a valid unit/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/Please select a unit from the list/i),
+        ).toBeInTheDocument();
       });
     });
   });
@@ -744,13 +794,17 @@ describe('ResidentDetailDialog', () => {
       const mockResidentsWithIds = {
         value: [
           { id: 1, name: 'John Doe' },
-          { id: 2, name: 'Jane Smith' }
-        ]
+          { id: 2, name: 'Jane Smith' },
+        ],
       };
 
-      (CheckoutAPICalls.getResidents as Mock).mockResolvedValue(mockResidentsWithIds);
+      (CheckoutAPICalls.getResidents as Mock).mockResolvedValue(
+        mockResidentsWithIds,
+      );
       (CheckoutAPICalls.getLastResidentVisit as Mock)
-        .mockResolvedValueOnce({ value: [{ transaction_date: '2025-01-15T10:30:00' }] })
+        .mockResolvedValueOnce({
+          value: [{ transaction_date: '2025-01-15T10:30:00' }],
+        })
         .mockResolvedValueOnce({ value: [] });
 
       const propsWithUnits = {
@@ -764,8 +818,14 @@ describe('ResidentDetailDialog', () => {
       fireEvent.change(unitInput, { target: { value: '101' } });
 
       await waitFor(() => {
-        expect(CheckoutAPICalls.getLastResidentVisit).toHaveBeenCalledWith(mockUser, 1);
-        expect(CheckoutAPICalls.getLastResidentVisit).toHaveBeenCalledWith(mockUser, 2);
+        expect(CheckoutAPICalls.getLastResidentVisit).toHaveBeenCalledWith(
+          mockUser,
+          1,
+        );
+        expect(CheckoutAPICalls.getLastResidentVisit).toHaveBeenCalledWith(
+          mockUser,
+          2,
+        );
       });
     });
 
@@ -773,13 +833,17 @@ describe('ResidentDetailDialog', () => {
       const mockResidentsWithIds = {
         value: [
           { id: 1, name: 'John Doe' },
-          { id: 2, name: 'Jane Smith' }
-        ]
+          { id: 2, name: 'Jane Smith' },
+        ],
       };
 
-      (CheckoutAPICalls.getResidents as Mock).mockResolvedValue(mockResidentsWithIds);
+      (CheckoutAPICalls.getResidents as Mock).mockResolvedValue(
+        mockResidentsWithIds,
+      );
       (CheckoutAPICalls.getLastResidentVisit as Mock)
-        .mockResolvedValueOnce({ value: [{ transaction_date: '2025-01-15T10:30:00' }] })
+        .mockResolvedValueOnce({
+          value: [{ transaction_date: '2025-01-15T10:30:00' }],
+        })
         .mockResolvedValueOnce({ value: [] });
 
       const propsWithUnits = {
@@ -801,19 +865,25 @@ describe('ResidentDetailDialog', () => {
       fireEvent.mouseDown(nameInput);
 
       await waitFor(() => {
-        expect(screen.getByText(/John Doe - Last visit: 1\/15\/2025/i)).toBeInTheDocument();
-        expect(screen.getByText(/Jane Smith - Last visit: No previous visits/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/John Doe - Last visit: 1\/15\/2025/i),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(/Jane Smith - Last visit: No previous visits/i),
+        ).toBeInTheDocument();
       });
     });
 
     test('displays last visit date below resident name field when resident selected', async () => {
       const mockResidentsWithIds = {
-        value: [{ id: 1, name: 'John Doe' }]
+        value: [{ id: 1, name: 'John Doe' }],
       };
 
-      (CheckoutAPICalls.getResidents as Mock).mockResolvedValue(mockResidentsWithIds);
+      (CheckoutAPICalls.getResidents as Mock).mockResolvedValue(
+        mockResidentsWithIds,
+      );
       (CheckoutAPICalls.getLastResidentVisit as Mock).mockResolvedValue({
-        value: [{ transaction_date: '2025-01-15T10:30:00' }]
+        value: [{ transaction_date: '2025-01-15T10:30:00' }],
       });
 
       const propsWithUnits = {
@@ -827,17 +897,23 @@ describe('ResidentDetailDialog', () => {
       fireEvent.change(unitInput, { target: { value: '101' } });
 
       await waitFor(() => {
-        expect(screen.getByText(/last visit: 1\/15\/2025/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/last visit: 1\/15\/2025/i),
+        ).toBeInTheDocument();
       });
     });
 
     test('displays "none" when resident has no previous visits', async () => {
       const mockResidentsWithIds = {
-        value: [{ id: 1, name: 'John Doe' }]
+        value: [{ id: 1, name: 'John Doe' }],
       };
 
-      (CheckoutAPICalls.getResidents as Mock).mockResolvedValue(mockResidentsWithIds);
-      (CheckoutAPICalls.getLastResidentVisit as Mock).mockResolvedValue({ value: [] });
+      (CheckoutAPICalls.getResidents as Mock).mockResolvedValue(
+        mockResidentsWithIds,
+      );
+      (CheckoutAPICalls.getLastResidentVisit as Mock).mockResolvedValue({
+        value: [],
+      });
 
       const propsWithUnits = {
         ...defaultProps,
@@ -858,14 +934,20 @@ describe('ResidentDetailDialog', () => {
       const mockResidentsWithIds = {
         value: [
           { id: 1, name: 'John Doe' },
-          { id: 2, name: 'Jane Smith' }
-        ]
+          { id: 2, name: 'Jane Smith' },
+        ],
       };
 
-      (CheckoutAPICalls.getResidents as Mock).mockResolvedValue(mockResidentsWithIds);
+      (CheckoutAPICalls.getResidents as Mock).mockResolvedValue(
+        mockResidentsWithIds,
+      );
       (CheckoutAPICalls.getLastResidentVisit as Mock)
-        .mockResolvedValueOnce({ value: [{ transaction_date: '2025-01-15T10:30:00' }] })
-        .mockResolvedValueOnce({ value: [{ transaction_date: '2025-02-01T14:20:00' }] });
+        .mockResolvedValueOnce({
+          value: [{ transaction_date: '2025-01-15T10:30:00' }],
+        })
+        .mockResolvedValueOnce({
+          value: [{ transaction_date: '2025-02-01T14:20:00' }],
+        });
 
       const propsWithUnits = {
         ...defaultProps,
@@ -895,18 +977,22 @@ describe('ResidentDetailDialog', () => {
 
       // Should now show John's date
       await waitFor(() => {
-        expect(screen.getByText(/last visit: 1\/15\/2025/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/last visit: 1\/15\/2025/i),
+        ).toBeInTheDocument();
       });
     });
 
     test('clears last visit date when new resident name is entered via autocomplete', async () => {
       const mockResidentsWithIds = {
-        value: [{ id: 1, name: 'John Doe' }]
+        value: [{ id: 1, name: 'John Doe' }],
       };
 
-      (CheckoutAPICalls.getResidents as Mock).mockResolvedValue(mockResidentsWithIds);
+      (CheckoutAPICalls.getResidents as Mock).mockResolvedValue(
+        mockResidentsWithIds,
+      );
       (CheckoutAPICalls.getLastResidentVisit as Mock).mockResolvedValue({
-        value: [{ transaction_date: '2025-01-15T10:30:00' }]
+        value: [{ transaction_date: '2025-01-15T10:30:00' }],
       });
 
       const propsWithUnits = {
@@ -920,29 +1006,39 @@ describe('ResidentDetailDialog', () => {
       fireEvent.change(unitInput, { target: { value: '101' } });
 
       await waitFor(() => {
-        expect(screen.getByText(/last visit: 1\/15\/2025/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/last visit: 1\/15\/2025/i),
+        ).toBeInTheDocument();
       });
 
       // Clear the autocomplete by clicking the clear button
       const nameInput = screen.getByLabelText('Resident Name');
       const autocomplete = nameInput.closest('.MuiAutocomplete-root');
-      const clearButton = autocomplete?.querySelector('.MuiAutocomplete-clearIndicator');
+      const clearButton = autocomplete?.querySelector(
+        '.MuiAutocomplete-clearIndicator',
+      );
 
       expect(clearButton).toBeTruthy();
       fireEvent.click(clearButton!);
 
       await waitFor(() => {
-        expect(screen.queryByText(/last visit: 1\/15\/2025/i)).not.toBeInTheDocument();
+        expect(
+          screen.queryByText(/last visit: 1\/15\/2025/i),
+        ).not.toBeInTheDocument();
       });
     });
 
     test('continues gracefully when last visit fetch fails', async () => {
       const mockResidentsWithIds = {
-        value: [{ id: 1, name: 'John Doe' }]
+        value: [{ id: 1, name: 'John Doe' }],
       };
 
-      (CheckoutAPICalls.getResidents as Mock).mockResolvedValue(mockResidentsWithIds);
-      (CheckoutAPICalls.getLastResidentVisit as Mock).mockRejectedValue(new Error('Network error'));
+      (CheckoutAPICalls.getResidents as Mock).mockResolvedValue(
+        mockResidentsWithIds,
+      );
+      (CheckoutAPICalls.getLastResidentVisit as Mock).mockRejectedValue(
+        new Error('Network error'),
+      );
 
       const propsWithUnits = {
         ...defaultProps,
@@ -962,13 +1058,15 @@ describe('ResidentDetailDialog', () => {
 
     test('passes lastVisitDate to parent when submitting with existing resident', async () => {
       const mockResidentsWithIds = {
-        value: [{ id: 1, name: 'John Doe' }]
+        value: [{ id: 1, name: 'John Doe' }],
       };
 
       (CheckoutAPICalls.getUnitNumbers as Mock).mockResolvedValue(mockUnits);
-      (CheckoutAPICalls.getResidents as Mock).mockResolvedValue(mockResidentsWithIds);
+      (CheckoutAPICalls.getResidents as Mock).mockResolvedValue(
+        mockResidentsWithIds,
+      );
       (CheckoutAPICalls.getLastResidentVisit as Mock).mockResolvedValue({
-        value: [{ transaction_date: '2025-01-15T10:30:00' }]
+        value: [{ transaction_date: '2025-01-15T10:30:00' }],
       });
       (CheckoutAPICalls.findResident as Mock).mockResolvedValue({
         value: [{ id: 5, name: 'John Doe' }],
@@ -1015,8 +1113,8 @@ describe('ResidentDetailDialog', () => {
           expect.objectContaining({
             id: 5,
             name: 'John Doe',
-            lastVisitDate: '2025-01-15T10:30:00'
-          })
+            lastVisitDate: '2025-01-15T10:30:00',
+          }),
         );
         expect(handleShowDialog).toHaveBeenCalled();
       });
@@ -1071,8 +1169,8 @@ describe('ResidentDetailDialog', () => {
           expect.objectContaining({
             id: 10,
             name: 'New Resident',
-            lastVisitDate: null
-          })
+            lastVisitDate: null,
+          }),
         );
         expect(handleShowDialog).toHaveBeenCalled();
       });

--- a/src/components/Checkout/ResidentDetailDialog.tsx
+++ b/src/components/Checkout/ResidentDetailDialog.tsx
@@ -6,6 +6,7 @@ import {
   ResidentInfo,
   Unit,
   ResidentNameOption,
+  ResidentFormError,
 } from '../../types/interfaces';
 import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
 import DialogTemplate from '../DialogTemplate';
@@ -38,7 +39,11 @@ const ResidentDetailDialog = ({
     residentInfo.building,
   );
   const [selectedUnit, setSelectedUnit] = useState<Unit>(residentInfo.unit);
-  const [showError, setShowError] = useState<boolean>(false);
+  const [formError, setFormError] = useState<ResidentFormError>({
+    buildingError: false,
+    unitError: false,
+    nameError: false,
+  });
 
   const residentNameFilter = createFilterOptions<ResidentNameOption>({
     matchFrom: 'start',
@@ -99,8 +104,7 @@ const ResidentDetailDialog = ({
       residentsHook.nameInput,
       selectedBuilding,
       selectedUnit,
-      showError,
-      setShowError,
+      setFormError,
       residentsHook.currentLastVisitDate,
     );
   }
@@ -129,7 +133,14 @@ const ResidentDetailDialog = ({
             setSelectedBuilding={setSelectedBuilding}
             setSelectedUnit={setSelectedUnit}
             fetchUnitNumbers={fetchUnitNumbers}
-            error={showError && !selectedBuilding.id}
+            error={formError.buildingError}
+            resetError={() =>
+              setFormError({
+                buildingError: false,
+                unitError: false,
+                nameError: false,
+              })
+            }
             disabled={isWaiting}
           />
         </FormControl>
@@ -153,7 +164,11 @@ const ResidentDetailDialog = ({
               );
               if (matchingUnit) {
                 setSelectedUnit(matchingUnit);
-                setShowError(false);
+                setFormError({
+                  ...formError,
+                  unitError: false,
+                  nameError: false,
+                });
               } else {
                 setSelectedUnit({ id: 0, unit_number: newValue });
               }
@@ -163,22 +178,17 @@ const ResidentDetailDialog = ({
               return `${option.unit_number}`;
             }}
             renderInput={(params) => {
-              const getHelperText = () => {
-                if (!showError) return '';
-                if (selectedUnit.id === 0 && selectedUnit.unit_number)
-                  return 'Not a valid unit';
-                if (selectedUnit.id === 0)
-                  return 'Please select a unit from the list';
-                return '';
-              };
-
               return (
                 <TextField
                   {...params}
                   id={selectedUnit.unit_number}
                   label="Unit Number"
-                  error={showError}
-                  helperText={getHelperText()}
+                  error={formError.unitError}
+                  helperText={
+                    formError.unitError
+                      ? 'Please select a unit from the list'
+                      : ''
+                  }
                 />
               );
             }}
@@ -191,6 +201,9 @@ const ResidentDetailDialog = ({
             value={residentsHook.nameInput}
             disabled={isWaiting}
             onChange={(_event, newValue) => {
+              if (formError.nameError) {
+                setFormError({ ...formError, nameError: false });
+              }
               if (typeof newValue === 'string') {
                 residentsHook.setNameInput(newValue);
                 residentsHook.setCurrentLastVisitDate(null);
@@ -214,6 +227,9 @@ const ResidentDetailDialog = ({
               }
             }}
             onInputChange={(_event, newInputValue, reason) => {
+              if (formError.nameError) {
+                setFormError({ ...formError, nameError: false });
+              }
               if (reason === 'input') {
                 residentsHook.setNameInput(newInputValue);
                 residentsHook.setCurrentLastVisitDate(null);
@@ -251,10 +267,10 @@ const ResidentDetailDialog = ({
               <TextField
                 {...params}
                 label="Resident Name"
-                error={showError && !residentsHook.nameInput}
+                error={formError.nameError}
                 helperText={
-                  showError && !residentsHook.nameInput
-                    ? "Please enter the resident's name"
+                  formError.nameError
+                    ? 'Please enter the name of the resident'
                     : ''
                 }
               />

--- a/src/components/Checkout/WelcomeBasketBuildingDialog.test.tsx
+++ b/src/components/Checkout/WelcomeBasketBuildingDialog.test.tsx
@@ -18,7 +18,7 @@ describe('WelcomeBasketBuildingDialog', () => {
     id: 1,
     userDetails: 'Test User',
     userRoles: ['volunteer'],
-    userID: 'testuser'
+    userID: 'testuser',
   };
 
   const mockUserContext = {
@@ -42,10 +42,7 @@ describe('WelcomeBasketBuildingDialog', () => {
   ];
 
   const mockAdminResidents = {
-    value: [
-      { id: 100, name: 'admin' },
-      { name: 'Other Resident' },
-    ],
+    value: [{ id: 100, name: 'admin' }, { name: 'Other Resident' }],
   };
 
   const defaultProps = {
@@ -64,20 +61,24 @@ describe('WelcomeBasketBuildingDialog', () => {
     return render(
       <UserContext.Provider value={mockUserContext}>
         <WelcomeBasketBuildingDialog {...defaultProps} {...props} />
-      </UserContext.Provider>
+      </UserContext.Provider>,
     );
   };
 
   describe('Rendering', () => {
     test('renders dialog when showDialog is true', () => {
       renderComponent();
-      expect(screen.getByText('provide building code to continue')).toBeInTheDocument();
+      expect(
+        screen.getByText('provide building code to continue'),
+      ).toBeInTheDocument();
       expect(screen.getByLabelText('Building Code')).toBeInTheDocument();
     });
 
     test('does not render dialog when showDialog is false', () => {
       renderComponent({ showDialog: false });
-      expect(screen.queryByText('provide building code to continue')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('provide building code to continue'),
+      ).not.toBeInTheDocument();
     });
 
     test('only shows Building Code field', () => {
@@ -89,7 +90,9 @@ describe('WelcomeBasketBuildingDialog', () => {
 
     test('renders continue button', () => {
       renderComponent();
-      expect(screen.getByRole('button', { name: /continue/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /continue/i }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -113,7 +116,9 @@ describe('WelcomeBasketBuildingDialog', () => {
       fireEvent.click(continueButton);
 
       await waitFor(() => {
-        expect(screen.getByText(/Please select a building/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/Please select the building code/i),
+        ).toBeInTheDocument();
       });
     });
   });
@@ -128,7 +133,9 @@ describe('WelcomeBasketBuildingDialog', () => {
 
       getUnitNumbersMock.mockResolvedValue(mockWelcomeUnits);
       getResidentsMock.mockResolvedValue(mockAdminResidents);
-      findResidentMock.mockResolvedValue({ value: [{ id: 100, name: 'admin' }] });
+      findResidentMock.mockResolvedValue({
+        value: [{ id: 100, name: 'admin' }],
+      });
 
       renderComponent({
         handleShowDialog,
@@ -137,7 +144,9 @@ describe('WelcomeBasketBuildingDialog', () => {
 
       const buildingSelect = screen.getByLabelText('Building Code');
       fireEvent.mouseDown(buildingSelect);
-      const buildingOption = await screen.findByRole('option', { name: /A \(Building A\)/i });
+      const buildingOption = await screen.findByRole('option', {
+        name: /A \(Building A\)/i,
+      });
       fireEvent.click(buildingOption);
 
       const continueButton = screen.getByRole('button', { name: /continue/i });
@@ -168,9 +177,13 @@ describe('WelcomeBasketBuildingDialog', () => {
       const addResidentMock = CheckoutAPICalls.addResident as Mock;
 
       getUnitNumbersMock.mockResolvedValue(mockWelcomeUnits);
-      getResidentsMock.mockResolvedValue({ value: [{ name: 'Other Resident' }] });
+      getResidentsMock.mockResolvedValue({
+        value: [{ name: 'Other Resident' }],
+      });
       findResidentMock.mockResolvedValue({ value: [] });
-      addResidentMock.mockResolvedValue({ value: [{ id: 200, name: 'admin' }] });
+      addResidentMock.mockResolvedValue({
+        value: [{ id: 200, name: 'admin' }],
+      });
 
       renderComponent({
         handleShowDialog,
@@ -179,7 +192,9 @@ describe('WelcomeBasketBuildingDialog', () => {
 
       const buildingSelect = screen.getByLabelText('Building Code');
       fireEvent.mouseDown(buildingSelect);
-      const buildingOption = await screen.findByRole('option', { name: /A \(Building A\)/i });
+      const buildingOption = await screen.findByRole('option', {
+        name: /A \(Building A\)/i,
+      });
       fireEvent.click(buildingOption);
 
       const continueButton = screen.getByRole('button', { name: /continue/i });
@@ -210,8 +225,12 @@ describe('WelcomeBasketBuildingDialog', () => {
       const addResidentMock = CheckoutAPICalls.addResident as Mock;
 
       getUnitNumbersMock.mockResolvedValue(mockWelcomeUnits);
-      getResidentsMock.mockResolvedValue({ value: [{ name: 'Other Resident' }] });
-      findResidentMock.mockResolvedValue({ value: [{ id: 150, name: 'admin' }] });
+      getResidentsMock.mockResolvedValue({
+        value: [{ name: 'Other Resident' }],
+      });
+      findResidentMock.mockResolvedValue({
+        value: [{ id: 150, name: 'admin' }],
+      });
 
       renderComponent({
         handleShowDialog,
@@ -220,7 +239,9 @@ describe('WelcomeBasketBuildingDialog', () => {
 
       const buildingSelect = screen.getByLabelText('Building Code');
       fireEvent.mouseDown(buildingSelect);
-      const buildingOption = await screen.findByRole('option', { name: /A \(Building A\)/i });
+      const buildingOption = await screen.findByRole('option', {
+        name: /A \(Building A\)/i,
+      });
       fireEvent.click(buildingOption);
 
       const continueButton = screen.getByRole('button', { name: /continue/i });
@@ -255,14 +276,18 @@ describe('WelcomeBasketBuildingDialog', () => {
 
       const buildingSelect = screen.getByLabelText('Building Code');
       fireEvent.mouseDown(buildingSelect);
-      const buildingOption = await screen.findByRole('option', { name: /A \(Building A\)/i });
+      const buildingOption = await screen.findByRole('option', {
+        name: /A \(Building A\)/i,
+      });
       fireEvent.click(buildingOption);
 
       const continueButton = screen.getByRole('button', { name: /continue/i });
       fireEvent.click(continueButton);
 
       await waitFor(() => {
-        expect(screen.getByText(/No welcome unit found for this building/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/No welcome unit found for this building/i),
+        ).toBeInTheDocument();
       });
     });
 
@@ -283,7 +308,9 @@ describe('WelcomeBasketBuildingDialog', () => {
 
       const buildingSelect = screen.getByLabelText('Building Code');
       fireEvent.mouseDown(buildingSelect);
-      const buildingOption = await screen.findByRole('option', { name: /A \(Building A\)/i });
+      const buildingOption = await screen.findByRole('option', {
+        name: /A \(Building A\)/i,
+      });
       fireEvent.click(buildingOption);
 
       const continueButton = screen.getByRole('button', { name: /continue/i });
@@ -308,7 +335,9 @@ describe('WelcomeBasketBuildingDialog', () => {
 
       const buildingSelect = screen.getByLabelText('Building Code');
       fireEvent.mouseDown(buildingSelect);
-      const buildingOption = await screen.findByRole('option', { name: /A \(Building A\)/i });
+      const buildingOption = await screen.findByRole('option', {
+        name: /A \(Building A\)/i,
+      });
       fireEvent.click(buildingOption);
 
       const continueButton = screen.getByRole('button', { name: /continue/i });
@@ -331,7 +360,9 @@ describe('WelcomeBasketBuildingDialog', () => {
 
       const buildingSelect = screen.getByLabelText('Building Code');
       fireEvent.mouseDown(buildingSelect);
-      const buildingOption = await screen.findByRole('option', { name: /A \(Building A\)/i });
+      const buildingOption = await screen.findByRole('option', {
+        name: /A \(Building A\)/i,
+      });
       fireEvent.click(buildingOption);
 
       const continueButton = screen.getByRole('button', { name: /continue/i });
@@ -351,14 +382,18 @@ describe('WelcomeBasketBuildingDialog', () => {
 
       const buildingSelect = screen.getByLabelText('Building Code');
       fireEvent.mouseDown(buildingSelect);
-      const buildingOption = await screen.findByRole('option', { name: /A \(Building A\)/i });
+      const buildingOption = await screen.findByRole('option', {
+        name: /A \(Building A\)/i,
+      });
       fireEvent.click(buildingOption);
 
       const continueButton = screen.getByRole('button', { name: /continue/i });
       fireEvent.click(continueButton);
 
       await waitFor(() => {
-        expect(screen.getByText(/An error occurred while submitting/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/An error occurred while submitting/i),
+        ).toBeInTheDocument();
       });
     });
   });
@@ -370,7 +405,9 @@ describe('WelcomeBasketBuildingDialog', () => {
 
       getUnitNumbersMock.mockImplementation(() => {
         expect(document.body.style.cursor).toBe('wait');
-        return new Promise(resolve => setTimeout(() => resolve(mockWelcomeUnits), 100));
+        return new Promise((resolve) =>
+          setTimeout(() => resolve(mockWelcomeUnits), 100),
+        );
       });
       getResidentsMock.mockResolvedValue(mockAdminResidents);
 
@@ -378,7 +415,9 @@ describe('WelcomeBasketBuildingDialog', () => {
 
       const buildingSelect = screen.getByLabelText('Building Code');
       fireEvent.mouseDown(buildingSelect);
-      const buildingOption = await screen.findByRole('option', { name: /A \(Building A\)/i });
+      const buildingOption = await screen.findByRole('option', {
+        name: /A \(Building A\)/i,
+      });
       fireEvent.click(buildingOption);
 
       const continueButton = screen.getByRole('button', { name: /continue/i });
@@ -396,7 +435,9 @@ describe('WelcomeBasketBuildingDialog', () => {
 
       getUnitNumbersMock.mockResolvedValue(mockWelcomeUnits);
       getResidentsMock.mockImplementation(() => {
-        return new Promise(resolve => setTimeout(() => resolve(mockAdminResidents), 200));
+        return new Promise((resolve) =>
+          setTimeout(() => resolve(mockAdminResidents), 200),
+        );
       });
       findResidentMock.mockResolvedValue({ value: [{ id: 100 }] });
 
@@ -404,18 +445,21 @@ describe('WelcomeBasketBuildingDialog', () => {
 
       const buildingSelect = screen.getByLabelText('Building Code');
       fireEvent.mouseDown(buildingSelect);
-      const buildingOption = await screen.findByRole('option', { name: /A \(Building A\)/i });
+      const buildingOption = await screen.findByRole('option', {
+        name: /A \(Building A\)/i,
+      });
       fireEvent.click(buildingOption);
 
       const continueButton = screen.getByRole('button', { name: /continue/i });
       fireEvent.click(continueButton);
 
       await waitFor(() => {
-        const buildingInput = screen.getByTestId('test-id-select-building').querySelector('input');
+        const buildingInput = screen
+          .getByTestId('test-id-select-building')
+          .querySelector('input');
         expect(buildingInput).toBeDisabled();
         expect(continueButton).toBeDisabled();
       });
     });
   });
-
 });

--- a/src/components/Checkout/WelcomeBasketBuildingDialog.tsx
+++ b/src/components/Checkout/WelcomeBasketBuildingDialog.tsx
@@ -132,6 +132,7 @@ const WelcomeBasketBuildingDialog = ({
             setSelectedUnit={() => {}} // No-op since we don't show unit selector
             fetchUnitNumbers={async () => {}} // No-op since we handle units in submit
             error={showError && !selectedBuilding.id}
+            resetError={() => setShowError(false)}
             disabled={isSubmitting}
           />
         </FormControl>

--- a/src/components/Checkout/hooks/useResidentFormSubmit.ts
+++ b/src/components/Checkout/hooks/useResidentFormSubmit.ts
@@ -1,69 +1,100 @@
 import { useState } from 'react';
-import { Building, Unit, ResidentInfo, ClientPrincipal } from '../../../types/interfaces';
+import {
+  Building,
+  Unit,
+  ResidentInfo,
+  ClientPrincipal,
+  ResidentFormError,
+} from '../../../types/interfaces';
 import { addResident, findResident } from '../../../services/CheckoutAPICalls';
 
 export const useResidentFormSubmit = (
-    user: ClientPrincipal | null,
-    onSuccess: (residentInfo: ResidentInfo) => void
+  user: ClientPrincipal | null,
+  onSuccess: (residentInfo: ResidentInfo) => void,
 ) => {
-    const [isSubmitting, setIsSubmitting] = useState(false);
-    const [apiError, setApiError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [apiError, setApiError] = useState('');
 
-    const handleSubmit = async (
-        nameInput: string,
-        selectedBuilding: Building,
-        selectedUnit: Unit,
-        _showError: boolean,
-        setShowError: (show: boolean) => void,
-        currentLastVisitDate: string | null = null
-    ) => {
-        setApiError('');
-        if (!nameInput || !selectedBuilding.id || !selectedUnit.id) {
-            setShowError(true);
-            return false;
-        }
-        setIsSubmitting(true);
-        document.body.style.cursor = 'wait';
-        try {
-            let residentId;
-            const existingResponse = await findResident(user, nameInput, selectedUnit.id);
-            if (!existingResponse.value.length) {
-                const response = await addResident(user, nameInput, selectedUnit.id);
-                if (!response.value || response.value.length === 0) {
-                    throw new Error('Failed to create resident: API returned no data');
-                }
-                residentId = response.value[0].id;
-            } else {
-                residentId = existingResponse.value[0].id;
-            }
-
-            onSuccess({
-                id: residentId,
-                name: nameInput,
-                unit: selectedUnit,
-                building: selectedBuilding,
-                lastVisitDate: currentLastVisitDate
-            });
-            setShowError(false);
-            return true;
-        } catch (error) {
-            console.error('Error submitting resident info', error);
-            if (error instanceof TypeError && error.message === 'Failed to fetch') {
-                setApiError('Your system appears to be offline. Please check your connection and try again.');
-            } else {
-                setApiError('An error occurred while submitting. Please try again.');
-            }
-            return false;
-        } finally {
-            setIsSubmitting(false);
-            document.body.style.cursor = 'default';
-        }
+  const handleSubmit = async (
+    nameInput: string,
+    selectedBuilding: Building,
+    selectedUnit: Unit,
+    setFormError: (formErrorObject: ResidentFormError) => void,
+    currentLastVisitDate: string | null = null,
+  ) => {
+    const normalizedName = nameInput.trim();
+    const activeErrors = {
+      buildingError: false,
+      unitError: false,
+      nameError: false,
     };
+    if (!normalizedName) {
+      activeErrors.nameError = true;
+    }
+    if (!selectedBuilding.id) {
+      activeErrors.buildingError = true;
+    }
+    if (!selectedUnit.id) {
+      activeErrors.unitError = true;
+    }
+    setFormError(activeErrors);
+    if (
+      activeErrors.nameError ||
+      activeErrors.buildingError ||
+      activeErrors.unitError
+    ) {
+      return false;
+    }
+    setIsSubmitting(true);
+    document.body.style.cursor = 'wait';
+    try {
+      let residentId;
+      const existingResponse = await findResident(
+        user,
+        normalizedName,
+        selectedUnit.id,
+      );
+      if (!existingResponse.value.length) {
+        const response = await addResident(
+          user,
+          normalizedName,
+          selectedUnit.id,
+        );
+        if (!response.value || response.value.length === 0) {
+          throw new Error('Failed to create resident: API returned no data');
+        }
+        residentId = response.value[0].id;
+      } else {
+        residentId = existingResponse.value[0].id;
+      }
+      onSuccess({
+        id: residentId,
+        name: normalizedName,
+        unit: selectedUnit,
+        building: selectedBuilding,
+        lastVisitDate: currentLastVisitDate,
+      });
+      return true;
+    } catch (error) {
+      console.error('Error submitting resident info', error);
+      if (error instanceof TypeError && error.message === 'Failed to fetch') {
+        setApiError(
+          'Your system appears to be offline. Please check your connection and try again.',
+        );
+      } else {
+        setApiError('An error occurred while submitting. Please try again.');
+      }
+      return false;
+    } finally {
+      setIsSubmitting(false);
+      document.body.style.cursor = 'default';
+    }
+  };
 
-    return {
-        isSubmitting,
-        apiError,
-        setApiError,
-        handleSubmit
-    };
+  return {
+    isSubmitting,
+    apiError,
+    setApiError,
+    handleSubmit,
+  };
 };

--- a/src/components/inventory/AddItemModal.tsx
+++ b/src/components/inventory/AddItemModal.tsx
@@ -218,16 +218,16 @@ const AddItemModal = ({
       {/* Item Type */}
       {!inventoryType && (
         <Box id="add-item-type" sx={{ width: '100%' }}>
-        <Typography fontWeight="bold">Inventory Type</Typography>
-        <Select
-          value={formData.type}
-          onChange={(e) => handleInputChange('type', e.target.value)}
-          sx={{ width: '100%' }}
-        >
-          <MenuItem value={'General'}>General</MenuItem>
-          <MenuItem value={'Welcome Basket'}>Welcome Basket</MenuItem>
-        </Select>
-      </Box>
+          <Typography fontWeight="bold">Inventory Type</Typography>
+          <Select
+            value={formData.type}
+            onChange={(e) => handleInputChange('type', e.target.value)}
+            sx={{ width: '100%' }}
+          >
+            <MenuItem value={'General'}>General</MenuItem>
+            <MenuItem value={'Welcome Basket'}>Welcome Basket</MenuItem>
+          </Select>
+        </Box>
       )}
 
       {/* Item Name */}
@@ -273,8 +273,16 @@ const AddItemModal = ({
         />
       </Box>
 
+      {updateItem && (
+        <Box id="current-value">
+          <Typography>
+            Current Quantity of this Item: {updateItem.quantity}
+          </Typography>
+        </Box>
+      )}
+
       <Box id="add-item-quantity">
-        <Typography fontWeight="bold">Quantity</Typography>
+        <Typography fontWeight="bold">Quantity To Add/Remove</Typography>
         <Box
           sx={{
             display: 'flex',

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -472,7 +472,7 @@ const CheckoutPage: React.FC<CheckoutPageProps> = ({ checkoutType = 'general' })
                 : `${residentInfo.building.code} - ${residentInfo.unit.unit_number} - ${residentInfo.name} (last visit: ${residentInfo.lastVisitDate ? new Date(residentInfo.lastVisitDate).toLocaleDateString() : 'none'})`}
           </Button>
           <SearchBar
-            data={data}
+            data={checkoutType === 'general' ? filteredData : data}
             setSearchData={setSearchData}
             setSearchActive={setSearchActive}
           />

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -471,11 +471,14 @@ const CheckoutPage: React.FC<CheckoutPageProps> = ({ checkoutType = 'general' })
                 ? `${residentInfo.building.code}`
                 : `${residentInfo.building.code} - ${residentInfo.unit.unit_number} - ${residentInfo.name} (last visit: ${residentInfo.lastVisitDate ? new Date(residentInfo.lastVisitDate).toLocaleDateString() : 'none'})`}
           </Button>
-          <SearchBar
-            data={checkoutType === 'general' ? filteredData : data}
-            setSearchData={setSearchData}
-            setSearchActive={setSearchActive}
-          />
+          {/* Search is only shown for general checkout — Welcome Basket only has two items */}
+          {checkoutType === 'general' && (
+            <SearchBar
+              data={filteredData}
+              setSearchData={setSearchData}
+              setSearchActive={setSearchActive}
+            />
+          )}
         </Box>
         {!searchActive && checkoutType === 'general' && (
           <Navbar

--- a/src/pages/inventory/index.tsx
+++ b/src/pages/inventory/index.tsx
@@ -1,4 +1,10 @@
-import React, { useContext, useState, useEffect, useCallback, useRef } from 'react';
+import React, {
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+} from 'react';
 import { Alert, Box, Button, Pagination } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import AddItemModal from '../../components/inventory/AddItemModal.tsx';
@@ -8,7 +14,7 @@ import InventoryTable from '../../components/inventory/InventoryTable';
 import { UserContext } from '../../components/contexts/UserContext';
 import { getRole } from '../../utils/userUtils';
 import { CategoryItem, InventoryItem } from '../../types/interfaces.ts';
-import { ENDPOINTS, API_HEADERS, SETTINGS } from "../../types/constants";
+import { ENDPOINTS, API_HEADERS, SETTINGS } from '../../types/constants';
 import SnackbarAlert from '../../components/SnackbarAlert';
 import { useLocation } from 'react-router-dom';
 
@@ -18,10 +24,12 @@ const Inventory = () => {
   const [originalData, setOriginalData] = useState<InventoryItem[]>([]);
   const [displayData, setDisplayData] = useState<InventoryItem[]>([]);
   const [categoryData, setCategoryData] = useState<CategoryItem[]>([]);
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc' | 'original'>('original');
+  const [sortDirection, setSortDirection] = useState<
+    'asc' | 'desc' | 'original'
+  >('original');
   const [addModal, setAddModal] = useState(false);
   const [adjustModal, setAdjustModal] = useState(false);
-  const [itemToEdit, setItemToEdit] = useState<InventoryItem | null>(null)
+  const [itemToEdit, setItemToEdit] = useState<InventoryItem | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [filters, setFilters] = useState({
     type: '',
@@ -40,10 +48,11 @@ const Inventory = () => {
     open: boolean;
     message: string;
     severity: 'success' | 'warning';
-  }>({ 
-    open: location.state && location.state.message, 
-    message: location.state ? location.state.message : '', 
-    severity: 'success' });
+  }>({
+    open: location.state && location.state.message,
+    message: location.state ? location.state.message : '',
+    severity: 'success',
+  });
   const [itemsPerPage, setItemsPerPage] = useState(SETTINGS.itemsPerPage);
   const tableContainerRef = useRef<HTMLElement | null>(null);
   const [showResults, setShowResults] = useState(false);
@@ -54,12 +63,13 @@ const Inventory = () => {
 
   const calculateItemsPerPage = () => {
     if (tableContainerRef.current) {
-      const parentHeight = tableContainerRef.current?.parentElement?.clientHeight ?? 0; // Calculates the parent container height in px
+      const parentHeight =
+        tableContainerRef.current?.parentElement?.clientHeight ?? 0; // Calculates the parent container height in px
       const tableHeight = (parentHeight * 80) / 100; // Calculates the table height in px as 80% of the parent height
       const items = Math.floor(tableHeight / 64); // Within the table height, each row has a height of 64px. Sets how many items to be shown within each table
       setItemsPerPage(items > 0 ? items - 1 : 1); // Subtract 1 because of header row
     }
-  }
+  };
 
   const handleAddOpen = () => {
     setAddModal(true);
@@ -71,7 +81,10 @@ const Inventory = () => {
   };
 
   // Consolidated function for handling all filter clicks
-  const handleFilterClick = (filter: 'type' | 'category' | 'status', event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleFilterClick = (
+    filter: 'type' | 'category' | 'status',
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) => {
     setAnchors((prev) => ({ ...prev, [filter]: event.currentTarget }));
   };
 
@@ -90,7 +103,10 @@ const Inventory = () => {
   };
 
   // Consolidated function for handling all menu item clicks (type, category, status)
-  const handleMenuClick = (filter: 'type' | 'category' | 'status', value: string) => {
+  const handleMenuClick = (
+    filter: 'type' | 'category' | 'status',
+    value: string,
+  ) => {
     setFilters((prevFilters) => ({
       ...prevFilters,
       [filter]: value,
@@ -113,18 +129,16 @@ const Inventory = () => {
     }));
   };
 
-  const handlePageChange = (_event: React.ChangeEvent<unknown>, value: number) => {
+  const handlePageChange = (
+    _event: React.ChangeEvent<unknown>,
+    value: number,
+  ) => {
     setCurrentPage(value);
   };
 
-  const negativeItemCount = originalData.reduce((accumulator, currentVal: InventoryItem) => {
-    if (currentVal.quantity < 0) { 
-      return accumulator + 1;
-    } else {
-      return accumulator;
-    }
-  }, 0);
-
+  const negativeItemCount = originalData.filter(
+    (item) => item.quantity < 0,
+  ).length;
 
   const handleFilter = useCallback(() => {
     const searchFiltered = originalData.filter(
@@ -152,11 +166,11 @@ const Inventory = () => {
 
         const matchesSearch = filters.search
           ? row.name.toLowerCase().includes(lowerCaseSearch) ||
-          row.description?.toLowerCase().includes(lowerCaseSearch) ||
-          row.type.toLowerCase().includes(lowerCaseSearch) ||
-          row.category.toLowerCase().includes(lowerCaseSearch) ||
-          row.status.toLowerCase().includes(lowerCaseSearch) ||
-          row.quantity.toString().toLowerCase().includes(lowerCaseSearch)
+            row.description?.toLowerCase().includes(lowerCaseSearch) ||
+            row.type.toLowerCase().includes(lowerCaseSearch) ||
+            row.category.toLowerCase().includes(lowerCaseSearch) ||
+            row.status.toLowerCase().includes(lowerCaseSearch) ||
+            row.quantity.toString().toLowerCase().includes(lowerCaseSearch)
           : true;
 
         return matchesType && matchesCategory && matchesSearch && matchesStatus;
@@ -176,11 +190,16 @@ const Inventory = () => {
   const fetchData = useCallback(async () => {
     try {
       const headers = { ...API_HEADERS, 'X-MS-API-ROLE': getRole(user) };
-      const response = await fetch(ENDPOINTS.EXPANDED_ITEMS + `?$first=${SETTINGS.api_fetch_limit_items}`, { headers: headers, method: 'GET' });
+      const response = await fetch(
+        ENDPOINTS.EXPANDED_ITEMS + `?$first=${SETTINGS.api_fetch_limit_items}`,
+        { headers: headers, method: 'GET' },
+      );
       if (!response.ok) {
         if (response.status === 500) {
-          throw new Error('Database is likely starting up. Try again in 30 seconds.');
-        } else { 
+          throw new Error(
+            'Database is likely starting up. Try again in 30 seconds.',
+          );
+        } else {
           throw new Error(response.statusText);
         }
       }
@@ -188,8 +207,7 @@ const Inventory = () => {
       const inventoryList = data.value;
       setOriginalData(inventoryList);
       setDisplayData(inventoryList);
-    }
-    catch (error) {
+    } catch (error) {
       setError('Could not get inventory. \r\n' + error);
       console.error('Could not get inventory:', error);
     }
@@ -199,7 +217,10 @@ const Inventory = () => {
   const fetchCategories = useCallback(async () => {
     try {
       const headers = { ...API_HEADERS, 'X-MS-API-ROLE': getRole(user) };
-      const response = await fetch(ENDPOINTS.CATEGORY, { headers: headers, method: 'GET' });
+      const response = await fetch(ENDPOINTS.CATEGORY, {
+        headers: headers,
+        method: 'GET',
+      });
       if (!response.ok) {
         throw new Error(response.statusText);
       }
@@ -257,15 +278,25 @@ const Inventory = () => {
   return (
     <Box ref={tableContainerRef} sx={{ height: '100%' }}>
       {/* Negative item warning */}
-      <Box id="negative-warning-container" sx={{ display: 'flex', justifyContent: 'start', marginTop: '1rem' }}>
-        {negativeItemCount > 0 ? <Alert severity="warning">
-          {negativeItemCount} {negativeItemCount === 1 ? 'item needs' : 'items need'} review: 
-          &nbsp;{originalData.filter(i => i.quantity < 0).map(i => i.name).join(", ")}
-        </Alert> : <></>}
+      <Box
+        id="negative-warning-container"
+        sx={{ display: 'flex', justifyContent: 'start', marginTop: '1rem' }}
+      >
+        {negativeItemCount > 0 ? (
+          <Alert severity="warning">
+            {negativeItemCount}{' '}
+            {negativeItemCount === 1 ? 'item needs' : 'items need'} review.
+          </Alert>
+        ) : (
+          <></>
+        )}
       </Box>
       {/* Add button */}
       <Box id="add-container" sx={{ display: 'flex', justifyContent: 'end' }}>
-        <Button sx={{ bgcolor: '#F5F5F5', color: 'black' }} onClick={handleAddOpen}>
+        <Button
+          sx={{ bgcolor: '#F5F5F5', color: 'black' }}
+          onClick={handleAddOpen}
+        >
           <AddIcon fontSize="small" sx={{ color: 'black' }} />
           Add
         </Button>
@@ -282,7 +313,7 @@ const Inventory = () => {
 
       <AdjustQuantityModal
         showDialog={adjustModal}
-        handleClose={()=>setAdjustModal(false)}
+        handleClose={() => setAdjustModal(false)}
         fetchData={fetchData}
         itemToEdit={itemToEdit}
         handleSnackbar={setSnackbarState}
@@ -309,7 +340,9 @@ const Inventory = () => {
       />
 
       {/* Pagination */}
-      <Box sx={{ display: 'flex', justifyContent: 'center', marginTop: '15px'}}>
+      <Box
+        sx={{ display: 'flex', justifyContent: 'center', marginTop: '15px' }}
+      >
         <Pagination
           count={Math.ceil(displayData.length / itemsPerPage)}
           page={currentPage}

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -33,7 +33,11 @@ export type CategoryProps = {
 export type CheckoutCardProps = {
   item: CheckoutItemProp;
   categoryCheckout: CategoryProps;
-  addItemToCart: (item: CheckoutItemProp, quantity: number, category: string) => void;
+  addItemToCart: (
+    item: CheckoutItemProp,
+    quantity: number,
+    category: string,
+  ) => void;
   removeItemFromCart: (itemId: number, categoryName: string) => void;
   removeButton: boolean;
   disableAdd?: boolean;
@@ -46,6 +50,12 @@ export type CheckoutCardProps = {
 export type ShoppingCart = {
   user_id: string;
   items: CheckoutItemProp[];
+};
+
+export type ResidentFormError = {
+  buildingError: boolean;
+  unitError: boolean;
+  nameError: boolean;
 };
 
 // ─── Users / Auth ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

Hotfix for a live issue where Welcome Basket items were appearing in general checkout search results. Volunteers searching for items like "toilet paper" or "all purpose cleaner" would see Welcome Basket versions alongside general items. Adding one would lock the cart to Welcome Basket mode, silently preventing any general items from being added.

Also hides the search bar entirely in Welcome Basket checkout mode, since only two items (twin/full-size sheet sets) are shown there.

## Jira Ticket
- Closes: [PIT-451](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-451)

## Type of Change
**Type:** Bug fix

## Changes Made
- Pass `filteredData` (Welcome Basket excluded) to `SearchBar` instead of the full `data` list
- Hide `SearchBar` entirely when `checkoutType === 'welcomeBasket'`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have run [prettier](https://github.com/digitalaidseattle/plymouth-housing#code-formatting) on the code
- [x] I have performed a self-review of my code
- [x] I have commented my code only in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings in Chrome Dev Tools
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## QA Instructions

1. Start a **General Checkout**
2. Search for "toilet paper" — confirm only the Personal Care item appears, not the Welcome Basket version
3. Search for "all purpose cleaner" — confirm no results (it's Welcome Basket only)
4. Start a **Welcome Basket Checkout** — confirm the search bar is not visible