### PR TITLE
PIT-459 fix: use captured volunteerId consistently in PIN verification

### DIFF
--- a/src/pages/authentication/EnterPinPage.test.tsx
+++ b/src/pages/authentication/EnterPinPage.test.tsx
@@ -57,20 +57,24 @@ describe('EnterPinPage Component', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/pick-your-name');
   });
 
-  test('shows snackbar warning when PIN is incomplete', async () => {
+  test('disables Continue button when PIN is incomplete', async () => {
     render(
       <UserContext.Provider value={createUserContextValue()}>
         <EnterPinPage />
       </UserContext.Provider>
     );
 
-    // With default PIN state (["", "", "", ""]), click Continue.
+    // With default PIN state (["", "", "", ""]), Continue button should be disabled
     const continueButton = screen.getByRole('button', { name: /Continue/i });
-    fireEvent.click(continueButton);
+    expect(continueButton).toBeDisabled();
 
-    // Expect a warning snackbar message about incomplete PIN
+    // Simulate entering a complete PIN via the mocked PinInput.
+    const pinInput = screen.getByTestId('pin-input');
+    fireEvent.change(pinInput, { target: { value: '1234' } });
+
+    // After PIN is complete, button should be enabled
     await waitFor(() => {
-      expect(screen.getByText(/Please enter your PIN before continuing./i)).toBeInTheDocument();
+      expect(continueButton).not.toBeDisabled();
     });
   });
 

--- a/src/pages/authentication/EnterPinPage.tsx
+++ b/src/pages/authentication/EnterPinPage.tsx
@@ -4,7 +4,7 @@
  *  @copyright 2024 Digital Aid Seattle
  *
  */
-import React, { useCallback, useContext, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Typography, Button, Box } from '@mui/material';
 import MinimalWrapper from '../../layout/MinimalLayout/MinimalWrapper';
@@ -26,9 +26,18 @@ const EnterPinPage: React.FC = () => {
   const { loggedInUserId, user, activeVolunteers } = useContext(UserContext);
   const navigate = useNavigate();
 
-  if (!loggedInUserId) {
-    navigate('/pick-your-name');
-  }
+  const handlePinChange = useCallback((newPin: string[]) => {
+    setPin(newPin);
+  }, []);
+
+  const isPinComplete = pin.every((p) => p !== '');
+
+  useEffect(() => {
+    if (!loggedInUserId) {
+      setPin(Array(4).fill('')); // Clear PIN when user changes or logs out
+      navigate('/pick-your-name');
+    }
+  }, [loggedInUserId, navigate]);
 
   const getVolunteerName = (id: number | null): string => {
     if (!id) return 'Unknown';
@@ -127,15 +136,18 @@ const EnterPinPage: React.FC = () => {
   const handleNextClick = async () => {
     if (pin.every((p) => p !== '')) {
       const enteredPin = pin.join(''); // Combine array into a single string (e.g., '1234')
-      let result = null;
-      if (loggedInUserId !== null) {
-        result = await verifyPin(loggedInUserId, enteredPin);
-      } else {
+      const volunteerId = loggedInUserId; // Capture volunteer ID at submission time
+
+      if (volunteerId === null) {
         handleTheSnackies(
           'Volunteer ID is missing. Please try again.',
           'warning',
         );
+        return;
       }
+
+      let result = null;
+      result = await verifyPin(volunteerId, enteredPin);
 
       if (result?.IsValid) {
         trackEvent('PIN_Submission', {
@@ -151,17 +163,19 @@ const EnterPinPage: React.FC = () => {
         }
         navigate('/volunteer-home');
       } else if (result) {
+        // API succeeded but PIN was incorrect
+        const volunteerName =
+          getVolunteerName(loggedInUserId) || 'unknown volunteer';
         trackEvent('PIN_Submission', {
           volunteerId: loggedInUserId?.toString() || 'unknown',
-          volunteerName: getVolunteerName(loggedInUserId),
+          volunteerName: volunteerName,
           success: false,
           errorMessage: result.ErrorMessage || 'Incorrect PIN',
           component: 'EnterPinPage',
           action: 'pin_failed',
         });
-        // API succeeded but PIN was incorrect
         handleTheSnackies(
-          result.ErrorMessage || 'Incorrect PIN. Please try again.',
+          `${volunteerName}: ${result.ErrorMessage || 'Incorrect PIN. Please try again.'}`,
           'warning',
         );
       }
@@ -175,10 +189,6 @@ const EnterPinPage: React.FC = () => {
     navigate('/pick-your-name');
   };
 
-  const handlePinChange = useCallback((newPin: string[]) => {
-    setPin(newPin);
-  }, []);
-
   const handleSnackbarClose = (
     _event?: React.SyntheticEvent | Event,
     reason?: string,
@@ -189,6 +199,10 @@ const EnterPinPage: React.FC = () => {
     setOpenSnackbar(false);
   };
 
+  if (!loggedInUserId) {
+    return null;
+  }
+
   return (
     <MinimalWrapper>
       <CenteredLayout>
@@ -197,12 +211,21 @@ const EnterPinPage: React.FC = () => {
             variant="h4"
             textAlign="left"
             sx={{
-              height: '50px',
+              lineHeight: '50px',
+            }}
+          >
+            Welcome, {getVolunteerName(loggedInUserId)}!
+          </Typography>
+
+          <Typography
+            variant="h4"
+            textAlign="left"
+            sx={{
               lineHeight: '50px',
               marginBottom: 2,
             }}
           >
-            Enter Your PIN.
+            Enter your PIN
           </Typography>
 
           <Typography
@@ -219,12 +242,17 @@ const EnterPinPage: React.FC = () => {
             {import.meta.env.VITE_ADMIN_EMAIL}
           </Typography>
           <Box sx={{ marginBottom: 6 }}>
-            <PinInput onPinChange={handlePinChange} onSubmit={handleNextClick} />
+            <PinInput
+              key={loggedInUserId}
+              onPinChange={handlePinChange}
+              onSubmit={handleNextClick}
+            />
           </Box>
 
           <Button
             variant="contained"
             onClick={handleNextClick}
+            disabled={!isPinComplete}
             sx={{
               height: '45px',
               width: '100%',
@@ -232,9 +260,6 @@ const EnterPinPage: React.FC = () => {
               backgroundColor: 'black',
               color: 'white',
               marginTop: 2,
-              '&:hover': {
-                backgroundColor: '#4f4f4f',
-              },
             }}
           >
             Continue

--- a/src/pages/authentication/EnterPinPage.tsx
+++ b/src/pages/authentication/EnterPinPage.tsx
@@ -151,23 +151,21 @@ const EnterPinPage: React.FC = () => {
 
       if (result?.IsValid) {
         trackEvent('PIN_Submission', {
-          volunteerId: loggedInUserId?.toString() || 'unknown',
-          volunteerName: getVolunteerName(loggedInUserId),
+          volunteerId: volunteerId.toString(),
+          volunteerName: getVolunteerName(volunteerId),
           success: true,
           component: 'EnterPinPage',
           action: 'pin_verified',
         });
         handleTheSnackies('Login successful! Redirecting...', 'success');
-        if (loggedInUserId !== null) {
-          result = await updateLastSignedIn(loggedInUserId); // Update last signed-in date after successful login
-        }
+        result = await updateLastSignedIn(volunteerId); // Update last signed-in date after successful login
         navigate('/volunteer-home');
       } else if (result) {
         // API succeeded but PIN was incorrect
         const volunteerName =
-          getVolunteerName(loggedInUserId) || 'unknown volunteer';
+          getVolunteerName(volunteerId) || 'unknown volunteer';
         trackEvent('PIN_Submission', {
-          volunteerId: loggedInUserId?.toString() || 'unknown',
+          volunteerId: volunteerId.toString(),
           volunteerName: volunteerName,
           success: false,
           errorMessage: result.ErrorMessage || 'Incorrect PIN',

--- a/src/pages/authentication/EnterPinPage.tsx
+++ b/src/pages/authentication/EnterPinPage.tsx
@@ -214,7 +214,7 @@ const EnterPinPage: React.FC = () => {
               lineHeight: '50px',
             }}
           >
-            Welcome, {getVolunteerName(loggedInUserId)}!
+            Welcome, <span id='volunteer-name'>{getVolunteerName(loggedInUserId)}!</span>
           </Typography>
 
           <Typography

--- a/src/pages/authentication/PickNamePage.test.tsx
+++ b/src/pages/authentication/PickNamePage.test.tsx
@@ -95,12 +95,11 @@ describe('PickNamePage Component', () => {
     });
   });
 
-  test('shows snackbar warning if no name is selected when clicking Continue', async () => {
+  test('disables Continue button when no name is selected', async () => {
     const volunteers = [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }];
 
     mockFetchWithRetry.mockResolvedValue({ value: volunteers });
 
-    // Provide context with volunteers but with no selected volunteer (loggedInUserId: null)
     render(
       <UserContext.Provider
         value={createUserContextValue({
@@ -117,15 +116,7 @@ describe('PickNamePage Component', () => {
     });
 
     const continueButton = screen.getByRole('button', { name: /Continue/i });
-    fireEvent.click(continueButton);
-
-    // Wait for the snackbar message; use a flexible matcher in case the text is split.
-    await waitFor(() => {
-      const snackbar = screen.getByText((content) =>
-        content.replace(/\s+/g, ' ').includes('Please select a name before continuing.')
-      );
-      expect(snackbar).toBeInTheDocument();
-    });
+    expect(continueButton).toBeDisabled();
   });
 
   test('disables Autocomplete and Continue button while loading', async () => {

--- a/src/pages/authentication/PickNamePage.tsx
+++ b/src/pages/authentication/PickNamePage.tsx
@@ -98,6 +98,9 @@ const PickYourNamePage: React.FC = () => {
     setSnackbarState((prev) => ({ ...prev, open: false }));
   };
 
+  const isValidVolunteer = (volunteerId: number | null): boolean =>
+    volunteerId ? activeVolunteers.some(v => v.id === volunteerId) : false;
+
   return (
       <MinimalWrapper>
         <CenteredLayout>
@@ -159,7 +162,7 @@ const PickYourNamePage: React.FC = () => {
                 backgroundColor: 'black',
                 color: 'white',
               }}
-              disabled={isLoading || !loggedInUserId}
+              disabled={isLoading || !loggedInUserId || !isValidVolunteer(loggedInUserId)}
             >
               Continue
             </Button>

--- a/src/pages/authentication/PickNamePage.tsx
+++ b/src/pages/authentication/PickNamePage.tsx
@@ -158,11 +158,8 @@ const PickYourNamePage: React.FC = () => {
                 fontSize: '16px',
                 backgroundColor: 'black',
                 color: 'white',
-                '&:hover': {
-                  backgroundColor: '#4f4f4f',
-                },
               }}
-              disabled={isLoading}
+              disabled={isLoading || !loggedInUserId}
             >
               Continue
             </Button>


### PR DESCRIPTION
## Description

Addresses feedback from PR #466 Copilot review: the captured `volunteerId` must be used consistently throughout the PIN verification flow to prevent analytics and session updates from being misattributed if `loggedInUserId` changes while the API request is in-flight.

Previously, the code captured `volunteerId` to avoid race conditions on the API call, but then used `loggedInUserId` in the success/error tracking paths. This creates a window where if the user context changes, analytics would be attributed to the wrong volunteer.

## Jira Ticket
- Closes: [PIT-459](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-459)
Bug: PIN authentication still failing after prior fix

## Type of Change
**Type:** Bug fix

## Changes Made
- Use captured `volunteerId` in trackEvent calls (success and error paths) instead of `loggedInUserId`
- Use captured `volunteerId` in getVolunteerName() calls for proper name derivation
- Use captured `volunteerId` in updateLastSignedIn() call to update correct volunteer's session
- Removes unnecessary null check on `loggedInUserId` since `volunteerId` is guaranteed to be non-null

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have run prettier on the code
- [x] I have performed a self-review of my code
- [x] I have commented my code only in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings in Chrome Dev Tools
- [x] Unit tests already cover this scenario and continue to pass
- [x] No new tests needed (existing tests cover the code paths)

## QA Instructions, Screenshots, Recordings

Test scenarios from original PR #466 continue to pass:
- Continue button disabled until all 4 digits entered
- Welcome message shows volunteer name
- Error message includes volunteer name
- Logout → new login shows correct volunteer (not previous)
- All authentication tests pass