### PR TITLE
Fix regression by handling stale elements and improving E2E stability

### DIFF
--- a/tests/pages/login_page.py
+++ b/tests/pages/login_page.py
@@ -95,7 +95,11 @@ class LoginPage(BasePage):
         input_field = self.driver.find_element(*LoginPageLocators.USER_PERSON)
 
         # 5. use safe condition instead of clickable
-        self.wait.until(lambda d: input_field.is_displayed() and input_field.is_enabled())
+        self.wait.until(
+            lambda d: (
+                          el := d.find_element(*LoginPageLocators.USER_PERSON)
+                      ).is_displayed() and el.is_enabled()
+        )
 
         print("Volunteer field is ready")
 


### PR DESCRIPTION
## Description

This PR fixes regression issues observed after pulling the latest updates from the `dev` branch.  

The failures were mainly caused by UI changes (React/MUI re-renders) that led to stale element references and unstable waits in E2E tests, especially in login and history flows.  

To address this, wait strategies were improved and elements are now re-fetched after UI state changes to ensure consistent and stable interactions.

---

## Jira Ticket
- Closes: [PIT-???](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-???)

---

## Type of Change

**Type:** (Bug fix)

---

## Changes Made

- Fixed stale element issues by re-fetching elements after React re-renders  
- Improved wait logic in login flow (`wait_for_volunteer_ready`) for better stability  
- Stabilized autocomplete selection by handling dynamic DOM updates  
- Updated History page navigation to use state-based waits instead of fragile text checks  
- Increased reliability of smoke tests in CI after dev updates  

---

## Checklist

- [x] My code follows the project's style guidelines  
- [x] I have run prettier on the code  
- [x] I have performed a self-review of my code  
- [x] I have commented my code only in hard-to-understand areas  
- [ ] I have updated the documentation accordingly  
- [x] My changes generate no new warnings in Chrome Dev Tools  
- [ ] I have added unit tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of the volunteer login page testing by fixing element reference handling to prevent test instability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->