### PR TITLE
fix: UI tweaks for pin auth failing after logout

### DIFF
--- a/src/pages/authentication/EnterPinPage.test.tsx
+++ b/src/pages/authentication/EnterPinPage.test.tsx
@@ -57,20 +57,24 @@ describe('EnterPinPage Component', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/pick-your-name');
   });
 
-  test('shows snackbar warning when PIN is incomplete', async () => {
+  test('disables Continue button when PIN is incomplete', async () => {
     render(
       <UserContext.Provider value={createUserContextValue()}>
         <EnterPinPage />
       </UserContext.Provider>
     );
 
-    // With default PIN state (["", "", "", ""]), click Continue.
+    // With default PIN state (["", "", "", ""]), Continue button should be disabled
     const continueButton = screen.getByRole('button', { name: /Continue/i });
-    fireEvent.click(continueButton);
+    expect(continueButton).toBeDisabled();
 
-    // Expect a warning snackbar message about incomplete PIN
+    // Simulate entering a complete PIN via the mocked PinInput.
+    const pinInput = screen.getByTestId('pin-input');
+    fireEvent.change(pinInput, { target: { value: '1234' } });
+
+    // After PIN is complete, button should be enabled
     await waitFor(() => {
-      expect(screen.getByText(/Please enter your PIN before continuing./i)).toBeInTheDocument();
+      expect(continueButton).not.toBeDisabled();
     });
   });
 

--- a/src/pages/authentication/EnterPinPage.tsx
+++ b/src/pages/authentication/EnterPinPage.tsx
@@ -4,7 +4,7 @@
  *  @copyright 2024 Digital Aid Seattle
  *
  */
-import React, { useCallback, useContext, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Typography, Button, Box } from '@mui/material';
 import MinimalWrapper from '../../layout/MinimalLayout/MinimalWrapper';
@@ -26,9 +26,18 @@ const EnterPinPage: React.FC = () => {
   const { loggedInUserId, user, activeVolunteers } = useContext(UserContext);
   const navigate = useNavigate();
 
-  if (!loggedInUserId) {
-    navigate('/pick-your-name');
-  }
+  const handlePinChange = useCallback((newPin: string[]) => {
+    setPin(newPin);
+  }, []);
+
+  const isPinComplete = pin.every((p) => p !== '');
+
+  useEffect(() => {
+    if (!loggedInUserId) {
+      setPin(Array(4).fill('')); // Clear PIN when user changes or logs out
+      navigate('/pick-your-name');
+    }
+  }, [loggedInUserId, navigate]);
 
   const getVolunteerName = (id: number | null): string => {
     if (!id) return 'Unknown';
@@ -127,15 +136,18 @@ const EnterPinPage: React.FC = () => {
   const handleNextClick = async () => {
     if (pin.every((p) => p !== '')) {
       const enteredPin = pin.join(''); // Combine array into a single string (e.g., '1234')
-      let result = null;
-      if (loggedInUserId !== null) {
-        result = await verifyPin(loggedInUserId, enteredPin);
-      } else {
+      const volunteerId = loggedInUserId; // Capture volunteer ID at submission time
+
+      if (volunteerId === null) {
         handleTheSnackies(
           'Volunteer ID is missing. Please try again.',
           'warning',
         );
+        return;
       }
+
+      let result = null;
+      result = await verifyPin(volunteerId, enteredPin);
 
       if (result?.IsValid) {
         trackEvent('PIN_Submission', {
@@ -151,17 +163,19 @@ const EnterPinPage: React.FC = () => {
         }
         navigate('/volunteer-home');
       } else if (result) {
+        // API succeeded but PIN was incorrect
+        const volunteerName =
+          getVolunteerName(loggedInUserId) || 'unknown volunteer';
         trackEvent('PIN_Submission', {
           volunteerId: loggedInUserId?.toString() || 'unknown',
-          volunteerName: getVolunteerName(loggedInUserId),
+          volunteerName: volunteerName,
           success: false,
           errorMessage: result.ErrorMessage || 'Incorrect PIN',
           component: 'EnterPinPage',
           action: 'pin_failed',
         });
-        // API succeeded but PIN was incorrect
         handleTheSnackies(
-          result.ErrorMessage || 'Incorrect PIN. Please try again.',
+          `${volunteerName}: ${result.ErrorMessage || 'Incorrect PIN. Please try again.'}`,
           'warning',
         );
       }
@@ -175,10 +189,6 @@ const EnterPinPage: React.FC = () => {
     navigate('/pick-your-name');
   };
 
-  const handlePinChange = useCallback((newPin: string[]) => {
-    setPin(newPin);
-  }, []);
-
   const handleSnackbarClose = (
     _event?: React.SyntheticEvent | Event,
     reason?: string,
@@ -189,6 +199,10 @@ const EnterPinPage: React.FC = () => {
     setOpenSnackbar(false);
   };
 
+  if (!loggedInUserId) {
+    return null;
+  }
+
   return (
     <MinimalWrapper>
       <CenteredLayout>
@@ -197,12 +211,21 @@ const EnterPinPage: React.FC = () => {
             variant="h4"
             textAlign="left"
             sx={{
-              height: '50px',
+              lineHeight: '50px',
+            }}
+          >
+            Welcome, {getVolunteerName(loggedInUserId)}!
+          </Typography>
+
+          <Typography
+            variant="h4"
+            textAlign="left"
+            sx={{
               lineHeight: '50px',
               marginBottom: 2,
             }}
           >
-            Enter Your PIN.
+            Enter your PIN
           </Typography>
 
           <Typography
@@ -219,12 +242,17 @@ const EnterPinPage: React.FC = () => {
             {import.meta.env.VITE_ADMIN_EMAIL}
           </Typography>
           <Box sx={{ marginBottom: 6 }}>
-            <PinInput onPinChange={handlePinChange} onSubmit={handleNextClick} />
+            <PinInput
+              key={loggedInUserId}
+              onPinChange={handlePinChange}
+              onSubmit={handleNextClick}
+            />
           </Box>
 
           <Button
             variant="contained"
             onClick={handleNextClick}
+            disabled={!isPinComplete}
             sx={{
               height: '45px',
               width: '100%',
@@ -232,9 +260,6 @@ const EnterPinPage: React.FC = () => {
               backgroundColor: 'black',
               color: 'white',
               marginTop: 2,
-              '&:hover': {
-                backgroundColor: '#4f4f4f',
-              },
             }}
           >
             Continue

--- a/src/pages/authentication/EnterPinPage.tsx
+++ b/src/pages/authentication/EnterPinPage.tsx
@@ -214,7 +214,7 @@ const EnterPinPage: React.FC = () => {
               lineHeight: '50px',
             }}
           >
-            Welcome, <span id='volunteer-name'>{getVolunteerName(loggedInUserId)}!</span>
+            Welcome, <span id="volunteer-name">{getVolunteerName(loggedInUserId)}!</span>
           </Typography>
 
           <Typography

--- a/src/pages/authentication/EnterPinPage.tsx
+++ b/src/pages/authentication/EnterPinPage.tsx
@@ -136,18 +136,15 @@ const EnterPinPage: React.FC = () => {
   const handleNextClick = async () => {
     if (pin.every((p) => p !== '')) {
       const enteredPin = pin.join(''); // Combine array into a single string (e.g., '1234')
-      const volunteerId = loggedInUserId; // Capture volunteer ID at submission time
-
-      if (volunteerId === null) {
+      let result = null;
+      if (loggedInUserId !== null) {
+        result = await verifyPin(loggedInUserId, enteredPin);
+      } else {
         handleTheSnackies(
           'Volunteer ID is missing. Please try again.',
           'warning',
         );
-        return;
       }
-
-      let result = null;
-      result = await verifyPin(volunteerId, enteredPin);
 
       if (result?.IsValid) {
         trackEvent('PIN_Submission', {
@@ -163,19 +160,16 @@ const EnterPinPage: React.FC = () => {
         }
         navigate('/volunteer-home');
       } else if (result) {
-        // API succeeded but PIN was incorrect
-        const volunteerName =
-          getVolunteerName(loggedInUserId) || 'unknown volunteer';
         trackEvent('PIN_Submission', {
           volunteerId: loggedInUserId?.toString() || 'unknown',
-          volunteerName: volunteerName,
+          volunteerName: getVolunteerName(loggedInUserId),
           success: false,
           errorMessage: result.ErrorMessage || 'Incorrect PIN',
           component: 'EnterPinPage',
           action: 'pin_failed',
         });
         handleTheSnackies(
-          `${volunteerName}: ${result.ErrorMessage || 'Incorrect PIN. Please try again.'}`,
+          `${getVolunteerName(loggedInUserId)}: ${result.ErrorMessage || 'Incorrect PIN. Please try again.'}`,
           'warning',
         );
       }

--- a/src/pages/authentication/EnterPinPage.tsx
+++ b/src/pages/authentication/EnterPinPage.tsx
@@ -33,8 +33,8 @@ const EnterPinPage: React.FC = () => {
   const isPinComplete = pin.every((p) => p !== '');
 
   useEffect(() => {
+    setPin(Array(4).fill('')); // Clear PIN on any loggedInUserId change
     if (!loggedInUserId) {
-      setPin(Array(4).fill('')); // Clear PIN when user changes or logs out
       navigate('/pick-your-name');
     }
   }, [loggedInUserId, navigate]);

--- a/src/pages/authentication/EnterPinPage.tsx
+++ b/src/pages/authentication/EnterPinPage.tsx
@@ -214,7 +214,7 @@ const EnterPinPage: React.FC = () => {
               lineHeight: '50px',
             }}
           >
-            Welcome, {getVolunteerName(loggedInUserId)}!
+            Welcome, <span id='volunteer-name'>{getVolunteerName(loggedInUserId)}!</span>
           </Typography>
 
           <Typography

--- a/src/pages/authentication/PickNamePage.test.tsx
+++ b/src/pages/authentication/PickNamePage.test.tsx
@@ -95,12 +95,11 @@ describe('PickNamePage Component', () => {
     });
   });
 
-  test('shows snackbar warning if no name is selected when clicking Continue', async () => {
+  test('disables Continue button when no name is selected', async () => {
     const volunteers = [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }];
 
     mockFetchWithRetry.mockResolvedValue({ value: volunteers });
 
-    // Provide context with volunteers but with no selected volunteer (loggedInUserId: null)
     render(
       <UserContext.Provider
         value={createUserContextValue({
@@ -117,15 +116,7 @@ describe('PickNamePage Component', () => {
     });
 
     const continueButton = screen.getByRole('button', { name: /Continue/i });
-    fireEvent.click(continueButton);
-
-    // Wait for the snackbar message; use a flexible matcher in case the text is split.
-    await waitFor(() => {
-      const snackbar = screen.getByText((content) =>
-        content.replace(/\s+/g, ' ').includes('Please select a name before continuing.')
-      );
-      expect(snackbar).toBeInTheDocument();
-    });
+    expect(continueButton).toBeDisabled();
   });
 
   test('disables Autocomplete and Continue button while loading', async () => {

--- a/src/pages/authentication/PickNamePage.tsx
+++ b/src/pages/authentication/PickNamePage.tsx
@@ -98,6 +98,9 @@ const PickYourNamePage: React.FC = () => {
     setSnackbarState((prev) => ({ ...prev, open: false }));
   };
 
+  const isValidVolunteer = (volunteerId: number | null): boolean =>
+    volunteerId ? activeVolunteers.some(v => v.id === volunteerId) : false;
+
   return (
       <MinimalWrapper>
         <CenteredLayout>
@@ -159,7 +162,7 @@ const PickYourNamePage: React.FC = () => {
                 backgroundColor: 'black',
                 color: 'white',
               }}
-              disabled={isLoading || !loggedInUserId}
+              disabled={isLoading || !loggedInUserId || !isValidVolunteer(loggedInUserId)}
             >
               Continue
             </Button>

--- a/src/pages/authentication/PickNamePage.tsx
+++ b/src/pages/authentication/PickNamePage.tsx
@@ -99,7 +99,7 @@ const PickYourNamePage: React.FC = () => {
   };
 
   const isValidVolunteer = (volunteerId: number | null): boolean =>
-    volunteerId ? activeVolunteers.some(v => v.id === volunteerId) : false;
+    volunteerId !== null && activeVolunteers.some((v) => v.id === volunteerId);
 
   return (
       <MinimalWrapper>

--- a/src/pages/authentication/PickNamePage.tsx
+++ b/src/pages/authentication/PickNamePage.tsx
@@ -158,11 +158,8 @@ const PickYourNamePage: React.FC = () => {
                 fontSize: '16px',
                 backgroundColor: 'black',
                 color: 'white',
-                '&:hover': {
-                  backgroundColor: '#4f4f4f',
-                },
               }}
-              disabled={isLoading}
+              disabled={isLoading || !loggedInUserId}
             >
               Continue
             </Button>


### PR DESCRIPTION
## Description

The goal of this is to improve tracking user id and PIN, both to fix the bug of failed auth, and if not, try to figure out why is it happening on prod.


## Jira Ticket
- Closes: [PIT-459](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-459)
Bug: PIN authentication still failing after prior fix

## Type of Change
<!-- Select the relevant option(s) by putting an 'x' in the brackets -->
**Type:** (Bug fix X / New feature / Breaking change / Refactoring / Documentation / Configuration / Performance)

## Changes Made

EnterPinPage:
- Move React hooks above conditional returns
- Replace direct navigate() call with useEffect for redirect
- Add key prop to PinInput to force remount on volunteer change
- Disable Continue button until PIN is complete
- Capture volunteerId at submission time to prevent race condition
- Include volunteer name in PIN error messages (to track actual user id)
- Display welcome message with volunteer name in heading (to track actual user id)
- Add response validation to PIN verification API call

PickNamePage:
- Disable Continue button until volunteer selected

Tests:
- Update auth tests to verify button disabled state
- 
- 

## Checklist
<!-- Ensure all items are completed before requesting review -->
- [ *] My code follows the project's style guidelines
- [ *] I have run [prettier](https://github.com/digitalaidseattle/plymouth-housing#code-formatting) on the code
- [ *] I have performed a self-review of my code
- [ *] I have commented my code only in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ *] My changes generate no new warnings in Chrome Dev Tools
- [ *] I have added unit tests that prove my fix is effective or that my feature works
- [ *] New and existing unit tests pass locally with my changes

## QA Instructions, Screenshots, Recordings
 Continue button disabled until all 4 digits entered
 Welcome message shows volunteer name
 Error message includes volunteer name
 Logout → new login shows correct volunteer (not previous)
 All authentication tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Personalized "Welcome, <name>!" greeting on the PIN entry page.

* **Refactor**
  * Continue buttons remain disabled until PIN or name selection is fully completed.
  * Navigation now returns users to the name-picking step when no user is selected and prevents rendering without a selected user.
  * Incorrect-PIN warnings now include the volunteer’s name; PIN input is refreshed when the selected user changes.
  * Minor heading typography adjustment.

* **Tests**
  * Tests updated to assert button disabled/enabled states instead of snackbar text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->