### PR TITLE
feat(#434): return CHECKOUT_EDIT corrections in checkout history

### DIFF
--- a/database/data_seed/transaction_type_data.sql
+++ b/database/data_seed/transaction_type_data.sql
@@ -3,10 +3,15 @@ GO
 
 SET IDENTITY_INSERT TransactionTypes ON;
 
-INSERT INTO TransactionTypes (id, transaction_type) VALUES
-(1, 'CHECKOUT'),
-(2, 'RESTOCK'),
-(3, 'CORRECTION'); -- Corrected spelling
+INSERT INTO TransactionTypes
+    (id, transaction_type)
+VALUES
+    (1, 'CHECKOUT'),
+    (2, 'RESTOCK'),
+    (3, 'CORRECTION'),
+    -- reset of inventory
+    (4, 'CHECKOUT_EDIT');
+-- checkout that was edited after the fact (e.g. quantity changed, item added/removed)
 
 SET IDENTITY_INSERT TransactionTypes OFF;
 GO

--- a/database/procedures/get_checkout_history.sql
+++ b/database/procedures/get_checkout_history.sql
@@ -13,10 +13,6 @@ BEGIN
         RETURN;
     END
 
-    -- Query for the checkout transaction type ID
-    DECLARE @CheckoutTransactionType INT;
-    SELECT @CheckoutTransactionType = id FROM TransactionTypes WHERE transaction_type = 'CHECKOUT';
-
     SELECT
         Transactions.user_id,
         Transactions.id AS transaction_id,
@@ -36,7 +32,7 @@ BEGIN
     INNER JOIN TransactionItems ti ON ti.transaction_id = Transactions.id
     WHERE [transaction_date] >= @start_date
         AND [transaction_date] <= @end_date
-        AND [transaction_type] = @CheckoutTransactionType
+        AND [transaction_type] IN (SELECT id FROM TransactionTypes WHERE transaction_type IN ('CHECKOUT', 'CHECKOUT_EDIT'))
     GROUP BY
         Transactions.user_id,
         Transactions.id,

--- a/database/procedures/get_checkout_history.sql
+++ b/database/procedures/get_checkout_history.sql
@@ -16,6 +16,8 @@ BEGIN
     SELECT
         Transactions.user_id,
         Transactions.id AS transaction_id,
+        Transactions.transaction_type,
+        Transactions.parent_transaction_id,
         Transactions.resident_id,
         Residents.name AS resident_name,
         Units.unit_number,
@@ -36,6 +38,8 @@ BEGIN
     GROUP BY
         Transactions.user_id,
         Transactions.id,
+        Transactions.transaction_type,
+        Transactions.parent_transaction_id,
         Transactions.resident_id,
         Residents.name,
         Units.unit_number,

--- a/database/tables/transaction.sql
+++ b/database/tables/transaction.sql
@@ -8,6 +8,7 @@ CREATE TABLE Transactions (
     transaction_type INT NOT NULL,
     transaction_date DATETIME DEFAULT GETDATE() NOT NULL,
     building_id INT,
+    parent_transaction_id UNIQUEIDENTIFIER NULL,
 );
 
 GO

--- a/src/components/History/transactionProcessors.test.ts
+++ b/src/components/History/transactionProcessors.test.ts
@@ -1,0 +1,117 @@
+import { describe, test, expect } from 'vitest';
+import { mapCheckoutRows } from './transactionProcessors';
+import { CheckoutRow, TransactionType } from '../../types/interfaces';
+
+const baseRow: CheckoutRow = {
+  user_id: 1,
+  transaction_id: 'txn-1',
+  transaction_type: TransactionType.Checkout,
+  parent_transaction_id: null,
+  resident_id: 10,
+  resident_name: 'Resident A',
+  unit_number: '101',
+  building_id: 1,
+  transaction_date: '2025-01-01T00:00:00Z',
+  total_quantity: 7,
+  welcome_basket_item_id: null,
+  welcome_basket_quantity: null,
+};
+
+const editRow = (
+  id: string,
+  parentId: string,
+  quantity: number,
+): CheckoutRow => ({
+  ...baseRow,
+  transaction_id: id,
+  transaction_type: TransactionType.CheckoutEdit,
+  parent_transaction_id: parentId,
+  total_quantity: quantity,
+});
+
+describe('mapCheckoutRows', () => {
+  test('returns checkout transaction with is_edited=false when no edits exist', () => {
+    const result = mapCheckoutRows([baseRow]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].is_edited).toBe(false);
+    expect(result[0].total_quantity).toBe(7);
+  });
+
+  test('applies a single edit delta to total_quantity and sets is_edited=true', () => {
+    const result = mapCheckoutRows([baseRow, editRow('edit-1', 'txn-1', 3)]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].total_quantity).toBe(10);
+    expect(result[0].is_edited).toBe(true);
+  });
+
+  test('applies multiple edit deltas including negative values', () => {
+    const result = mapCheckoutRows([
+      baseRow,
+      editRow('edit-1', 'txn-1', 3),
+      editRow('edit-2', 'txn-1', -2),
+    ]);
+
+    expect(result[0].total_quantity).toBe(8);
+    expect(result[0].is_edited).toBe(true);
+  });
+
+  test('filters edit rows out of the result', () => {
+    const result = mapCheckoutRows([baseRow, editRow('edit-1', 'txn-1', 3)]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].transaction_id).toBe('txn-1');
+  });
+
+  test('edit row with null parent_transaction_id does not affect any transaction', () => {
+    const orphanEdit: CheckoutRow = {
+      ...editRow('edit-orphan', 'txn-1', 5),
+      parent_transaction_id: null,
+    };
+
+    const result = mapCheckoutRows([baseRow, orphanEdit]);
+
+    expect(result[0].total_quantity).toBe(7);
+    expect(result[0].is_edited).toBe(false);
+  });
+
+  test('edits for one transaction do not affect another', () => {
+    const secondRow: CheckoutRow = {
+      ...baseRow,
+      transaction_id: 'txn-2',
+      total_quantity: 5,
+    };
+
+    const result = mapCheckoutRows([
+      baseRow,
+      secondRow,
+      editRow('edit-1', 'txn-1', 3),
+    ]);
+
+    const txn1 = result.find((r) => r.transaction_id === 'txn-1')!;
+    const txn2 = result.find((r) => r.transaction_id === 'txn-2')!;
+    expect(txn1.total_quantity).toBe(10);
+    expect(txn1.is_edited).toBe(true);
+    expect(txn2.total_quantity).toBe(5);
+    expect(txn2.is_edited).toBe(false);
+  });
+
+  test('sets item_type to "welcome" when welcome_basket_item_id is present', () => {
+    const welcomeRow: CheckoutRow = {
+      ...baseRow,
+      welcome_basket_item_id: 171,
+      welcome_basket_quantity: 1,
+    };
+
+    const result = mapCheckoutRows([welcomeRow]);
+
+    expect(result[0].item_type).toBe('welcome');
+  });
+
+  test('sets item_type to "general" when welcome_basket_item_id is null', () => {
+    const result = mapCheckoutRows([baseRow]);
+
+    expect(result[0].item_type).toBe('general');
+  });
+});

--- a/src/components/History/transactionProcessors.ts
+++ b/src/components/History/transactionProcessors.ts
@@ -1,34 +1,11 @@
 import {
+  CheckoutRow,
   CheckoutTransaction,
+  InventoryRow,
   InventoryTransaction,
   TransactionType,
   TransactionsByUser,
 } from '../../types/interfaces';
-
-type CheckoutRow = {
-  user_id: number;
-  transaction_id: string;
-  transaction_type: number;
-  parent_transaction_id: string | null;
-  resident_id: number;
-  resident_name: string;
-  unit_number: string;
-  building_id: number;
-  transaction_date: string;
-  total_quantity: number;
-  welcome_basket_item_id: number | null;
-  welcome_basket_quantity: number | null;
-};
-
-type InventoryRow = {
-  user_id: number;
-  transaction_id: string;
-  transaction_type: number;
-  transaction_date: string;
-  item_name: string;
-  category_name: string;
-  quantity: number;
-};
 
 export function processTransactionsByUser(
   history: CheckoutTransaction[] | InventoryTransaction[],

--- a/src/components/History/transactionProcessors.ts
+++ b/src/components/History/transactionProcessors.ts
@@ -8,6 +8,8 @@ import {
 type CheckoutRow = {
   user_id: number;
   transaction_id: string;
+  transaction_type: number;
+  parent_transaction_id: string | null;
   resident_id: number;
   resident_name: string;
   unit_number: string;
@@ -50,20 +52,40 @@ export function processTransactionsByUser(
   }));
 }
 
+// Maps raw checkout rows to CheckoutTransactions. CHECKOUT_EDIT (type=4) rows are
+// delta corrections to an original CHECKOUT (type=1): their quantities are summed
+// and applied to the original's total. Edit rows are excluded from the output;
+// originals with at least one edit are flagged with is_edited=true.
 export function mapCheckoutRows(rows: CheckoutRow[]): CheckoutTransaction[] {
-  return rows.map((row) => ({
-    user_id: row.user_id,
-    transaction_id: row.transaction_id,
-    resident_id: row.resident_id,
-    resident_name: row.resident_name,
-    unit_number: row.unit_number,
-    building_id: row.building_id,
-    transaction_date: row.transaction_date,
-    total_quantity: row.total_quantity,
-    welcome_basket_item_id: row.welcome_basket_item_id,
-    welcome_basket_quantity: row.welcome_basket_quantity,
-    item_type: row.welcome_basket_item_id != null ? 'welcome' : 'general',
-  }));
+  const editsByParent = new Map<string, CheckoutRow[]>();
+  for (const row of rows) {
+    if (row.transaction_type === TransactionType.CheckoutEdit && row.parent_transaction_id) {
+      const edits = editsByParent.get(row.parent_transaction_id) ?? [];
+      edits.push(row);
+      editsByParent.set(row.parent_transaction_id, edits);
+    }
+  }
+
+  return rows
+    .filter((row) => row.transaction_type === TransactionType.Checkout)
+    .map((row) => {
+      const edits = editsByParent.get(row.transaction_id) ?? [];
+      const deltaQuantity = edits.reduce((sum, e) => sum + e.total_quantity, 0);
+      return {
+        user_id: row.user_id,
+        transaction_id: row.transaction_id,
+        resident_id: row.resident_id,
+        resident_name: row.resident_name,
+        unit_number: row.unit_number,
+        building_id: row.building_id,
+        transaction_date: row.transaction_date,
+        total_quantity: row.total_quantity + deltaQuantity,
+        welcome_basket_item_id: row.welcome_basket_item_id,
+        welcome_basket_quantity: row.welcome_basket_quantity,
+        item_type: row.welcome_basket_item_id != null ? 'welcome' : 'general',
+        is_edited: edits.length > 0,
+      };
+    });
 }
 
 function toInventoryTransactionType(

--- a/src/pages/history/index.test.tsx
+++ b/src/pages/history/index.test.tsx
@@ -118,6 +118,7 @@ const mockCheckoutTransactions: CheckoutTransaction[] = [
     total_quantity: 2,
     welcome_basket_item_id: null,
     welcome_basket_quantity: null,
+    is_edited: false,
   },
 ];
 
@@ -432,6 +433,7 @@ describe('HistoryPage Component', () => {
         total_quantity: 1,
         welcome_basket_item_id: null,
         welcome_basket_quantity: null,
+        is_edited: false,
       },
     ];
 
@@ -464,6 +466,7 @@ describe('HistoryPage Component', () => {
         total_quantity: 2,
         welcome_basket_item_id: null,
         welcome_basket_quantity: null,
+        is_edited: false,
       },
     ];
 
@@ -530,6 +533,7 @@ describe('HistoryPage Component', () => {
         total_quantity: 1,
         welcome_basket_item_id: null,
         welcome_basket_quantity: null,
+        is_edited: false,
       },
     ];
 

--- a/src/services/historyService.ts
+++ b/src/services/historyService.ts
@@ -2,7 +2,9 @@ import { getRole } from '../utils/userUtils';
 import { ENDPOINTS } from '../types/constants';
 import {
   ClientPrincipal,
+  CheckoutRow,
   CheckoutTransaction,
+  InventoryRow,
   InventoryTransaction,
 } from '../types/interfaces';
 import {
@@ -10,29 +12,6 @@ import {
   mapInventoryRows,
 } from '../components/History/transactionProcessors';
 import { apiRequest } from './apiRequest';
-
-type CheckoutRow = {
-  user_id: number;
-  transaction_id: string;
-  resident_id: number;
-  resident_name: string;
-  unit_number: string;
-  building_id: number;
-  transaction_date: string;
-  total_quantity: number;
-  welcome_basket_item_id: number | null;
-  welcome_basket_quantity: number | null;
-};
-
-type InventoryRow = {
-  user_id: number;
-  transaction_id: string;
-  transaction_type: number;
-  transaction_date: string;
-  item_name: string;
-  category_name: string;
-  quantity: number;
-};
 
 export async function getCheckoutHistory(
   user: ClientPrincipal | null,

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -216,6 +216,31 @@ export type TransactionsByUser<T> = {
   transactions: T[];
 };
 
+export type CheckoutRow = {
+  user_id: number;
+  transaction_id: string;
+  transaction_type: number;
+  parent_transaction_id: string | null;
+  resident_id: number;
+  resident_name: string;
+  unit_number: string;
+  building_id: number;
+  transaction_date: string;
+  total_quantity: number;
+  welcome_basket_item_id: number | null;
+  welcome_basket_quantity: number | null;
+};
+
+export type InventoryRow = {
+  user_id: number;
+  transaction_id: string;
+  transaction_type: number;
+  transaction_date: string;
+  item_name: string;
+  category_name: string;
+  quantity: number;
+};
+
 // ─── Context Types ────────────────────────────────────────────────────────────
 
 export interface SpinUpContextType {

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -181,10 +181,12 @@ export enum TransactionType {
   Checkout = 1,
   InventoryAdd = 2,
   InventoryReplaceValue = 3,
+  CheckoutEdit = 4,
 }
 
 export type CheckoutTransaction = {
   building_id: number;
+  is_edited: boolean;
   item_type: 'general' | 'welcome';
   resident_id: number;
   resident_name: string;


### PR DESCRIPTION
## Description

Adds support for `CHECKOUT_EDIT` (type=4) transactions in the checkout history flow. These are delta corrections to an existing checkout — e.g. a volunteer adjusts the quantity after the fact. The history page now shows the corrected totals and flags edited transactions with `is_edited=true`.

Note: the `is_edited` flag is not yet surfaced in the UI — that is a follow-up story.

## Jira Ticket
- Closes: [PIT-434](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-434)

## Type of Change
**Type:** New feature

## Changes Made
- Added `CHECKOUT_EDIT` (id=4) to `TransactionTypes` seed data
- Added `parent_transaction_id` column to `Transactions` table
- Updated `GetCheckoutHistory` stored procedure to return both `CHECKOUT` and `CHECKOUT_EDIT` rows, including `transaction_type` and `parent_transaction_id` in the result set
- Added `TransactionType.CheckoutEdit = 4` to the enum; added `is_edited` field to `CheckoutTransaction`
- Moved `CheckoutRow` and `InventoryRow` types to `src/types/interfaces.ts` (were duplicated in `transactionProcessors.ts` and `historyService.ts`)
- Implemented delta grouping in `mapCheckoutRows`: edit rows are summed per original transaction and filtered from the output
- Added unit tests for `mapCheckoutRows` covering no-edit, single delta, multiple deltas, negative deltas, orphan edits, and isolation between transactions

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have run [prettier](https://github.com/digitalaidseattle/plymouth-housing#code-formatting) on the code
- [x] I have performed a self-review of my code
- [x] I have commented my code only in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings in Chrome Dev Tools
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## QA Instructions

No UI changes in this PR. To verify the backend logic:
1. Run `npm run test:unit` — all 288 tests should pass
2. Apply the DB changes (`transaction.sql`, `get_checkout_history.sql`, seed data) to a local DB
3. Insert a `CHECKOUT_EDIT` row with a `parent_transaction_id` pointing to an existing checkout and confirm the history API returns the corrected total

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking edited checkouts. Users can now identify which transactions have been modified after creation.
  * Enhanced checkout history to display edit status and maintain relationships between original and edited transactions.

* **Bug Fixes**
  * Improved handling of parent transaction references to allow proper tracking of checkout edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->