### PR TITLE
fix: exclude Welcome Basket items from general checkout search (hotfix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plymouth-housing",
   "private": true,
-  "version": "1.3.2",
+  "version": "1.3.3",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000",

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -472,7 +472,7 @@ const CheckoutPage: React.FC<CheckoutPageProps> = ({ checkoutType = 'general' })
                 : `${residentInfo.building.code} - ${residentInfo.unit.unit_number} - ${residentInfo.name} (last visit: ${residentInfo.lastVisitDate ? new Date(residentInfo.lastVisitDate).toLocaleDateString() : 'none'})`}
           </Button>
           <SearchBar
-            data={data}
+            data={checkoutType === 'general' ? filteredData : data}
             setSearchData={setSearchData}
             setSearchActive={setSearchActive}
           />

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -471,11 +471,14 @@ const CheckoutPage: React.FC<CheckoutPageProps> = ({ checkoutType = 'general' })
                 ? `${residentInfo.building.code}`
                 : `${residentInfo.building.code} - ${residentInfo.unit.unit_number} - ${residentInfo.name} (last visit: ${residentInfo.lastVisitDate ? new Date(residentInfo.lastVisitDate).toLocaleDateString() : 'none'})`}
           </Button>
-          <SearchBar
-            data={checkoutType === 'general' ? filteredData : data}
-            setSearchData={setSearchData}
-            setSearchActive={setSearchActive}
-          />
+          {/* Search is only shown for general checkout — Welcome Basket only has two items */}
+          {checkoutType === 'general' && (
+            <SearchBar
+              data={filteredData}
+              setSearchData={setSearchData}
+              setSearchActive={setSearchActive}
+            />
+          )}
         </Box>
         {!searchActive && checkoutType === 'general' && (
           <Navbar


### PR DESCRIPTION
## Description

Hotfix for a live issue where Welcome Basket items were appearing in general checkout search results. Volunteers searching for items like "toilet paper" or "all purpose cleaner" would see Welcome Basket versions alongside general items. Adding one would lock the cart to Welcome Basket mode, silently preventing any general items from being added.

Also hides the search bar entirely in Welcome Basket checkout mode, since only two items (twin/full-size sheet sets) are shown there.

## Jira Ticket
- Closes: [PIT-451](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-451)

## Type of Change
**Type:** Bug fix

## Changes Made
- Pass `filteredData` (Welcome Basket excluded) to `SearchBar` instead of the full `data` list
- Hide `SearchBar` entirely when `checkoutType === 'welcomeBasket'`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have run [prettier](https://github.com/digitalaidseattle/plymouth-housing#code-formatting) on the code
- [x] I have performed a self-review of my code
- [x] I have commented my code only in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings in Chrome Dev Tools
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## QA Instructions

1. Start a **General Checkout**
2. Search for "toilet paper" — confirm only the Personal Care item appears, not the Welcome Basket version
3. Search for "all purpose cleaner" — confirm no results (it's Welcome Basket only)
4. Start a **Welcome Basket Checkout** — confirm the search bar is not visible