### PR TITLE
fix: show specific validation errors in Add Item modal (PIT-413)

### DIFF
--- a/src/components/inventory/AddItemModal.test.tsx
+++ b/src/components/inventory/AddItemModal.test.tsx
@@ -232,4 +232,32 @@ describe('AddItemModal', () => {
         expect(screen.getByText('Edit Item Quantity')).toBeInTheDocument();
         expect(screen.getByText('Inventory Type')).toBeInTheDocument();
     });
+
+    it('should show only the quantity error when quantity is 0, not the transaction ID error', async () => {
+        renderComponent();
+
+        // Select General type
+        const typeSelect = screen.getAllByRole('combobox')[0];
+        fireEvent.mouseDown(typeSelect);
+        await waitFor(() => {
+            fireEvent.click(screen.getByRole('option', { name: 'General' }));
+        });
+
+        // Select an item
+        const autocomplete = screen.getAllByRole('combobox')[1];
+        fireEvent.change(autocomplete, { target: { value: 'Item 1' } });
+        await waitFor(() => {
+            fireEvent.click(screen.getByRole('option', { name: /Item 1/ }));
+        });
+
+        // Leave quantity at 0 and submit
+        fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('"Quantity To Add/Remove" cannot be 0')).toBeInTheDocument();
+        });
+
+        // Should NOT show transaction ID error
+        expect(screen.queryByText(/Transaction ID/i)).not.toBeInTheDocument();
+    });
 });

--- a/src/components/inventory/AddItemModal.tsx
+++ b/src/components/inventory/AddItemModal.tsx
@@ -127,23 +127,23 @@ const AddItemModal = ({
   };
 
   const updateItemHandler = async () => {
-    if (
-      formData.type === '' ||
-      formData.name === '' ||
-      formData.quantity === 0 ||
-      !updateItem ||
-      !transactionId
-    ) {
-      setErrorMessage(
-        'Missing Information, Quantity cannot be 0, or Transaction ID not initialized',
-      );
+    if (formData.type === '') {
+      setErrorMessage('Please select an inventory type.');
+      return;
+    }
+    if (formData.name === '' || !updateItem) {
+      setErrorMessage('Please select an item.');
+      return;
+    }
+    if (formData.quantity === 0) {
+      setErrorMessage('"Quantity To Add/Remove" cannot be 0');
       return;
     }
     // regex test to check for only whole numbers, including negatives
     const rx = new RegExp(/^-?\d+$/);
     if (!rx.test(formData.quantity.toString())) {
       setErrorMessage('The quantity must be a non-decimal number.');
-      return false;
+      return;
     }
     if (!transactionId) {
       setErrorMessage('Transaction ID is missing. Please try again.');


### PR DESCRIPTION
## Description

Fixes a bug where setting the quantity to 0 in the Add Item modal displayed both "Quantity cannot be 0" and "Transaction ID is missing" errors simultaneously. The validation now checks each field individually and shows only the first relevant error.

## Jira Ticket
- Closes: [PIT-413](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-413)

## Type of Change
**Type:** Bug fix

## Changes Made
- Split the combined validation check into separate, ordered checks with specific error messages:
  - "Please select an inventory type."
  - "Please select an item."
  - "\"Quantity To Add/Remove\" cannot be 0"
  - "The quantity must be a non-decimal number."
  - "Transaction ID is missing. Please try again."
- Each check returns early so only one error displays at a time
- Added a test verifying that submitting with quantity 0 only shows the quantity error, not the transaction ID error

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have run [prettier](https://github.com/digitalaidseattle/plymouth-housing#code-formatting) on the code
- [x] I have performed a self-review of my code
- [x] I have commented my code only in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings in Chrome Dev Tools
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## QA Instructions, Screenshots, Recordings

1. Navigate to the Inventory page
2. Click "Add" to open the Edit Item Quantity modal
3. Select an inventory type (e.g., General)
4. Select an item (e.g., Adult Absorbent Underwear)
5. Leave quantity at 0 and click Submit
6. Verify only `"Quantity To Add/Remove" cannot be 0` error appears
7. Verify "Transaction ID is missing" does NOT appear
8. Also test submitting with no type selected — should show "Please select an inventory type."
9. Test submitting with type but no item — should show "Please select an item."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error messaging in the inventory item modal to provide more specific, user-friendly feedback. Validation errors are now shown individually for each field issue, offering clearer guidance.

* **Tests**
  * Added test case to verify quantity validation error handling displays correctly without interference from other validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->