### PR TITLE
Navami/432 add edit support to process checkout

### DIFF
--- a/database/procedures/log_transaction.sql
+++ b/database/procedures/log_transaction.sql
@@ -6,19 +6,22 @@ CREATE PROCEDURE LogTransaction
     @user_id INT,
     @transaction_type NVARCHAR(50),
     @resident_id INT,
-    @new_transaction_id UNIQUEIDENTIFIER
+    @new_transaction_id UNIQUEIDENTIFIER,
+    @parent_transaction_id UNIQUEIDENTIFIER = NULL
 AS
 BEGIN
     INSERT INTO Transactions (
         id,
         user_id,
         transaction_type,
-        resident_id
+        resident_id,
+        parent_transaction_id
     )
     VALUES (
         @new_transaction_id,
         @user_id,
         @transaction_type,
-        @resident_id
+        @resident_id,
+        @parent_transaction_id
     );
 END;

--- a/database/procedures/process_checkout.sql
+++ b/database/procedures/process_checkout.sql
@@ -6,7 +6,8 @@ CREATE PROCEDURE ProcessCheckout
     @items NVARCHAR(MAX),
     @message NVARCHAR(MAX) = NULL OUTPUT,
     @resident_id INT,
-    @new_transaction_id UNIQUEIDENTIFIER
+    @new_transaction_id UNIQUEIDENTIFIER,
+    @original_transaction_id UNIQUEIDENTIFIER = NULL
 AS
 BEGIN
     SET NOCOUNT ON;
@@ -98,7 +99,8 @@ BEGIN
         DECLARE @CurrentItemId INT
         DECLARE @CurrentQuantity INT
         DECLARE @CurrentAdditionalNotes NVARCHAR(255)
-        
+        DECLARE @transaction_type INT = CASE WHEN @original_transaction_id IS NOT NULL THEN 4 ELSE 1 END
+
         DECLARE item_cursor CURSOR FOR
         SELECT ItemId, Quantity, AdditionalNotes FROM @CartItems
 
@@ -107,9 +109,10 @@ BEGIN
 
         EXEC LogTransaction
             @user_id = @user_id,
-            @transaction_type = 1,
+            @transaction_type = @transaction_type,
             @resident_id = @resident_id,
-            @new_transaction_id = @new_transaction_id;
+            @new_transaction_id = @new_transaction_id,
+            @parent_transaction_id = @original_transaction_id;
 
         WHILE @@FETCH_STATUS = 0
         BEGIN

--- a/database/tests/test_checkout_basket.sql
+++ b/database/tests/test_checkout_basket.sql
@@ -498,6 +498,50 @@ IF @transaction_items_count <> 0
 PRINT 'Test 15 PASSED: Empty JSON array handled correctly';
 GO
 
+-- Test 16: Checkout edit sets transaction_type = 4 and parent_transaction_id
+PRINT 'Test 16: Checkout edit sets transaction_type = 4 and parent_transaction_id'
+DECLARE @original_transaction_id UNIQUEIDENTIFIER = NEWID();
+DECLARE @edit_transaction_id UNIQUEIDENTIFIER = NEWID();
+DECLARE @stored_type INT;
+DECLARE @stored_parent UNIQUEIDENTIFIER;
+
+-- Create the original transaction
+EXEC ProcessCheckout
+    @user_id = 1,
+    @resident_id = 1,
+    @new_transaction_id = @original_transaction_id,
+    @items = N'[{"id": 2, "quantity": 1}]';
+
+-- Assert: Original transaction should exist with type 1
+IF NOT EXISTS (SELECT 1 FROM Transactions WHERE id = @original_transaction_id AND transaction_type = 1)
+    THROW 50016, 'Test 16 FAILED: Original transaction not created with type 1', 1;
+
+-- Execute edit checkout referencing the original
+EXEC ProcessCheckout
+    @user_id = 1,
+    @resident_id = 1,
+    @new_transaction_id = @edit_transaction_id,
+    @items = N'[{"id": 2, "quantity": 2}]',
+    @original_transaction_id = @original_transaction_id;
+
+-- Get stored transaction_type and parent_transaction_id
+SELECT
+    @stored_type = transaction_type,
+    @stored_parent = parent_transaction_id
+FROM Transactions
+WHERE id = @edit_transaction_id;
+
+-- Assert: transaction_type should be 4 (CHECKOUT_EDIT)
+IF @stored_type <> 4
+    THROW 50016, 'Test 16 FAILED: Edit transaction should have transaction_type = 4', 1;
+
+-- Assert: parent_transaction_id should reference the original transaction
+IF @stored_parent <> @original_transaction_id
+    THROW 50016, 'Test 16 FAILED: parent_transaction_id should reference original transaction', 1;
+
+PRINT 'Test 16 PASSED: Checkout edit sets transaction_type = 4 and parent_transaction_id correctly';
+GO
+
 PRINT '';
 PRINT '========================================';
 PRINT 'ALL TESTS PASSED for ProcessCheckout';

--- a/docs/research/fix-logout.md
+++ b/docs/research/fix-logout.md
@@ -1,0 +1,94 @@
+# Fix Back-Button Login Bypass After Logout
+
+## Context
+
+After logging out, pressing the browser Back button restores the authenticated session and lets users view the app without re-authenticating. This is a known limitation of SWA's **free plan** "managed" authentication: the browser cookie is cleared on logout, but the browser's in-memory cache still holds the SPA page. On Back navigation, the cached JS bundle re-renders with the old `UserContext` state before any network request confirms the session is gone.
+
+The fix is to switch to SWA **custom authentication** (standard plan only). With custom auth, the SWA runtime maintains a **server-side session**. When `/.auth/logout` is called, that session is invalidated. Any subsequent request — including a Back-button cache restoration that makes an API call — gets a 401, which `responseOverrides` redirects to the AAD login page.
+
+Related upstream issues:
+- [How to properly make my SWA logout from a custom identity provider? · Issue #594](https://github.com/Azure/static-web-apps/issues/594)
+- [Impossible to log out with standard aad · Issue #1625](https://github.com/Azure/static-web-apps/issues/1625)
+
+---
+
+## What Changes
+
+### 1. Azure Portal (infrastructure — done during/before deployment)
+
+| Step | Where | Action |
+|------|--------|--------|
+| Upgrade plan | Azure Portal → Static Web Apps → your app → Hosting plan | Switch from Free to Standard |
+| App Registration: change platform | Azure Portal → Entra ID → App registrations → your app → Authentication | Delete the SPA platform entry, add a **Web** platform with redirect URI: `https://black-bush-0857ce61e.6.azurestaticapps.net/.auth/login/aad/callback` |
+| App Registration: create client secret | Azure Portal → Entra ID → App registrations → your app → Certificates & secrets | Create a new client secret; copy the value |
+| SWA app settings | Azure Portal → Static Web Apps → your app → Configuration | Add two app settings: `AZURE_CLIENT_ID` = App Registration Application (client) ID; `AZURE_CLIENT_SECRET` = the secret value from the step above |
+
+> **Note on Tenant ID**: The tenant ID (a GUID) belongs in the config file. It is **not** a secret — it is embedded publicly in every OAuth URL and JWT token the app issues. It can safely be committed to source control.
+
+---
+
+### 2. Code Change: `staticwebapp.config.json`
+
+**File**: [staticwebapp.config.json](../../staticwebapp.config.json)
+
+Add an `auth` block and a `Cache-Control: no-store` global header. The existing `routes` and `responseOverrides` sections remain unchanged.
+
+```json
+{
+  "auth": {
+    "identityProviders": {
+      "azureActiveDirectory": {
+        "registration": {
+          "openIdIssuer": "https://login.microsoftonline.com/<TENANT_ID>/v2.0",
+          "clientIdSettingName": "AZURE_CLIENT_ID",
+          "clientSecretSettingName": "AZURE_CLIENT_SECRET"
+        }
+      }
+    }
+  },
+  "globalHeaders": {
+    "Cache-Control": "no-store"
+  },
+  "navigationFallback": {
+    "rewrite": "/index.html"
+  },
+  "routes": [
+    { "route": "/login.html", "allowedRoles": ["anonymous"] },
+    { "route": "/logout.html", "allowedRoles": ["anonymous"] },
+    { "route": "/favicon.ico", "allowedRoles": ["anonymous"] },
+    { "route": "/*", "allowedRoles": ["authenticated"] }
+  ],
+  "responseOverrides": {
+    "401": {
+      "statusCode": 302,
+      "redirect": "/.auth/login/aad"
+    }
+  }
+}
+```
+
+Replace `<TENANT_ID>` with the Plymouth Housing Entra directory GUID before committing.
+
+**Why `Cache-Control: no-store`?**
+Defense in depth. The custom auth server-side session is the primary fix. `no-store` adds a second layer: it prevents the browser from caching the authenticated SPA response at all, so Back button triggers a fresh network request that is immediately rejected if the session is gone.
+
+---
+
+### 3. No other code changes needed
+
+- `src/layout/MainLayout/Header/HeaderContent/Profile/index.tsx` — `handleLogout` already calls `/.auth/logout?post_logout_redirect_uri=/login.html` ✓
+- `src/hooks/useAuthorization.ts` — already calls `/.auth/logout` for role violations ✓
+- `src/pages/RootRedirect.tsx` — already handles unauthenticated redirects ✓
+- `public/login.html` — already has the correct `/.auth/login/aad` link ✓
+- GitHub workflows — no changes needed; Azure app settings are configured in Portal ✓
+
+---
+
+## Verification
+
+1. Deploy the updated `staticwebapp.config.json` to staging
+2. Confirm the Azure Portal infrastructure steps above are complete for the staging environment
+3. Log in → use the app → click Logout
+4. The app should redirect to `login.html`
+5. Press browser Back button → should NOT show the app; should redirect to AAD login (or show login.html)
+6. Verify both `admin` and `volunteer` roles still function normally after re-authenticating

--- a/docs/research/service_layer.md
+++ b/docs/research/service_layer.md
@@ -1,0 +1,96 @@
+# Service Layer for API Calls
+
+## Objective
+
+API calls (`fetch`) are scattered across components, modals, and pages throughout the codebase.
+This makes it hard to maintain consistent error handling, retry logic, and auth headers, and means
+changes to endpoints or request structure require hunting across many files.
+
+The goal is to consolidate all `fetch` calls into a dedicated service layer under `src/services/`,
+one file per domain.
+
+## Approach
+
+### Current state
+
+The following files currently call `fetch` directly:
+
+| File | What it calls |
+|---|---|
+| `src/services/CheckoutAPICalls.ts` | Checkout, residents, buildings |
+| `src/components/History/HistoryAPICalls.ts` | Transaction history |
+| `src/components/utils/fetchCategorizedItems.ts` | Categorized items |
+| `src/components/inventory/AddItemModal.tsx` | POST inventory change |
+| `src/components/inventory/AdjustQuantityModal.tsx` | PUT reset quantity |
+| `src/components/inventory/UpdateItemModal.tsx` | POST/PATCH items |
+| `src/components/AddVolunteerModal/AddVolunteerModal.tsx` | POST user |
+| `src/pages/inventory/index.tsx` | GET items, GET categories |
+| `src/pages/VolunteerHome/index.tsx` | GET items |
+| `src/pages/checkout/CheckoutPage.tsx` | GET categorized items |
+| `src/pages/people/useUsers.ts` | GET users |
+| `src/pages/authentication/EnterPinPage.tsx` | POST PIN verify, GET user by ID |
+| `src/layout/MainLayout/index.tsx` | GET `/.auth/me`, GET/PATCH/POST user |
+
+Note: `src/services/fetchWithRetry.ts` exists as a resilient wrapper but is bypassed by most of the above.
+
+### Target state
+
+One service file per domain, all under `src/services/`:
+
+```
+src/services/
+├── authService.ts        # /.auth/me, PIN verification
+├── userService.ts        # User CRUD (volunteers, admins)
+├── itemService.ts        # Items and categories catalog
+├── inventoryService.ts   # Stock adjustments and resets
+├── checkoutService.ts    # Checkout flow, residents, buildings
+└── historyService.ts     # Transaction history
+```
+
+Each file exports plain async functions. Hooks and components call service functions;
+they never call `fetch` directly. All service functions route through `fetchWithRetry`.
+
+### Domain breakdown
+
+**`authService.ts`**
+- `/.auth/me` (get current Azure Static Web Apps identity)
+- `POST` PIN verification
+
+**`userService.ts`**
+- GET all users
+- GET user by ID
+- POST create user
+- PATCH update user
+
+**`itemService.ts`**
+- GET items (expanded, paginated)
+- GET categories
+- GET categorized items
+- POST create item
+- PATCH update item
+
+**`inventoryService.ts`**
+- POST inventory change (add stock)
+- PUT reset quantity
+
+**`checkoutService.ts`**
+- Already largely covered by `CheckoutAPICalls.ts` — absorb and rename
+
+**`historyService.ts`**
+- Already largely covered by `HistoryAPICalls.ts` — move to `src/services/` and rename
+
+## Results
+
+Not yet implemented. The `maarten/manage-inventory` branch has taken a first step by extracting
+`Items.ts` and `Categories.ts`. These would fold into `itemService.ts`.
+
+## Next Steps
+
+1. Merge `maarten/manage-inventory` first to avoid conflicts with `Items.ts`/`Categories.ts`
+2. Move `HistoryAPICalls.ts` → `src/services/historyService.ts`
+3. Extract `userService.ts` from `MainLayout`, `EnterPinPage`, `useUsers`, `AddVolunteerModal`
+4. Extract `inventoryService.ts` from the three inventory modals and `pages/inventory/index.tsx`
+5. Extract `authService.ts` from `MainLayout`
+6. Move `fetchCategorizedItems.ts` into `itemService.ts`
+7. Ensure all service functions use `fetchWithRetry` instead of bare `fetch`
+8. Delete `src/components/utils/fetchCategorizedItems.ts` once absorbed


### PR DESCRIPTION
## Description
Modifies `ProcessCheckout` and `LogTransaction` stored procedures to support checkout edits. When `@original_transaction_id` is provided, the new transaction is recorded as a `CHECKOUT_EDIT` (type 4) with a `parent_transaction_id` reference to the original. Inventory update logic is unchanged.

## Jira Ticket
- Closes: [PIT-432](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-432)

## Type of Change
**Type:** New feature

## Changes Made
- Added `@original_transaction_id UNIQUEIDENTIFIER = NULL` to `ProcessCheckout`; sets `transaction_type = 4` when provided
- Added `@parent_transaction_id UNIQUEIDENTIFIER = NULL` to `LogTransaction` and persists it to `Transactions`
- Added SQL unit test (Test 16) verifying edit transaction gets `transaction_type = 4` and correct `parent_transaction_id`

## QA Instructions
1. Run `log_transaction.sql` and `process_checkout.sql` to update the SPs
2. Run `test_checkout_basket.sql` — all 16 tests should pass
3. Test 16 specifically verifies the edit flow end-to-end


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling to prevent authenticated content from displaying after logout when users navigate back in their browser.

* **Documentation**
  * Added architectural documentation outlining planned improvements to internal service organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->