### PR TITLE
feat: Admin Manage Residents page

### DIFF
--- a/dab/dab-config.json
+++ b/dab/dab-config.json
@@ -181,6 +181,23 @@
         }
       ]
     },
+    "ResidentsByBuilding": {
+      "source": {
+        "object": "dbo.ResidentsByBuilding",
+        "type": "table",
+        "key-fields": ["id"]
+      },
+      "rest": {
+        "enabled": true,
+        "path": "/residents-by-building"
+      },
+      "permissions": [
+        {
+          "actions": ["read"],
+          "role": "admin"
+        }
+      ]
+    },
     "VerifyPin": {
       "source": {
         "object": "dbo.VerifyVolunteerPin",

--- a/database/tables/residents.sql
+++ b/database/tables/residents.sql
@@ -8,3 +8,20 @@ CREATE TABLE Residents (
 );
 
 GO
+
+CREATE VIEW ResidentsByBuilding
+AS
+    SELECT
+        r.id,
+        r.name,
+        u.id AS unit_id,
+        u.unit_number,
+        b.id AS building_id,
+        b.name AS building_name,
+        b.code AS building_code
+    FROM
+        Residents r
+    JOIN Units u ON r.unit_id = u.id
+    JOIN Buildings b ON u.building_id = b.id;
+
+GO

--- a/database/tables/residents.sql
+++ b/database/tables/residents.sql
@@ -1,12 +1,16 @@
 DROP TABLE IF EXISTS [dbo].[Residents];
 GO
 
-CREATE TABLE Residents (
+CREATE TABLE Residents
+(
     id INT NOT NULL IDENTITY(1,1) PRIMARY KEY,
     name NVARCHAR(255) NOT NULL,
     unit_id INT NOT NULL
 );
 
+GO
+
+DROP VIEW IF EXISTS [dbo].[ResidentsByBuilding];  
 GO
 
 CREATE VIEW ResidentsByBuilding
@@ -21,7 +25,7 @@ AS
         b.code AS building_code
     FROM
         Residents r
-    JOIN Units u ON r.unit_id = u.id
-    JOIN Buildings b ON u.building_id = b.id;
+        JOIN Units u ON r.unit_id = u.id
+        JOIN Buildings b ON u.building_id = b.id;
 
 GO

--- a/src/components/Checkout/ResidentDetailDialog.test.tsx
+++ b/src/components/Checkout/ResidentDetailDialog.test.tsx
@@ -3,10 +3,10 @@ import '@testing-library/jest-dom';
 import { describe, test, expect, vi, beforeEach, type Mock } from 'vitest';
 import ResidentDetailDialog from './ResidentDetailDialog';
 import { UserContext } from '../contexts/UserContext';
-import * as CheckoutAPICalls from '../../services/checkoutService';
+import * as CheckoutAPICalls from '../../services/residentService';
 
 // Mock the CheckoutAPICalls module
-vi.mock('../../services/checkoutService', () => ({
+vi.mock('../../services/residentService', () => ({
   getUnitNumbers: vi.fn(),
   getResidents: vi.fn(),
   findResident: vi.fn(),

--- a/src/components/Checkout/WelcomeBasketBuildingDialog.test.tsx
+++ b/src/components/Checkout/WelcomeBasketBuildingDialog.test.tsx
@@ -3,10 +3,10 @@ import '@testing-library/jest-dom';
 import { describe, test, expect, vi, beforeEach, type Mock } from 'vitest';
 import WelcomeBasketBuildingDialog from './WelcomeBasketBuildingDialog';
 import { UserContext } from '../contexts/UserContext';
-import * as CheckoutAPICalls from '../../services/checkoutService';
+import * as CheckoutAPICalls from '../../services/residentService';
 
 // Mock the CheckoutAPICalls module
-vi.mock('../../services/checkoutService', () => ({
+vi.mock('../../services/residentService', () => ({
   getUnitNumbers: vi.fn(),
   getResidents: vi.fn(),
   findResident: vi.fn(),

--- a/src/components/Checkout/WelcomeBasketBuildingDialog.tsx
+++ b/src/components/Checkout/WelcomeBasketBuildingDialog.tsx
@@ -9,7 +9,7 @@ import {
   getResidents,
   addResident,
   findResident,
-} from '../../services/checkoutService';
+} from '../../services/residentService';
 
 type WelcomeBasketBuildingDialogProps = {
   showDialog: boolean;

--- a/src/components/Checkout/hooks/useResidentFormSubmit.ts
+++ b/src/components/Checkout/hooks/useResidentFormSubmit.ts
@@ -6,7 +6,7 @@ import {
   ClientPrincipal,
   ResidentFormError,
 } from '../../../types/interfaces';
-import { addResident, findResident } from '../../../services/checkoutService';
+import { addResident, findResident } from '../../../services/residentService';
 
 export const useResidentFormSubmit = (
   user: ClientPrincipal | null,

--- a/src/components/Checkout/hooks/useResidents.ts
+++ b/src/components/Checkout/hooks/useResidents.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Unit, ClientPrincipal, ResidentNameOption } from '../../../types/interfaces';
-import { getResidents, getLastResidentVisit } from '../../../services/checkoutService';
+import { getResidents, getLastResidentVisit } from '../../../services/residentService';
 
 export const useResidents = (
     user: ClientPrincipal | null,

--- a/src/components/Checkout/hooks/useUnitNumbers.ts
+++ b/src/components/Checkout/hooks/useUnitNumbers.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Unit, ClientPrincipal } from '../../../types/interfaces';
-import { getUnitNumbers } from '../../../services/checkoutService';
+import { getUnitNumbers } from '../../../services/residentService';
 
 export const useUnitNumbers = (
     setSelectedUnit: (unit: Unit) => void,

--- a/src/hooks/useCheckoutData.ts
+++ b/src/hooks/useCheckoutData.ts
@@ -7,7 +7,7 @@ import {
   ClientPrincipal,
   CheckoutType,
 } from '../types/interfaces';
-import { getBuildings } from '../services/checkoutService';
+import { getBuildings } from '../services/residentService';
 import { getCategorizedItems } from '../services/itemsService';
 import { CATEGORY_IDS, WELCOME_BASKET_ITEMS } from '../types/constants';
 

--- a/src/hooks/useReferenceData.ts
+++ b/src/hooks/useReferenceData.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Building, CategoryProps, User } from '../types/interfaces';
-import { getBuildings } from '../services/checkoutService';
+import { getBuildings } from '../services/residentService';
 import { getUsers } from '../services/userService';
 import { getCategorizedItems } from '../services/itemsService';
 import type { ClientPrincipal } from '../types/interfaces';

--- a/src/menu-items/index.tsx
+++ b/src/menu-items/index.tsx
@@ -13,6 +13,7 @@ import {
   UserOutlined,
   HomeOutlined,
   ShoppingCartOutlined,
+  TeamOutlined,
 } from '@ant-design/icons';
 
 const icons = {
@@ -29,6 +30,7 @@ const icons = {
   UserOutlined,
   HomeOutlined,
   ShoppingCartOutlined,
+  TeamOutlined,
 };
 
 const dashboard = {
@@ -82,6 +84,14 @@ const dashboard = {
       type: 'admin',
       url: '/people',
       icon: icons.UserOutlined,
+      breadcrumbs: false,
+    },
+    {
+      id: 'residents',
+      title: 'Residents',
+      type: 'admin',
+      url: '/residents',
+      icon: icons.TeamOutlined,
       breadcrumbs: false,
     },
     {

--- a/src/pages/history/index.test.tsx
+++ b/src/pages/history/index.test.tsx
@@ -12,7 +12,7 @@ import HistoryPage from './index';
 import { UserContext } from '../../components/contexts/UserContext';
 import * as historyService from '../../services/historyService';
 import * as userService from '../../services/userService';
-import * as checkoutService from '../../services/checkoutService';
+import * as residentService from '../../services/residentService';
 import * as itemsService from '../../services/itemsService';
 import {
   TransactionType,
@@ -24,7 +24,7 @@ import {
 // Mock modules
 vi.mock('../../services/historyService');
 vi.mock('../../services/userService');
-vi.mock('../../services/checkoutService');
+vi.mock('../../services/residentService');
 vi.mock('../../services/itemsService');
 vi.mock('../../components/CircularLoader', () => ({
   default: () => <div data-testid="circular-loader">Loading...</div>,
@@ -173,7 +173,7 @@ describe('HistoryPage Component', () => {
           setTimeout(() => resolve(mockUserList as any), 50),
         ),
     );
-    vi.spyOn(checkoutService, 'getBuildings').mockImplementation(
+    vi.spyOn(residentService, 'getBuildings').mockImplementation(
       () =>
         new Promise((resolve) => setTimeout(() => resolve(mockBuildings), 50)),
     );
@@ -283,7 +283,7 @@ describe('HistoryPage Component', () => {
     );
 
     await waitFor(() => {
-      expect(checkoutService.getBuildings).toHaveBeenCalled();
+      expect(residentService.getBuildings).toHaveBeenCalled();
       expect(itemsService.getCategorizedItems).toHaveBeenCalled();
     });
   });

--- a/src/pages/residents/index.test.tsx
+++ b/src/pages/residents/index.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import ResidentsPage from './index';
+import { UserContext } from '../../components/contexts/UserContext';
+import React from 'react';
+
+vi.mock('../../services/residentService', () => ({
+  getBuildings: vi.fn().mockResolvedValue([
+    { id: 1, name: 'Alpha House', code: 'AH' },
+    { id: 2, name: 'Beta House',  code: 'BH' },
+  ]),
+  getAllResidents: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('./useResidentsByBuilding', () => ({
+  useResidentsByBuilding: vi.fn(),
+}));
+
+import * as residentService from '../../services/residentService';
+import { useResidentsByBuilding } from './useResidentsByBuilding';
+
+const mockHook = vi.mocked(useResidentsByBuilding);
+
+const dummyUser = { userID: '1', userDetails: 'Test', userRoles: ['admin'], claims: [] };
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <UserContext.Provider
+    value={{
+      user: dummyUser,
+      setUser: vi.fn(),
+      loggedInUserId: 1,
+      setLoggedInUserId: vi.fn(),
+      activeVolunteers: [],
+      setActiveVolunteers: vi.fn(),
+      isLoading: false,
+    }}
+  >
+    {children}
+  </UserContext.Provider>
+);
+
+const buildingData = [
+  {
+    unit: { id: 10, unit_number: '101' },
+    residents: [{ id: 1, name: 'Alice Smith' }],
+  },
+  {
+    unit: { id: 20, unit_number: '202' },
+    residents: [{ id: 2, name: 'Bob Jones' }, { id: 3, name: 'Carol Jones' }],
+  },
+  {
+    unit: { id: 30, unit_number: '303' },
+    residents: [],
+  },
+];
+
+describe('ResidentsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHook.mockReturnValue({ data: [], isLoading: false, error: null });
+  });
+
+  test('renders building dropdown', async () => {
+    render(<Wrapper><ResidentsPage /></Wrapper>);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Building')).toBeInTheDocument();
+    });
+  });
+
+  test('loads buildings on mount', async () => {
+    render(<Wrapper><ResidentsPage /></Wrapper>);
+
+    await waitFor(() => {
+      expect(residentService.getBuildings).toHaveBeenCalled();
+    });
+  });
+
+  test('shows unit and resident rows after building data loads', async () => {
+    mockHook.mockReturnValue({ data: buildingData, isLoading: false, error: null });
+
+    render(<Wrapper><ResidentsPage /></Wrapper>);
+
+    await waitFor(() => {
+      expect(screen.getByText('101')).toBeInTheDocument();
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+      expect(screen.getByText('Bob Jones, Carol Jones')).toBeInTheDocument();
+    });
+  });
+
+  test('shows dash for units with no residents', async () => {
+    mockHook.mockReturnValue({ data: buildingData, isLoading: false, error: null });
+
+    render(<Wrapper><ResidentsPage /></Wrapper>);
+
+    await waitFor(() => {
+      expect(screen.getByText('303')).toBeInTheDocument();
+      expect(screen.getByText('—')).toBeInTheDocument();
+    });
+  });
+
+  test('shows loading spinner while fetching', () => {
+    mockHook.mockReturnValue({ data: [], isLoading: true, error: null });
+
+    render(<Wrapper><ResidentsPage /></Wrapper>);
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  test('shows error snackbar when hook reports an error', async () => {
+    mockHook.mockReturnValue({ data: [], isLoading: false, error: 'Failed to load residents' });
+
+    render(<Wrapper><ResidentsPage /></Wrapper>);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Failed to load residents');
+    });
+  });
+
+  test('renders all units when data is loaded', async () => {
+    mockHook.mockReturnValue({ data: buildingData, isLoading: false, error: null });
+
+    render(<Wrapper><ResidentsPage /></Wrapper>);
+
+    await waitFor(() => {
+      expect(screen.getByText('101')).toBeInTheDocument();
+      expect(screen.getByText('202')).toBeInTheDocument();
+      expect(screen.getByText('303')).toBeInTheDocument();
+    });
+  });
+
+  test('renders search input alongside building dropdown', async () => {
+    render(<Wrapper><ResidentsPage /></Wrapper>);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Search resident by name…')).toBeInTheDocument();
+      expect(screen.getByLabelText('Building')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/residents/index.test.tsx
+++ b/src/pages/residents/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import ResidentsPage from './index';
@@ -8,7 +8,7 @@ import React from 'react';
 vi.mock('../../services/residentService', () => ({
   getBuildings: vi.fn().mockResolvedValue([
     { id: 1, name: 'Alpha House', code: 'AH' },
-    { id: 2, name: 'Beta House',  code: 'BH' },
+    { id: 2, name: 'Beta House', code: 'BH' },
   ]),
   getAllResidents: vi.fn().mockResolvedValue([]),
 }));
@@ -22,7 +22,12 @@ import { useResidentsByBuilding } from './useResidentsByBuilding';
 
 const mockHook = vi.mocked(useResidentsByBuilding);
 
-const dummyUser = { userID: '1', userDetails: 'Test', userRoles: ['admin'], claims: [] };
+const dummyUser = {
+  userID: '1',
+  userDetails: 'Test',
+  userRoles: ['admin'],
+  claims: [],
+};
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
   <UserContext.Provider
@@ -47,7 +52,10 @@ const buildingData = [
   },
   {
     unit: { id: 20, unit_number: '202' },
-    residents: [{ id: 2, name: 'Bob Jones' }, { id: 3, name: 'Carol Jones' }],
+    residents: [
+      { id: 2, name: 'Bob Jones' },
+      { id: 3, name: 'Carol Jones' },
+    ],
   },
   {
     unit: { id: 30, unit_number: '303' },
@@ -62,7 +70,11 @@ describe('ResidentsPage', () => {
   });
 
   test('renders building dropdown', async () => {
-    render(<Wrapper><ResidentsPage /></Wrapper>);
+    render(
+      <Wrapper>
+        <ResidentsPage />
+      </Wrapper>,
+    );
 
     await waitFor(() => {
       expect(screen.getByLabelText('Building')).toBeInTheDocument();
@@ -70,7 +82,11 @@ describe('ResidentsPage', () => {
   });
 
   test('loads buildings on mount', async () => {
-    render(<Wrapper><ResidentsPage /></Wrapper>);
+    render(
+      <Wrapper>
+        <ResidentsPage />
+      </Wrapper>,
+    );
 
     await waitFor(() => {
       expect(residentService.getBuildings).toHaveBeenCalled();
@@ -78,9 +94,17 @@ describe('ResidentsPage', () => {
   });
 
   test('shows unit and resident rows after building data loads', async () => {
-    mockHook.mockReturnValue({ data: buildingData, isLoading: false, error: null });
+    mockHook.mockReturnValue({
+      data: buildingData,
+      isLoading: false,
+      error: null,
+    });
 
-    render(<Wrapper><ResidentsPage /></Wrapper>);
+    render(
+      <Wrapper>
+        <ResidentsPage />
+      </Wrapper>,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('101')).toBeInTheDocument();
@@ -90,9 +114,17 @@ describe('ResidentsPage', () => {
   });
 
   test('shows dash for units with no residents', async () => {
-    mockHook.mockReturnValue({ data: buildingData, isLoading: false, error: null });
+    mockHook.mockReturnValue({
+      data: buildingData,
+      isLoading: false,
+      error: null,
+    });
 
-    render(<Wrapper><ResidentsPage /></Wrapper>);
+    render(
+      <Wrapper>
+        <ResidentsPage />
+      </Wrapper>,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('303')).toBeInTheDocument();
@@ -103,25 +135,47 @@ describe('ResidentsPage', () => {
   test('shows loading spinner while fetching', () => {
     mockHook.mockReturnValue({ data: [], isLoading: true, error: null });
 
-    render(<Wrapper><ResidentsPage /></Wrapper>);
+    render(
+      <Wrapper>
+        <ResidentsPage />
+      </Wrapper>,
+    );
 
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
 
   test('shows error snackbar when hook reports an error', async () => {
-    mockHook.mockReturnValue({ data: [], isLoading: false, error: 'Failed to load residents' });
+    mockHook.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: 'Failed to load residents',
+    });
 
-    render(<Wrapper><ResidentsPage /></Wrapper>);
+    render(
+      <Wrapper>
+        <ResidentsPage />
+      </Wrapper>,
+    );
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent('Failed to load residents');
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Failed to load residents',
+      );
     });
   });
 
   test('renders all units when data is loaded', async () => {
-    mockHook.mockReturnValue({ data: buildingData, isLoading: false, error: null });
+    mockHook.mockReturnValue({
+      data: buildingData,
+      isLoading: false,
+      error: null,
+    });
 
-    render(<Wrapper><ResidentsPage /></Wrapper>);
+    render(
+      <Wrapper>
+        <ResidentsPage />
+      </Wrapper>,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('101')).toBeInTheDocument();
@@ -131,10 +185,16 @@ describe('ResidentsPage', () => {
   });
 
   test('renders search input alongside building dropdown', async () => {
-    render(<Wrapper><ResidentsPage /></Wrapper>);
+    render(
+      <Wrapper>
+        <ResidentsPage />
+      </Wrapper>,
+    );
 
     await waitFor(() => {
-      expect(screen.getByPlaceholderText('Search resident by name…')).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText('Search resident by name…'),
+      ).toBeInTheDocument();
       expect(screen.getByLabelText('Building')).toBeInTheDocument();
     });
   });

--- a/src/pages/residents/index.tsx
+++ b/src/pages/residents/index.tsx
@@ -44,21 +44,31 @@ const ResidentsPage = () => {
   const [filteredUnitId, setFilteredUnitId] = useState<number | null>(null);
   const [searchInput, setSearchInput] = useState('');
   const [buildingsError, setBuildingsError] = useState<string | null>(null);
+  const [allResidentsLoading, setAllResidentsLoading] = useState(false);
+  const [allResidentsError, setAllResidentsError] = useState<string | null>(null);
 
   const { data, isLoading, error: residentsError } = useResidentsByBuilding(selectedBuildingId);
 
-  const visibleData =
-    filteredUnitId !== null
-      ? data.filter((d) => d.unit.id === filteredUnitId)
-      : searchInput
-        ? data.filter((d) =>
-            d.residents.some((r) => r.name.toLowerCase().includes(searchInput.toLowerCase())),
-          )
-        : data;
+  let visibleData = data;
+  if (filteredUnitId !== null) {
+    visibleData = visibleData.filter((d) => d.unit.id === filteredUnitId);
+  }
+  if (searchInput) {
+    visibleData = visibleData.filter((d) =>
+      d.residents.some((r) => r.name.toLowerCase().includes(searchInput.toLowerCase())),
+    );
+  }
 
   useEffect(() => {
     getBuildings(user).then(setBuildings).catch(() => setBuildingsError('Failed to load buildings'));
-    getAllResidents(user).then(setAllResidents).catch(() => {});
+    setAllResidentsLoading(true);
+    getAllResidents(user)
+      .then((residents) => {
+        setAllResidents(residents);
+        setAllResidentsError(null);
+      })
+      .catch(() => setAllResidentsError('Failed to load residents'))
+      .finally(() => setAllResidentsLoading(false));
   }, [user]);
 
   const handleBuildingChange = (e: SelectChangeEvent<number>) => {
@@ -107,6 +117,8 @@ const ResidentsPage = () => {
           onInputChange={handleSearchInputChange}
           onChange={handleSearchSelect}
           noOptionsText="No residents found"
+          loading={allResidentsLoading}
+          disabled={allResidentsLoading}
           renderInput={(params) => (
             <TextField
               {...params}
@@ -163,6 +175,11 @@ const ResidentsPage = () => {
       {residentsError && (
         <SnackbarAlert open severity="warning" onClose={() => {}}>
           {residentsError}
+        </SnackbarAlert>
+      )}
+      {allResidentsError && (
+        <SnackbarAlert open severity="warning" onClose={() => setAllResidentsError(null)}>
+          {allResidentsError}
         </SnackbarAlert>
       )}
     </Box>

--- a/src/pages/residents/index.tsx
+++ b/src/pages/residents/index.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useContext } from 'react';
 import {
+  Autocomplete,
   Box,
   CircularProgress,
   FormControl,
@@ -12,49 +13,110 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  TextField,
   Typography,
 } from '@mui/material';
+import { createFilterOptions } from '@mui/material/Autocomplete';
 import { UserContext } from '../../components/contexts/UserContext';
 import { Building } from '../../types/interfaces';
-import { getBuildings } from '../../services/checkoutService';
+import { getBuildings, getAllResidents } from '../../services/residentService';
 import { useResidentsByBuilding } from './useResidentsByBuilding';
 import SnackbarAlert from '../../components/SnackbarAlert';
+
+type ResidentSearchResult = {
+  id: number;
+  name: string;
+  unit_id: number;
+  unit_number: string;
+  building_id: number;
+  building_code: string;
+};
+
+const filterOptions = createFilterOptions<ResidentSearchResult>({
+  stringify: (o) => o.name,
+});
 
 const ResidentsPage = () => {
   const { user } = useContext(UserContext);
   const [buildings, setBuildings] = useState<Building[]>([]);
+  const [allResidents, setAllResidents] = useState<ResidentSearchResult[]>([]);
   const [selectedBuildingId, setSelectedBuildingId] = useState<number | null>(null);
+  const [filteredUnitId, setFilteredUnitId] = useState<number | null>(null);
+  const [searchInput, setSearchInput] = useState('');
   const [buildingsError, setBuildingsError] = useState<string | null>(null);
 
   const { data, isLoading, error: residentsError } = useResidentsByBuilding(selectedBuildingId);
 
+  const visibleData =
+    filteredUnitId !== null
+      ? data.filter((d) => d.unit.id === filteredUnitId)
+      : searchInput
+        ? data.filter((d) =>
+            d.residents.some((r) => r.name.toLowerCase().includes(searchInput.toLowerCase())),
+          )
+        : data;
+
   useEffect(() => {
-    getBuildings(user)
-      .then(setBuildings)
-      .catch(() => setBuildingsError('Failed to load buildings'));
+    getBuildings(user).then(setBuildings).catch(() => setBuildingsError('Failed to load buildings'));
+    getAllResidents(user).then(setAllResidents).catch(() => {});
   }, [user]);
 
   const handleBuildingChange = (e: SelectChangeEvent<number>) => {
     setSelectedBuildingId(e.target.value as number);
+    setFilteredUnitId(null);
+  };
+
+  const handleSearchSelect = (_: React.SyntheticEvent, value: ResidentSearchResult | null) => {
+    if (!value) {
+      setFilteredUnitId(null);
+      return;
+    }
+    setSelectedBuildingId(value.building_id);
+    setFilteredUnitId(value.unit_id);
+  };
+
+  const handleSearchInputChange = (_: React.SyntheticEvent, value: string, reason: string) => {
+    setSearchInput(value);
+    if (reason === 'clear') setFilteredUnitId(null);
   };
 
   return (
     <Box>
-      <FormControl sx={{ minWidth: 240, mb: 3, mt: 3 }}>
-        <InputLabel id="building-select-label">Building</InputLabel>
-        <Select
-          labelId="building-select-label"
-          value={selectedBuildingId ?? ''}
-          label="Building"
-          onChange={handleBuildingChange}
-        >
-          {buildings.map((b) => (
-            <MenuItem key={b.id} value={b.id}>
-              {b.code} — {b.name}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mt: 3, mb: 3 }}>
+        <FormControl sx={{ minWidth: 240 }}>
+          <InputLabel id="building-select-label">Building</InputLabel>
+          <Select
+            labelId="building-select-label"
+            value={selectedBuildingId ?? ''}
+            label="Building"
+            onChange={handleBuildingChange}
+          >
+            {buildings.map((b) => (
+              <MenuItem key={b.id} value={b.id}>
+                {b.code} — {b.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <Autocomplete
+          options={allResidents}
+          getOptionLabel={(o) => `${o.name} — Unit ${o.unit_number} · ${o.building_code}`}
+          filterOptions={filterOptions}
+          inputValue={searchInput}
+          onInputChange={handleSearchInputChange}
+          onChange={handleSearchSelect}
+          noOptionsText="No residents found"
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              variant="standard"
+              placeholder="Search resident by name…"
+            />
+          )}
+          sx={{ flexGrow: 1 }}
+        />
+      </Box>
 
       {isLoading && (
         <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
@@ -62,11 +124,11 @@ const ResidentsPage = () => {
         </Box>
       )}
 
-      {!isLoading && selectedBuildingId !== null && data.length === 0 && (
-        <Typography color="text.secondary">No units found for this building.</Typography>
+      {!isLoading && selectedBuildingId !== null && visibleData.length === 0 && (
+        <Typography color="text.secondary">No units found.</Typography>
       )}
 
-      {!isLoading && data.length > 0 && (
+      {!isLoading && visibleData.length > 0 && (
         <Table size="small">
           <TableHead>
             <TableRow>
@@ -75,7 +137,7 @@ const ResidentsPage = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {data.map(({ unit, residents }) => (
+            {visibleData.map(({ unit, residents }) => (
               <TableRow key={unit.id} hover>
                 <TableCell>{unit.unit_number}</TableCell>
                 <TableCell>

--- a/src/pages/residents/index.tsx
+++ b/src/pages/residents/index.tsx
@@ -1,0 +1,110 @@
+import { useState, useEffect, useContext } from 'react';
+import {
+  Box,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { UserContext } from '../../components/contexts/UserContext';
+import { Building } from '../../types/interfaces';
+import { getBuildings } from '../../services/checkoutService';
+import { useResidentsByBuilding } from './useResidentsByBuilding';
+import SnackbarAlert from '../../components/SnackbarAlert';
+
+const ResidentsPage = () => {
+  const { user } = useContext(UserContext);
+  const [buildings, setBuildings] = useState<Building[]>([]);
+  const [selectedBuildingId, setSelectedBuildingId] = useState<number | null>(null);
+  const [buildingsError, setBuildingsError] = useState<string | null>(null);
+
+  const { data, isLoading, error: residentsError } = useResidentsByBuilding(selectedBuildingId);
+
+  useEffect(() => {
+    getBuildings(user)
+      .then(setBuildings)
+      .catch(() => setBuildingsError('Failed to load buildings'));
+  }, [user]);
+
+  const handleBuildingChange = (e: SelectChangeEvent<number>) => {
+    setSelectedBuildingId(e.target.value as number);
+  };
+
+  return (
+    <Box>
+      <FormControl sx={{ minWidth: 240, mb: 3, mt: 3 }}>
+        <InputLabel id="building-select-label">Building</InputLabel>
+        <Select
+          labelId="building-select-label"
+          value={selectedBuildingId ?? ''}
+          label="Building"
+          onChange={handleBuildingChange}
+        >
+          {buildings.map((b) => (
+            <MenuItem key={b.id} value={b.id}>
+              {b.code} — {b.name}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      {isLoading && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
+          <CircularProgress />
+        </Box>
+      )}
+
+      {!isLoading && selectedBuildingId !== null && data.length === 0 && (
+        <Typography color="text.secondary">No units found for this building.</Typography>
+      )}
+
+      {!isLoading && data.length > 0 && (
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ fontWeight: 'bold' }}>Unit</TableCell>
+              <TableCell sx={{ fontWeight: 'bold' }}>Residents</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data.map(({ unit, residents }) => (
+              <TableRow key={unit.id} hover>
+                <TableCell>{unit.unit_number}</TableCell>
+                <TableCell>
+                  {residents.length === 0 ? (
+                    <Typography variant="body2" color="text.secondary">
+                      —
+                    </Typography>
+                  ) : (
+                    residents.map((r) => r.name).join(', ')
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      {buildingsError && (
+        <SnackbarAlert open severity="warning" onClose={() => setBuildingsError(null)}>
+          {buildingsError}
+        </SnackbarAlert>
+      )}
+      {residentsError && (
+        <SnackbarAlert open severity="warning" onClose={() => {}}>
+          {residentsError}
+        </SnackbarAlert>
+      )}
+    </Box>
+  );
+};
+
+export default ResidentsPage;

--- a/src/pages/residents/index.tsx
+++ b/src/pages/residents/index.tsx
@@ -61,14 +61,19 @@ const ResidentsPage = () => {
 
   useEffect(() => {
     getBuildings(user).then(setBuildings).catch(() => setBuildingsError('Failed to load buildings'));
-    setAllResidentsLoading(true);
-    getAllResidents(user)
-      .then((residents) => {
+    async function fetchResidents() {
+      setAllResidentsLoading(true);
+      try {
+        const residents = await getAllResidents(user);
         setAllResidents(residents);
         setAllResidentsError(null);
-      })
-      .catch(() => setAllResidentsError('Failed to load residents'))
-      .finally(() => setAllResidentsLoading(false));
+      } catch {
+        setAllResidentsError('Failed to load residents');
+      } finally {
+        setAllResidentsLoading(false);
+      }
+    }
+    fetchResidents();
   }, [user]);
 
   const handleBuildingChange = (e: SelectChangeEvent<number>) => {

--- a/src/pages/residents/index.tsx
+++ b/src/pages/residents/index.tsx
@@ -60,7 +60,12 @@ const ResidentsPage = () => {
   }
 
   useEffect(() => {
-    getBuildings(user).then(setBuildings).catch(() => setBuildingsError('Failed to load buildings'));
+    getBuildings(user)
+      .then((loadedBuildings) => {
+        setBuildings(loadedBuildings);
+        setBuildingsError(null);
+      })
+      .catch(() => setBuildingsError('Failed to load buildings'));
     async function fetchResidents() {
       setAllResidentsLoading(true);
       try {
@@ -91,8 +96,12 @@ const ResidentsPage = () => {
   };
 
   const handleSearchInputChange = (_: React.SyntheticEvent, value: string, reason: string) => {
-    setSearchInput(value);
-    if (reason === 'clear') setFilteredUnitId(null);
+    if (reason === 'input') {
+      setSearchInput(value);
+    } else if (reason === 'clear' || reason === 'reset') {
+      setSearchInput('');
+      setFilteredUnitId(null);
+    }
   };
 
   return (

--- a/src/pages/residents/useResidentsByBuilding.test.ts
+++ b/src/pages/residents/useResidentsByBuilding.test.ts
@@ -1,0 +1,106 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { UserContext } from '../../components/contexts/UserContext';
+import { useResidentsByBuilding } from './useResidentsByBuilding';
+import * as residentService from '../../services/residentService';
+
+vi.mock('../../services/residentService');
+
+const dummyUser = { userID: '1', userDetails: 'Test User', userRoles: ['admin'], claims: [] };
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(UserContext.Provider, {
+    value: {
+      user: dummyUser,
+      setUser: vi.fn(),
+      loggedInUserId: 1,
+      setLoggedInUserId: vi.fn(),
+      activeVolunteers: [],
+      setActiveVolunteers: vi.fn(),
+      isLoading: false,
+    },
+    children,
+  });
+
+const mockRows = [
+  { id: 1, name: 'Alice', unit_id: 10, unit_number: '2',  building_id: 1, building_name: 'B', building_code: 'B1' },
+  { id: 2, name: 'Bob',   unit_id: 10, unit_number: '2',  building_id: 1, building_name: 'B', building_code: 'B1' },
+  { id: 3, name: 'Carol', unit_id: 20, unit_number: '10', building_id: 1, building_name: 'B', building_code: 'B1' },
+];
+
+describe('useResidentsByBuilding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns empty data when buildingId is null', () => {
+    const { result } = renderHook(() => useResidentsByBuilding(null), { wrapper });
+    expect(result.current.data).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('groups flat rows into units with residents', async () => {
+    vi.mocked(residentService.getResidentsByBuilding).mockResolvedValue(mockRows);
+
+    const { result } = renderHook(() => useResidentsByBuilding(1), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).toHaveLength(2);
+    const unit2 = result.current.data.find((d) => d.unit.unit_number === '2');
+    expect(unit2?.residents).toHaveLength(2);
+    expect(unit2?.residents.map((r) => r.name)).toEqual(['Alice', 'Bob']);
+  });
+
+  it('sorts units numerically by unit_number', async () => {
+    vi.mocked(residentService.getResidentsByBuilding).mockResolvedValue(mockRows);
+
+    const { result } = renderHook(() => useResidentsByBuilding(1), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const unitNumbers = result.current.data.map((d) => d.unit.unit_number);
+    expect(unitNumbers).toEqual(['2', '10']); // numeric order, not lexicographic
+  });
+
+  it('sets isLoading true while fetching', async () => {
+    let resolve: (v: typeof mockRows) => void;
+    vi.mocked(residentService.getResidentsByBuilding).mockReturnValue(
+      new Promise((r) => { resolve = r; }),
+    );
+
+    const { result } = renderHook(() => useResidentsByBuilding(1), { wrapper });
+
+    expect(result.current.isLoading).toBe(true);
+    resolve!(mockRows);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+  });
+
+  it('sets error when fetch fails', async () => {
+    vi.mocked(residentService.getResidentsByBuilding).mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useResidentsByBuilding(1), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBe('Failed to load residents');
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('refetches when buildingId changes', async () => {
+    vi.mocked(residentService.getResidentsByBuilding).mockResolvedValue(mockRows);
+
+    const { rerender } = renderHook(({ id }) => useResidentsByBuilding(id), {
+      wrapper,
+      initialProps: { id: 1 as number | null },
+    });
+
+    await waitFor(() => expect(residentService.getResidentsByBuilding).toHaveBeenCalledTimes(1));
+
+    rerender({ id: 2 });
+
+    await waitFor(() => expect(residentService.getResidentsByBuilding).toHaveBeenCalledTimes(2));
+    expect(residentService.getResidentsByBuilding).toHaveBeenLastCalledWith(dummyUser, 2);
+  });
+});

--- a/src/pages/residents/useResidentsByBuilding.ts
+++ b/src/pages/residents/useResidentsByBuilding.ts
@@ -1,0 +1,67 @@
+import { useState, useEffect, useContext } from 'react';
+import { UserContext } from '../../components/contexts/UserContext';
+import { Unit } from '../../types/interfaces';
+import { getResidentsByBuilding } from '../../services/checkoutService';
+
+export type UnitWithResidents = {
+  unit: Unit;
+  residents: Array<{ id: number; name: string }>;
+};
+
+export function useResidentsByBuilding(buildingId: number | null) {
+  const { user } = useContext(UserContext);
+  const [data, setData] = useState<UnitWithResidents[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (buildingId === null) {
+      setData([]);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchData() {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const rows = await getResidentsByBuilding(user, buildingId!);
+
+        const unitMap = new Map<number, UnitWithResidents>();
+        for (const row of rows) {
+          if (!unitMap.has(row.unit_id)) {
+            unitMap.set(row.unit_id, {
+              unit: { id: row.unit_id, unit_number: row.unit_number },
+              residents: [],
+            });
+          }
+          unitMap.get(row.unit_id)!.residents.push({ id: row.id, name: row.name });
+        }
+
+        const result = Array.from(unitMap.values()).sort((a, b) =>
+          a.unit.unit_number.localeCompare(b.unit.unit_number, undefined, { numeric: true }),
+        );
+
+        if (!cancelled) {
+          setData(result);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError('Failed to load residents');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    fetchData();
+    return () => {
+      cancelled = true;
+    };
+  }, [buildingId, user]);
+
+  return { data, isLoading, error };
+}

--- a/src/pages/residents/useResidentsByBuilding.ts
+++ b/src/pages/residents/useResidentsByBuilding.ts
@@ -24,6 +24,7 @@ export function useResidentsByBuilding(buildingId: number | null) {
 
     async function fetchData() {
       setIsLoading(true);
+      setData([]);
       setError(null);
       try {
         const rows = await getResidentsByBuilding(user, buildingId!);
@@ -36,17 +37,21 @@ export function useResidentsByBuilding(buildingId: number | null) {
               residents: [],
             });
           }
-          unitMap.get(row.unit_id)!.residents.push({ id: row.id, name: row.name });
+          unitMap
+            .get(row.unit_id)!
+            .residents.push({ id: row.id, name: row.name });
         }
 
         const result = Array.from(unitMap.values()).sort((a, b) =>
-          a.unit.unit_number.localeCompare(b.unit.unit_number, undefined, { numeric: true }),
+          a.unit.unit_number.localeCompare(b.unit.unit_number, undefined, {
+            numeric: true,
+          }),
         );
 
         if (!cancelled) {
           setData(result);
         }
-      } catch (err) {
+      } catch {
         if (!cancelled) {
           setError('Failed to load residents');
         }

--- a/src/pages/residents/useResidentsByBuilding.ts
+++ b/src/pages/residents/useResidentsByBuilding.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useContext } from 'react';
 import { UserContext } from '../../components/contexts/UserContext';
 import { Unit } from '../../types/interfaces';
-import { getResidentsByBuilding } from '../../services/checkoutService';
+import { getResidentsByBuilding } from '../../services/residentService';
 
 export type UnitWithResidents = {
   unit: Unit;

--- a/src/pages/routes.tsx
+++ b/src/pages/routes.tsx
@@ -9,6 +9,7 @@ import People from '../pages/people';
 import Inventory from './inventory';
 import CheckoutPageContainer from './checkout/CheckoutPageContainer';
 import HistoryPage from './history';
+import ResidentsPage from './residents';
 import { RootRedirect } from './RootRedirect';
 
 const routes = [
@@ -72,6 +73,16 @@ const routes = [
           <RootRedirect source="history">
             <MainContainer title="History">
               <HistoryPage />
+            </MainContainer>
+          </RootRedirect>
+        ),
+      },
+      {
+        path: 'residents',
+        element: (
+          <RootRedirect source="residents">
+            <MainContainer title="Manage Residents">
+              <ResidentsPage />
             </MainContainer>
           </RootRedirect>
         ),

--- a/src/services/checkoutService.test.tsx
+++ b/src/services/checkoutService.test.tsx
@@ -3,15 +3,9 @@ import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import {
   processWelcomeBasket,
   processGeneralItems,
-  getBuildings,
-  getUnitNumbers,
-  getResidents,
-  findResident,
-  addResident,
   checkPastCheckout,
-  getLastResidentVisit,
 } from './checkoutService';
-import { API_HEADERS, ENDPOINTS, SETTINGS } from '../types/constants';
+import { API_HEADERS, ENDPOINTS } from '../types/constants';
 import { getRole } from '../utils/userUtils';
 
 vi.mock('../utils/userUtils', () => ({
@@ -144,162 +138,6 @@ describe('checkoutService', () => {
     });
   });
 
-  describe('getBuildings', () => {
-    it('should fetch buildings successfully', async () => {
-      const mockBuildings = { value: [{ id: 1, code: 'A' }] };
-      (fetch as Mock).mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockBuildings),
-      });
-
-      const result = await getBuildings(user);
-
-      expect(fetch).toHaveBeenCalledWith(ENDPOINTS.BUILDINGS, {
-        headers: { ...API_HEADERS, 'X-MS-API-ROLE': 'admin' },
-        method: 'GET',
-      });
-      expect(result).toEqual(mockBuildings.value);
-    });
-
-    it('should throw an error if the request fails', async () => {
-      (fetch as Mock).mockResolvedValue({
-        ok: false,
-        statusText: 'Error',
-        clone: () => ({ json: () => Promise.reject(new Error()), text: () => Promise.resolve('') }),
-      });
-
-      await expect(getBuildings(user)).rejects.toThrow('Error');
-    });
-  });
-
-  describe('getUnitNumbers', () => {
-    const buildingId = 1;
-
-    it('should fetch unit numbers successfully', async () => {
-      const mockUnits = { value: [{ id: 1, unit_number: '101' }] };
-      (fetch as Mock).mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockUnits),
-      });
-
-      const result = await getUnitNumbers(user, buildingId);
-
-      expect(fetch).toHaveBeenCalledWith(`${ENDPOINTS.UNITS}?$filter=building_id eq ${buildingId}&$first=${SETTINGS.api_fetch_limit_units}`, {
-        method: 'GET',
-        headers: { ...API_HEADERS, 'X-MS-API-ROLE': 'admin' },
-      });
-      expect(result).toEqual(mockUnits.value);
-    });
-
-    it('should throw an error if the request fails', async () => {
-      (fetch as Mock).mockResolvedValue({
-        ok: false,
-        statusText: 'Error',
-        clone: () => ({ json: () => Promise.reject(new Error()), text: () => Promise.resolve('') }),
-      });
-
-      await expect(getUnitNumbers(user, buildingId)).rejects.toThrow('Error');
-    });
-  });
-
-  describe('getResidents', () => {
-    const unitId = 1;
-
-    it('should fetch residents successfully', async () => {
-      const mockResidents = { value: [{ id: 1, name: 'John Doe' }] };
-      (fetch as Mock).mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockResidents),
-      });
-
-      const result = await getResidents(user, unitId);
-
-      expect(fetch).toHaveBeenCalledWith(`${ENDPOINTS.RESIDENTS}?$filter=unit_id eq ${unitId}`, {
-        method: 'GET',
-        headers: { ...API_HEADERS, 'X-MS-API-ROLE': 'admin' },
-      });
-      expect(result).toEqual(mockResidents);
-    });
-
-    it('should throw an error if the request fails', async () => {
-      (fetch as Mock).mockResolvedValue({
-        ok: false,
-        statusText: 'Error',
-        clone: () => ({ json: () => Promise.reject(new Error()), text: () => Promise.resolve('') }),
-      });
-
-      await expect(getResidents(user, unitId)).rejects.toThrow('Error');
-    });
-  });
-
-  describe('findResident', () => {
-    const unitId = 1;
-    const name = "John's Doe";
-
-    it('should find a resident successfully', async () => {
-      const mockResident = { value: [{ id: 1, name: "John's Doe" }] };
-      (fetch as Mock).mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockResident),
-      });
-
-      const result = await findResident(user, name, unitId);
-      const safeName = name.replace(/'/g, "''");
-      const filter = encodeURIComponent(`name eq '${safeName}' and unit_id eq ${unitId}`);
-
-      expect(fetch).toHaveBeenCalledWith(`${ENDPOINTS.RESIDENTS}?$filter=${filter}`, {
-        method: 'GET',
-        headers: { ...API_HEADERS, 'X-MS-API-ROLE': 'admin' },
-      });
-      expect(result).toEqual(mockResident);
-    });
-
-    it('should throw an error if the request fails', async () => {
-      (fetch as Mock).mockResolvedValue({
-        ok: false,
-        statusText: 'Error',
-        clone: () => ({ json: () => Promise.reject(new Error()), text: () => Promise.resolve('') }),
-      });
-
-      await expect(findResident(user, name, unitId)).rejects.toThrow('Error');
-    });
-  });
-
-  describe('addResident', () => {
-    const unitId = 1;
-    const name = 'Jane Doe';
-
-    it('should add a resident successfully', async () => {
-      const mockResponse = { id: 2, name: 'Jane Doe' };
-      (fetch as Mock).mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockResponse),
-      });
-
-      const result = await addResident(user, name, unitId);
-
-      expect(fetch).toHaveBeenCalledWith(ENDPOINTS.RESIDENTS, {
-        method: 'POST',
-        headers: { ...API_HEADERS, 'X-MS-API-ROLE': 'admin' },
-        body: JSON.stringify({
-          name: name,
-          unit_id: unitId,
-        }),
-      });
-      expect(result).toEqual(mockResponse);
-    });
-
-    it('should throw an error if the request fails', async () => {
-      (fetch as Mock).mockResolvedValue({
-        ok: false,
-        statusText: 'Error',
-        clone: () => ({ json: () => Promise.reject(new Error()), text: () => Promise.resolve('') }),
-      });
-
-      await expect(addResident(user, name, unitId)).rejects.toThrow('Error');
-    });
-  });
-
   describe('checkPastCheckout', () => {
     const residentId = 1;
 
@@ -330,50 +168,6 @@ describe('checkoutService', () => {
       });
 
       await expect(checkPastCheckout(user, residentId)).rejects.toThrow('Error');
-    });
-  });
-
-  describe('getLastResidentVisit', () => {
-    const residentId = 1;
-
-    it('should fetch last resident visit successfully', async () => {
-      const mockResponse = { value: [{ transaction_date: '2025-01-15T10:30:00' }] };
-      (fetch as Mock).mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockResponse),
-      });
-
-      const result = await getLastResidentVisit(user, residentId);
-
-      expect(fetch).toHaveBeenCalledWith(ENDPOINTS.GET_LAST_RESIDENT_VISIT, {
-        method: 'POST',
-        headers: { ...API_HEADERS, 'X-MS-API-ROLE': 'admin' },
-        body: JSON.stringify({ resident_id: residentId }),
-      });
-      expect(result).toEqual(mockResponse);
-    });
-
-    it('should handle empty result when resident has no visits', async () => {
-      const mockResponse = { value: [] };
-      (fetch as Mock).mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockResponse),
-      });
-
-      const result = await getLastResidentVisit(user, residentId);
-
-      expect(result).toEqual(mockResponse);
-      expect(result.value).toEqual([]);
-    });
-
-    it('should throw an error if the request fails', async () => {
-      (fetch as Mock).mockResolvedValue({
-        ok: false,
-        statusText: 'Error',
-        clone: () => ({ json: () => Promise.reject(new Error()), text: () => Promise.resolve('') }),
-      });
-
-      await expect(getLastResidentVisit(user, residentId)).rejects.toThrow('Error');
     });
   });
 });

--- a/src/services/checkoutService.ts
+++ b/src/services/checkoutService.ts
@@ -1,13 +1,6 @@
 import { getRole } from '../utils/userUtils';
-import {
-  Building,
-  CheckoutItemProp,
-  ClientPrincipal,
-  ResidentInfo,
-  Unit,
-} from '../types/interfaces';
-import { ENDPOINTS, SETTINGS } from '../types/constants';
-import { cacheGet, cacheSet } from '../utils/sessionCache';
+import { CheckoutItemProp, ClientPrincipal, ResidentInfo } from '../types/interfaces';
+import { ENDPOINTS } from '../types/constants';
 import { apiRequest } from './apiRequest';
 
 export async function processWelcomeBasket(
@@ -69,141 +62,7 @@ export async function processGeneralItems(
   }
 }
 
-export async function getBuildings(
-  user: ClientPrincipal | null,
-) {
-  try {
-    const cachedBuildings = cacheGet<Building[]>('buildings');
-    if (cachedBuildings) {
-      return cachedBuildings;
-    }
-
-    const result = await apiRequest<Building[]>({
-      url: ENDPOINTS.BUILDINGS,
-      role: getRole(user),
-    });
-
-    result.value.sort((a: Building, b: Building) => a.code.localeCompare(b.code));
-
-    cacheSet('buildings', result.value);
-    return result.value;
-  } catch (error) {
-    console.error('Error fetching buildings:', error);
-    throw error;
-  }
-}
-
-export async function getUnitNumbers(
-  user: ClientPrincipal | null,
-  buildingId: number,
-) {
-  try {
-    const cacheKey = `units_${buildingId}`;
-    const cachedUnits = cacheGet<Unit[]>(cacheKey);
-    if (cachedUnits) {
-      return cachedUnits;
-    }
-
-    const result = await apiRequest<Unit[]>({
-      url: `${ENDPOINTS.UNITS}?$filter=building_id eq ${buildingId}&$first=${SETTINGS.api_fetch_limit_units}`,
-      role: getRole(user),
-    });
-
-    cacheSet(cacheKey, result.value);
-    return result.value;
-  } catch (error) {
-    console.error('Error fetching unit numbers:', error);
-    throw error;
-  }
-}
-
-export async function getResidentsByBuilding(
-  user: ClientPrincipal | null,
-  buildingId: number,
-) {
-  try {
-    const result = await apiRequest<Array<{
-      id: number;
-      name: string;
-      unit_id: number;
-      unit_number: string;
-      building_id: number;
-      building_name: string;
-      building_code: string;
-    }>>({
-      url: `${ENDPOINTS.RESIDENTS_BY_BUILDING}?$filter=building_id eq ${buildingId}&$orderby=unit_number`,
-      role: getRole(user),
-    });
-    return result.value;
-  } catch (error) {
-    console.error('Error fetching residents by building:', error);
-    throw error;
-  }
-}
-
-export async function getResidents(
-  user: ClientPrincipal | null,
-  unitId: number,
-) {
-  try {
-    const result = await apiRequest<Array<{ id: number; name: string }>>({
-      url: `${ENDPOINTS.RESIDENTS}?$filter=unit_id eq ${unitId}`,
-      role: getRole(user),
-    });
-    return result;
-  } catch (error) {
-    console.error('Error fetching residents:', error);
-    throw error;
-  }
-}
-
-export async function findResident(
-  user: ClientPrincipal | null,
-  name: string,
-  unitId: number,
-) {
-  try {
-    const safeName = name.replace(/'/g, "''");
-    const filter = encodeURIComponent(
-      `name eq '${safeName}' and unit_id eq ${unitId}`,
-    );
-    const result = await apiRequest<Array<{ id: number; name: string }>>({
-      url: `${ENDPOINTS.RESIDENTS}?$filter=${filter}`,
-      role: getRole(user),
-    });
-    return result;
-  } catch (error) {
-    console.error('Error fetching residents:', error);
-    throw error;
-  }
-}
-
-export async function addResident(
-  user: ClientPrincipal | null,
-  name: string,
-  unitId: number,
-) {
-  try {
-    const result = await apiRequest<Array<{ id: number; name: string }>>({
-      url: ENDPOINTS.RESIDENTS,
-      role: getRole(user),
-      method: 'POST',
-      body: {
-        name: name,
-        unit_id: unitId,
-      },
-    });
-    return result;
-  } catch (error) {
-    console.error('Error adding a resident:', error);
-    throw error;
-  }
-}
-
-export async function checkPastCheckout(
-  user: ClientPrincipal | null,
-  residentId: number,
-) {
+export async function checkPastCheckout(user: ClientPrincipal | null, residentId: number) {
   try {
     const result = await apiRequest<Array<{
       id: number;
@@ -215,31 +74,11 @@ export async function checkPastCheckout(
       url: ENDPOINTS.CHECK_PAST_CHECKOUT,
       role: getRole(user),
       method: 'POST',
-      body: {
-        resident_id: residentId,
-      },
-    });
-    return result;
-  } catch (error) {
-    console.error('Error checking for a past checkout:', error);
-    throw error;
-  }
-}
-
-export async function getLastResidentVisit(
-  user: ClientPrincipal | null,
-  residentId: number,
-) {
-  try {
-    const result = await apiRequest({
-      url: ENDPOINTS.GET_LAST_RESIDENT_VISIT,
-      role: getRole(user),
-      method: 'POST',
       body: { resident_id: residentId },
     });
     return result;
   } catch (error) {
-    console.error('Error fetching last resident visit:', error);
+    console.error('Error checking for a past checkout:', error);
     throw error;
   }
 }

--- a/src/services/checkoutService.ts
+++ b/src/services/checkoutService.ts
@@ -117,6 +117,30 @@ export async function getUnitNumbers(
   }
 }
 
+export async function getResidentsByBuilding(
+  user: ClientPrincipal | null,
+  buildingId: number,
+) {
+  try {
+    const result = await apiRequest<Array<{
+      id: number;
+      name: string;
+      unit_id: number;
+      unit_number: string;
+      building_id: number;
+      building_name: string;
+      building_code: string;
+    }>>({
+      url: `${ENDPOINTS.RESIDENTS_BY_BUILDING}?$filter=building_id eq ${buildingId}&$orderby=unit_number`,
+      role: getRole(user),
+    });
+    return result.value;
+  } catch (error) {
+    console.error('Error fetching residents by building:', error);
+    throw error;
+  }
+}
+
 export async function getResidents(
   user: ClientPrincipal | null,
   unitId: number,

--- a/src/services/residentService.test.tsx
+++ b/src/services/residentService.test.tsx
@@ -1,0 +1,225 @@
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import {
+  getBuildings,
+  getUnitNumbers,
+  getResidents,
+  findResident,
+  addResident,
+  getLastResidentVisit,
+} from './residentService';
+import { API_HEADERS, ENDPOINTS, SETTINGS } from '../types/constants';
+import { getRole } from '../utils/userUtils';
+
+vi.mock('../utils/userUtils', () => ({
+  getRole: vi.fn(),
+}));
+
+global.fetch = vi.fn();
+
+describe('residentService', () => {
+  const user = { userDetails: 'testuser' } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    (getRole as Mock).mockReturnValue('admin');
+  });
+
+  describe('getBuildings', () => {
+    it('should fetch buildings successfully', async () => {
+      const mockBuildings = { value: [{ id: 1, code: 'A' }] };
+      (fetch as Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockBuildings),
+      });
+
+      const result = await getBuildings(user);
+
+      expect(fetch).toHaveBeenCalledWith(ENDPOINTS.BUILDINGS, {
+        headers: { ...API_HEADERS, 'X-MS-API-ROLE': 'admin' },
+        method: 'GET',
+      });
+      expect(result).toEqual(mockBuildings.value);
+    });
+
+    it('should throw an error if the request fails', async () => {
+      (fetch as Mock).mockResolvedValue({
+        ok: false,
+        statusText: 'Error',
+        clone: () => ({ json: () => Promise.reject(new Error()), text: () => Promise.resolve('') }),
+      });
+
+      await expect(getBuildings(user)).rejects.toThrow('Error');
+    });
+  });
+
+  describe('getUnitNumbers', () => {
+    const buildingId = 1;
+
+    it('should fetch unit numbers successfully', async () => {
+      const mockUnits = { value: [{ id: 1, unit_number: '101' }] };
+      (fetch as Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockUnits),
+      });
+
+      const result = await getUnitNumbers(user, buildingId);
+
+      expect(fetch).toHaveBeenCalledWith(`${ENDPOINTS.UNITS}?$filter=building_id eq ${buildingId}&$first=${SETTINGS.api_fetch_limit_units}`, {
+        method: 'GET',
+        headers: { ...API_HEADERS, 'X-MS-API-ROLE': 'admin' },
+      });
+      expect(result).toEqual(mockUnits.value);
+    });
+
+    it('should throw an error if the request fails', async () => {
+      (fetch as Mock).mockResolvedValue({
+        ok: false,
+        statusText: 'Error',
+        clone: () => ({ json: () => Promise.reject(new Error()), text: () => Promise.resolve('') }),
+      });
+
+      await expect(getUnitNumbers(user, buildingId)).rejects.toThrow('Error');
+    });
+  });
+
+  describe('getResidents', () => {
+    const unitId = 1;
+
+    it('should fetch residents successfully', async () => {
+      const mockResidents = { value: [{ id: 1, name: 'John Doe' }] };
+      (fetch as Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResidents),
+      });
+
+      const result = await getResidents(user, unitId);
+
+      expect(fetch).toHaveBeenCalledWith(`${ENDPOINTS.RESIDENTS}?$filter=unit_id eq ${unitId}`, {
+        method: 'GET',
+        headers: { ...API_HEADERS, 'X-MS-API-ROLE': 'admin' },
+      });
+      expect(result).toEqual(mockResidents);
+    });
+
+    it('should throw an error if the request fails', async () => {
+      (fetch as Mock).mockResolvedValue({
+        ok: false,
+        statusText: 'Error',
+        clone: () => ({ json: () => Promise.reject(new Error()), text: () => Promise.resolve('') }),
+      });
+
+      await expect(getResidents(user, unitId)).rejects.toThrow('Error');
+    });
+  });
+
+  describe('findResident', () => {
+    const unitId = 1;
+    const name = "John's Doe";
+
+    it('should find a resident successfully', async () => {
+      const mockResident = { value: [{ id: 1, name: "John's Doe" }] };
+      (fetch as Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResident),
+      });
+
+      const result = await findResident(user, name, unitId);
+      const safeName = name.replace(/'/g, "''");
+      const filter = encodeURIComponent(`name eq '${safeName}' and unit_id eq ${unitId}`);
+
+      expect(fetch).toHaveBeenCalledWith(`${ENDPOINTS.RESIDENTS}?$filter=${filter}`, {
+        method: 'GET',
+        headers: { ...API_HEADERS, 'X-MS-API-ROLE': 'admin' },
+      });
+      expect(result).toEqual(mockResident);
+    });
+
+    it('should throw an error if the request fails', async () => {
+      (fetch as Mock).mockResolvedValue({
+        ok: false,
+        statusText: 'Error',
+        clone: () => ({ json: () => Promise.reject(new Error()), text: () => Promise.resolve('') }),
+      });
+
+      await expect(findResident(user, name, unitId)).rejects.toThrow('Error');
+    });
+  });
+
+  describe('addResident', () => {
+    const unitId = 1;
+    const name = 'Jane Doe';
+
+    it('should add a resident successfully', async () => {
+      const mockResponse = { id: 2, name: 'Jane Doe' };
+      (fetch as Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const result = await addResident(user, name, unitId);
+
+      expect(fetch).toHaveBeenCalledWith(ENDPOINTS.RESIDENTS, {
+        method: 'POST',
+        headers: { ...API_HEADERS, 'X-MS-API-ROLE': 'admin' },
+        body: JSON.stringify({ name, unit_id: unitId }),
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should throw an error if the request fails', async () => {
+      (fetch as Mock).mockResolvedValue({
+        ok: false,
+        statusText: 'Error',
+        clone: () => ({ json: () => Promise.reject(new Error()), text: () => Promise.resolve('') }),
+      });
+
+      await expect(addResident(user, name, unitId)).rejects.toThrow('Error');
+    });
+  });
+
+  describe('getLastResidentVisit', () => {
+    const residentId = 1;
+
+    it('should fetch last resident visit successfully', async () => {
+      const mockResponse = { value: [{ transaction_date: '2025-01-15T10:30:00' }] };
+      (fetch as Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const result = await getLastResidentVisit(user, residentId);
+
+      expect(fetch).toHaveBeenCalledWith(ENDPOINTS.GET_LAST_RESIDENT_VISIT, {
+        method: 'POST',
+        headers: { ...API_HEADERS, 'X-MS-API-ROLE': 'admin' },
+        body: JSON.stringify({ resident_id: residentId }),
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should handle empty result when resident has no visits', async () => {
+      const mockResponse = { value: [] };
+      (fetch as Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const result = await getLastResidentVisit(user, residentId);
+
+      expect(result).toEqual(mockResponse);
+      expect(result.value).toEqual([]);
+    });
+
+    it('should throw an error if the request fails', async () => {
+      (fetch as Mock).mockResolvedValue({
+        ok: false,
+        statusText: 'Error',
+        clone: () => ({ json: () => Promise.reject(new Error()), text: () => Promise.resolve('') }),
+      });
+
+      await expect(getLastResidentVisit(user, residentId)).rejects.toThrow('Error');
+    });
+  });
+});

--- a/src/services/residentService.test.tsx
+++ b/src/services/residentService.test.tsx
@@ -6,6 +6,8 @@ import {
   getResidents,
   findResident,
   addResident,
+  getResidentsByBuilding,
+  getAllResidents,
   getLastResidentVisit,
 } from './residentService';
 import { API_HEADERS, ENDPOINTS, SETTINGS } from '../types/constants';
@@ -176,6 +178,64 @@ describe('residentService', () => {
       });
 
       await expect(addResident(user, name, unitId)).rejects.toThrow('Error');
+    });
+  });
+
+  describe('getResidentsByBuilding', () => {
+    const buildingId = 2;
+
+    it('should fetch residents filtered by building successfully', async () => {
+      const mockResponse = {
+        value: [{ id: 1, name: 'Jane', unit_id: 10, unit_number: '101', building_id: 2, building_name: 'B', building_code: 'B2' }],
+      };
+      (fetch as Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const result = await getResidentsByBuilding(user, buildingId);
+
+      const expectedUrl = `${ENDPOINTS.RESIDENTS_BY_BUILDING}?$filter=building_id eq ${buildingId}&$orderby=unit_number`;
+      expect(fetch).toHaveBeenCalledWith(expectedUrl, expect.objectContaining({ method: 'GET' }));
+      expect(result).toEqual(mockResponse.value);
+    });
+
+    it('should throw an error if the request fails', async () => {
+      (fetch as Mock).mockResolvedValue({
+        ok: false,
+        statusText: 'Error',
+        clone: () => ({ json: () => Promise.reject(new Error()), text: () => Promise.resolve('') }),
+      });
+
+      await expect(getResidentsByBuilding(user, buildingId)).rejects.toThrow('Error');
+    });
+  });
+
+  describe('getAllResidents', () => {
+    it('should fetch all residents with a high limit', async () => {
+      const mockResponse = { value: [{ id: 1, name: 'Jane', unit_id: 10, unit_number: '101', building_id: 2, building_name: 'B', building_code: 'B2' }] };
+      (fetch as Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const result = await getAllResidents(user);
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('$first=10000'),
+        expect.objectContaining({ method: 'GET' }),
+      );
+      expect(result).toEqual(mockResponse.value);
+    });
+
+    it('should throw an error if the request fails', async () => {
+      (fetch as Mock).mockResolvedValue({
+        ok: false,
+        statusText: 'Error',
+        clone: () => ({ json: () => Promise.reject(new Error()), text: () => Promise.resolve('') }),
+      });
+
+      await expect(getAllResidents(user)).rejects.toThrow('Error');
     });
   });
 

--- a/src/services/residentService.ts
+++ b/src/services/residentService.ts
@@ -1,0 +1,148 @@
+import { getRole } from '../utils/userUtils';
+import { Building, ClientPrincipal, Unit } from '../types/interfaces';
+import { ENDPOINTS, SETTINGS } from '../types/constants';
+import { cacheGet, cacheSet } from '../utils/sessionCache';
+import { apiRequest } from './apiRequest';
+
+export async function getBuildings(user: ClientPrincipal | null) {
+  try {
+    const cachedBuildings = cacheGet<Building[]>('buildings');
+    if (cachedBuildings) {
+      return cachedBuildings;
+    }
+
+    const result = await apiRequest<Building[]>({
+      url: ENDPOINTS.BUILDINGS,
+      role: getRole(user),
+    });
+
+    result.value.sort((a: Building, b: Building) => a.code.localeCompare(b.code));
+
+    cacheSet('buildings', result.value);
+    return result.value;
+  } catch (error) {
+    console.error('Error fetching buildings:', error);
+    throw error;
+  }
+}
+
+export async function getUnitNumbers(user: ClientPrincipal | null, buildingId: number) {
+  try {
+    const cacheKey = `units_${buildingId}`;
+    const cachedUnits = cacheGet<Unit[]>(cacheKey);
+    if (cachedUnits) {
+      return cachedUnits;
+    }
+
+    const result = await apiRequest<Unit[]>({
+      url: `${ENDPOINTS.UNITS}?$filter=building_id eq ${buildingId}&$first=${SETTINGS.api_fetch_limit_units}`,
+      role: getRole(user),
+    });
+
+    cacheSet(cacheKey, result.value);
+    return result.value;
+  } catch (error) {
+    console.error('Error fetching unit numbers:', error);
+    throw error;
+  }
+}
+
+export async function getResidents(user: ClientPrincipal | null, unitId: number) {
+  try {
+    const result = await apiRequest<Array<{ id: number; name: string }>>({
+      url: `${ENDPOINTS.RESIDENTS}?$filter=unit_id eq ${unitId}`,
+      role: getRole(user),
+    });
+    return result;
+  } catch (error) {
+    console.error('Error fetching residents:', error);
+    throw error;
+  }
+}
+
+export async function findResident(user: ClientPrincipal | null, name: string, unitId: number) {
+  try {
+    const safeName = name.replace(/'/g, "''");
+    const filter = encodeURIComponent(`name eq '${safeName}' and unit_id eq ${unitId}`);
+    const result = await apiRequest<Array<{ id: number; name: string }>>({
+      url: `${ENDPOINTS.RESIDENTS}?$filter=${filter}`,
+      role: getRole(user),
+    });
+    return result;
+  } catch (error) {
+    console.error('Error fetching residents:', error);
+    throw error;
+  }
+}
+
+export async function addResident(user: ClientPrincipal | null, name: string, unitId: number) {
+  try {
+    const result = await apiRequest<Array<{ id: number; name: string }>>({
+      url: ENDPOINTS.RESIDENTS,
+      role: getRole(user),
+      method: 'POST',
+      body: { name, unit_id: unitId },
+    });
+    return result;
+  } catch (error) {
+    console.error('Error adding a resident:', error);
+    throw error;
+  }
+}
+
+export async function getResidentsByBuilding(user: ClientPrincipal | null, buildingId: number) {
+  try {
+    const result = await apiRequest<Array<{
+      id: number;
+      name: string;
+      unit_id: number;
+      unit_number: string;
+      building_id: number;
+      building_name: string;
+      building_code: string;
+    }>>({
+      url: `${ENDPOINTS.RESIDENTS_BY_BUILDING}?$filter=building_id eq ${buildingId}&$orderby=unit_number`,
+      role: getRole(user),
+    });
+    return result.value;
+  } catch (error) {
+    console.error('Error fetching residents by building:', error);
+    throw error;
+  }
+}
+
+export async function getAllResidents(user: ClientPrincipal | null) {
+  try {
+    const result = await apiRequest<Array<{
+      id: number;
+      name: string;
+      unit_id: number;
+      unit_number: string;
+      building_id: number;
+      building_name: string;
+      building_code: string;
+    }>>({
+      url: `${ENDPOINTS.RESIDENTS_BY_BUILDING}?$first=10000`,
+      role: getRole(user),
+    });
+    return result.value;
+  } catch (error) {
+    console.error('Error fetching all residents:', error);
+    throw error;
+  }
+}
+
+export async function getLastResidentVisit(user: ClientPrincipal | null, residentId: number) {
+  try {
+    const result = await apiRequest({
+      url: ENDPOINTS.GET_LAST_RESIDENT_VISIT,
+      role: getRole(user),
+      method: 'POST',
+      body: { resident_id: residentId },
+    });
+    return result;
+  } catch (error) {
+    console.error('Error fetching last resident visit:', error);
+    throw error;
+  }
+}

--- a/src/services/residentService.ts
+++ b/src/services/residentService.ts
@@ -122,7 +122,7 @@ export async function getAllResidents(user: ClientPrincipal | null) {
       building_name: string;
       building_code: string;
     }>>({
-      url: `${ENDPOINTS.RESIDENTS_BY_BUILDING}?$first=10000`,
+      url: `${ENDPOINTS.RESIDENTS_BY_BUILDING}?$first=${SETTINGS.api_fetch_limit_residents}`,
       role: getRole(user),
     });
     return result.value;

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -34,6 +34,7 @@ export const ENDPOINTS = {
   //Views
   EXPANDED_ITEMS: API_PREFIX + '/itemswithcategory',
   CATEGORIZED_ITEMS: API_PREFIX + '/itemsbycategory',
+  RESIDENTS_BY_BUILDING: API_PREFIX + '/residents-by-building',
 } as const;
 
 export const SETTINGS = {
@@ -54,7 +55,7 @@ export const USER_ROLES = {
 } as const;
 
 export const ROLE_PAGES = {
-  admin: ['inventory', 'checkout', 'checkout-general', 'checkout-welcome-basket', 'people', 'history'],
+  admin: ['inventory', 'checkout', 'checkout-general', 'checkout-welcome-basket', 'people', 'residents', 'history'],
   volunteer: ['volunteer-home', 'inventory', 'checkout', 'checkout-general', 'checkout-welcome-basket', 'history'],
 } as const;
 

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -42,6 +42,7 @@ export const SETTINGS = {
   checkout_item_limit: 10,
   api_fetch_limit_items: 10000,
   api_fetch_limit_units: 1000,
+  api_fetch_limit_residents: 10000,
   database_retry_attempts: 20,
   database_retry_delay: 5000,
   slow_request_threshold: 1000,


### PR DESCRIPTION
## Description

Adds a new admin-only **Manage Residents** page at `/residents`. Admins can select a building from a dropdown to see all units and their residents in a table, and search for a resident by name across all buildings using an autocomplete that loads the full resident list on mount.

Key implementation decisions:
- A new `ResidentsByBuilding` SQL view joins `Residents → Units → Buildings`, registered in DAB as a single read endpoint — replacing what would have been N+1 per-unit API calls.
- All building/unit/resident API functions extracted from `checkoutService` into a dedicated `residentService` for clearer separation of concerns.
- Cross-building search loads all residents once on mount and filters client-side (OData `contains()` is not supported by DAB for views).

## Jira Ticket
- Closes: [PIT-???](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-???)

## Type of Change
**Type:** New feature / Refactoring

## Changes Made
- Add `ResidentsByBuilding` SQL view in `database/tables/residents.sql`
- Register view in `dab/dab-config.json` as `/residents-by-building` (admin read-only)
- Extract `residentService.ts` from `checkoutService.ts` (buildings, units, residents)
- Add `useResidentsByBuilding` hook — fetches building residents, groups by unit, sorts numerically
- Add `ResidentsPage` component with building dropdown, resident table, and cross-building name search
- Wire up `/residents` route and admin nav menu item (`type: 'admin'`)
- Add unit tests for `residentService`, `useResidentsByBuilding`, and `ResidentsPage`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have run [prettier](https://github.com/digitalaidseattle/plymouth-housing#code-formatting) on the code
- [x] I have performed a self-review of my code
- [x] I have commented my code only in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings in Chrome Dev Tools
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## QA Instructions

1. Run `dab start` and apply the new view to your database:
   ```sql
   CREATE VIEW ResidentsByBuilding AS
   SELECT r.id, r.name, u.id AS unit_id, u.unit_number, b.id AS building_id, b.name AS building_name, b.code AS building_code
   FROM Residents r JOIN Units u ON r.unit_id = u.id JOIN Buildings b ON u.building_id = b.id
   ```
2. Log in as an admin — verify **Residents** appears in the nav sidebar.
3. Select a building — units and residents should load in the table.
4. Type a resident name in the search box — autocomplete should show cross-building matches; selecting one auto-selects the building and filters the table to that unit.
5. Log in as a volunteer — `/residents` should redirect away (access denied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Residents" admin page: view residents grouped by building and unit, building/unit filters, resident search, and a unit/resident table.
  * Dashboard and top-level route include a new "Residents" navigation item.
  * New backend endpoint and view to power fast building-scoped and global resident queries; admins granted read access.

* **Bug Fixes / UX**
  * Loading spinners and clear error/snackbar messages for fetch failures.

* **Tests**
  * Added comprehensive tests for the page, hook, and resident service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->