### PR TITLE
fix: restore hotfix guards lost during CheckoutPageHeader refactor (PIT-466)

### DIFF
--- a/src/components/Checkout/CheckoutPageHeader.tsx
+++ b/src/components/Checkout/CheckoutPageHeader.tsx
@@ -67,11 +67,13 @@ const CheckoutPageHeader: React.FC<CheckoutPageHeaderProps> = ({
         >
           {residentLabel}
         </Button>
-        <SearchBar
-          data={data}
-          setSearchData={setSearchData}
-          setSearchActive={setSearchActive}
-        />
+        {checkoutType === 'general' && (
+          <SearchBar
+            data={data}
+            setSearchData={setSearchData}
+            setSearchActive={setSearchActive}
+          />
+        )}
       </Box>
       {!searchActive && checkoutType === 'general' && (
         <Navbar

--- a/src/pages/checkout/CheckoutPage.tsx
+++ b/src/pages/checkout/CheckoutPage.tsx
@@ -168,7 +168,7 @@ const CheckoutPage: React.FC<CheckoutPageProps> = ({ checkoutType = 'general' })
         residentInfoIsMissing={residentInfoIsMissing}
         checkoutType={checkoutType}
         searchActive={searchActive}
-        data={data}
+        data={filteredData}
         navbarData={navbarData}
         setSearchData={setSearchData}
         setSearchActive={setSearchActive}


### PR DESCRIPTION
## Description

Restores two regression guards from PR #451 that were accidentally dropped during the `CheckoutPageHeader` refactor. When `SearchBar` was extracted into `CheckoutPageHeader`, the unfiltered `data` was passed instead of `filteredData`, and the search bar visibility guard was lost — causing Welcome Basket items to reappear in general checkout search results and the search bar to show in Welcome Basket mode.

## Jira Ticket
- Closes: [PIT-466](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-466)

## Type of Change

**Type:** Bug fix

## Changes Made
- Guard `SearchBar` render behind `checkoutType === 'general'` check in `CheckoutPageHeader`
- Pass `filteredData` instead of `data` to `CheckoutPageHeader` in `CheckoutPage`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have run [prettier](https://github.com/digitalaidseattle/plymouth-housing#code-formatting) on the code
- [x] I have performed a self-review of my code
- [x] I have commented my code only in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings in Chrome Dev Tools
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## QA Instructions

1. Open the checkout page in **general** mode — search bar should be visible and only non-Welcome-Basket items appear in results
2. Switch to **Welcome Basket** mode — search bar should be hidden and no general items should bleed through