### PR TITLE
feat: display total record count on history page (PIT-450)

### DIFF
--- a/src/pages/history/index.test.tsx
+++ b/src/pages/history/index.test.tsx
@@ -507,7 +507,7 @@ describe('HistoryPage Component', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/Showing 1 records total/i)).toBeInTheDocument();
+      expect(screen.getByText(/Showing 1 record total/i)).toBeInTheDocument();
     });
   });
 

--- a/src/pages/history/index.test.tsx
+++ b/src/pages/history/index.test.tsx
@@ -28,11 +28,7 @@ vi.mock('../../components/CircularLoader', () => ({
   default: () => <div data-testid="circular-loader">Loading...</div>,
 }));
 vi.mock('../../components/History/CustomDateDialog', () => ({
-  default: ({
-    showDialog,
-    handleShowDialog,
-    handleSetDateRange,
-  }: any) =>
+  default: ({ showDialog, handleShowDialog, handleSetDateRange }: any) =>
     showDialog && (
       <div data-testid="custom-date-dialog">
         <button
@@ -66,9 +62,7 @@ vi.mock('../../components/History/WelcomeBasketCard', () => ({
 }));
 vi.mock('../../components/History/InventoryCard', () => ({
   default: ({ inventoryTransaction }: any) => (
-    <div
-      data-testid={`inventory-card-${inventoryTransaction.transaction_id}`}
-    >
+    <div data-testid={`inventory-card-${inventoryTransaction.transaction_id}`}>
       Inventory
     </div>
   ),
@@ -501,6 +495,55 @@ describe('HistoryPage Component', () => {
     });
   });
 
+  test('displays total record count after loading', async () => {
+    vi.spyOn(HistoryAPICalls, 'getCheckoutHistory').mockResolvedValue(
+      mockCheckoutTransactions,
+    );
+
+    render(
+      <Wrapper>
+        <HistoryPage />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Showing 1 records total/i)).toBeInTheDocument();
+    });
+  });
+
+  test('displays total record count across multiple users', async () => {
+    const multiUserTransactions: CheckoutTransaction[] = [
+      ...mockCheckoutTransactions,
+      {
+        transaction_id: '2',
+        user_id: 2,
+        building_id: 1,
+        unit_number: '102',
+        resident_id: 2,
+        resident_name: 'Resident B',
+        transaction_date: new Date().toISOString(),
+        item_type: 'general',
+        total_quantity: 1,
+        welcome_basket_item_id: null,
+        welcome_basket_quantity: null,
+      },
+    ];
+
+    vi.spyOn(HistoryAPICalls, 'getCheckoutHistory').mockResolvedValue(
+      multiUserTransactions,
+    );
+
+    render(
+      <Wrapper>
+        <HistoryPage />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Showing 2 records total/i)).toBeInTheDocument();
+    });
+  });
+
   test('refetches transactions when date range changes', async () => {
     render(
       <Wrapper>
@@ -512,8 +555,8 @@ describe('HistoryPage Component', () => {
       expect(HistoryAPICalls.getCheckoutHistory).toHaveBeenCalled();
     });
 
-    const callCount = vi.mocked(HistoryAPICalls.getCheckoutHistory).mock
-      .calls.length;
+    const callCount = vi.mocked(HistoryAPICalls.getCheckoutHistory).mock.calls
+      .length;
 
     const dateSelect = screen.getByRole('combobox', { name: /Date/i });
     fireEvent.mouseDown(dateSelect);

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -162,7 +162,7 @@ const HistoryPage: React.FC = () => {
         </FormControl>
       </Stack>
 
-      <Stack direction="row" alignItems="center" gap="1.5rem">
+      <Stack>
         <Typography variant="h2" textTransform="capitalize">
           {dateRange.isCustom ? dateRangeString : dateInput}
         </Typography>
@@ -173,19 +173,22 @@ const HistoryPage: React.FC = () => {
             {dateInput !== 'this week' ? dateString : dateRangeString}
           </Typography>
         )}
+        {!isLoading && (() => {
+          const totalRecords = transactionsByUser.reduce(
+            (sum, user) => sum + user.transactions.length,
+            0,
+          );
+          return (
+            <Typography variant="body1">
+              Showing {totalRecords} {totalRecords === 1 ? 'record' : 'records'} total
+            </Typography>
+          );
+        })()}
       </Stack>
       {isLoading ? (
         <CircularLoader />
       ) : (
         <>
-          <Typography variant="body1">
-            Showing{' '}
-            {transactionsByUser.reduce(
-              (sum, user) => sum + user.transactions.length,
-              0,
-            )}{' '}
-            records total
-          </Typography>
           <TransactionsList
             transactionsByUser={transactionsByUser}
             userList={userList}

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -180,13 +180,23 @@ const HistoryPage: React.FC = () => {
       {isLoading ? (
         <CircularLoader />
       ) : (
-        <TransactionsList
-          transactionsByUser={transactionsByUser}
-          userList={userList}
-          buildings={buildings}
-          loggedInUserId={loggedInUserId}
-          historyType={historyType}
-        />
+        <>
+          <Typography variant="body1">
+            Showing{' '}
+            {transactionsByUser.reduce(
+              (sum, user) => sum + user.transactions.length,
+              0,
+            )}{' '}
+            records total
+          </Typography>
+          <TransactionsList
+            transactionsByUser={transactionsByUser}
+            userList={userList}
+            buildings={buildings}
+            loggedInUserId={loggedInUserId}
+            historyType={historyType}
+          />
+        </>
       )}
     </Stack>
   );

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -44,10 +44,7 @@ const HistoryPage: React.FC = () => {
     'checkout',
   );
 
-  const {
-    transactionsByUser,
-    isLoading: isLoadingHistory,
-  } = useHistoryData({
+  const { transactionsByUser, isLoading: isLoadingHistory } = useHistoryData({
     user,
     formattedDateRange,
     historyType,


### PR DESCRIPTION
## Description

Adds a total record count to the history page that displays below the date heading. Uses correct singular/plural grammar ("1 record" vs "2 records").

## Jira Ticket
- Closes: [PIT-450](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-450)

## Type of Change
**Type:** New feature

## Changes Made
- Display total record count on the history page, stacked vertically below the date range text
- Handle singular/plural: "Showing 1 record total" vs "Showing 2 records total"
- Add unit tests for single and multiple record counts
- Prettier formatting updates

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have run [prettier](https://github.com/digitalaidseattle/plymouth-housing#code-formatting) on the code
- [x] I have performed a self-review of my code
- [x] I have commented my code only in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings in Chrome Dev Tools
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## QA Instructions, Screenshots, Recordings

1. Navigate to the History page
2. Verify the total record count appears below the date range text
3. With 1 record, it should say "Showing 1 record total" (singular)
4. With multiple records, it should say "Showing X records total" (plural)
5. The count should update when switching date ranges or between Check out/Inventory tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added total record count display in the history page, showing the complete number of checkout transactions across all users in the interface.

* **Tests**
  * Added tests to validate total record count display after loading and when processing multiple user transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->