### PR TITLE
fix: remove welcome unit from general checkout dropdown

### DIFF
--- a/src/components/Checkout/WelcomeBasketBuildingDialog.tsx
+++ b/src/components/Checkout/WelcomeBasketBuildingDialog.tsx
@@ -2,6 +2,7 @@ import React, { FormEvent, useState, useContext } from 'react';
 import { Box, FormControl, Typography } from '@mui/material';
 import BuildingCodeSelect from './BuildingCodeSelect';
 import { Building, ResidentInfo, Unit } from '../../types/interfaces';
+import { SPECIAL_UNITS } from '../../types/constants';
 import DialogTemplate from '../DialogTemplate';
 import { UserContext } from '../contexts/UserContext.ts';
 import {
@@ -49,7 +50,7 @@ const WelcomeBasketBuildingDialog = ({
     try {
       const units = await getUnitNumbers(user, selectedBuilding.id);
       const welcomeUnit = units.find(
-        (u: Unit) => u.unit_number.toLowerCase() === 'welcome',
+        (u: Unit) => u.unit_number.toLowerCase() === SPECIAL_UNITS.WELCOME,
       );
 
       if (!welcomeUnit) {

--- a/src/components/Checkout/WelcomeBasketBuildingDialog.tsx
+++ b/src/components/Checkout/WelcomeBasketBuildingDialog.tsx
@@ -50,7 +50,7 @@ const WelcomeBasketBuildingDialog = ({
     try {
       const units = await getUnitNumbers(user, selectedBuilding.id);
       const welcomeUnit = units.find(
-        (u: Unit) => u.unit_number.toLowerCase() === SPECIAL_UNITS.WELCOME,
+        (u: Unit) => u.unit_number.trim().toLowerCase() === SPECIAL_UNITS.WELCOME,
       );
 
       if (!welcomeUnit) {

--- a/src/components/Checkout/hooks/useUnitNumbers.ts
+++ b/src/components/Checkout/hooks/useUnitNumbers.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Unit, ClientPrincipal } from '../../../types/interfaces';
 import { getUnitNumbers } from '../../../services/residentService';
+import { SPECIAL_UNITS } from '../../../types/constants';
 
 export const useUnitNumbers = (
     setSelectedUnit: (unit: Unit) => void,
@@ -16,7 +17,10 @@ export const useUnitNumbers = (
         try {
             const response = await getUnitNumbers(user, buildingId);
             const unitNumbers = response
-                .filter((item: Unit) => item.unit_number.trim() !== '');
+                .filter((item: Unit) =>
+                    item.unit_number.trim() !== '' &&
+                    item.unit_number.trim().toLowerCase() !== SPECIAL_UNITS.WELCOME
+                );
             setUnitNumberValues(unitNumbers);
             setSelectedUnit({id: 0, unit_number: ''});
         } catch (error) {

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -91,3 +91,7 @@ export const SPECIAL_ITEMS = {
   APPLIANCE_MISC: 166,
   RUG: 97,
 } as const;
+
+export const SPECIAL_UNITS = {
+  WELCOME: 'welcome',
+} as const;


### PR DESCRIPTION
- Add SPECIAL_UNITS constant and replace inline 'welcome' literals tounify the value across the frontend codebase.
- Remove 'welcome' option from General Checkout dropdown. No longer needed as we have a separate Welcome Basket flow.

## Jira Ticket
- Closes: [PIT-454](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-454)

## Type of Change
<!-- Select the relevant option(s) by putting an 'x' in the brackets -->
**Type:** (Bug fix / New feature / Breaking change / Refactoring  X  / Documentation / Configuration / Performance)


## Checklist
<!-- Ensure all items are completed before requesting review -->
- [* ] My code follows the project's style guidelines
- [ *] I have run [prettier](https://github.com/digitalaidseattle/plymouth-housing#code-formatting) on the code
- [ *] I have performed a self-review of my code
- [ *] I have commented my code only in hard-to-understand areas
- [ *] I have updated the documentation accordingly
- [ *] My changes generate no new warnings in Chrome Dev Tools
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ *] New and existing unit tests pass locally with my changes

## QA Instructions, Screenshots, Recordings

- Test that 'welcome' no longer shows in General Checkout
- Test that welcome basket still functions normally



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trim whitespace from unit number input and ignore the reserved "welcome" unit so it cannot be accidentally selected during checkout.

* **Refactor**
  * Centralized the reserved-unit identifier across checkout components for consistent unit selection and filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->