### PR TITLE
fix: correct foreign key reference and reorganize database views

### DIFF
--- a/database/bootstrap_db.ps1
+++ b/database/bootstrap_db.ps1
@@ -22,6 +22,7 @@ try {
     Invoke-Scripts-In-Folder -Folder "./database/dependencies/"
     Invoke-Scripts-In-Folder -Folder "./database/types/"
     Invoke-Scripts-In-Folder -Folder "./database/procedures/"
+    Invoke-Scripts-In-Folder -Folder "./database/views/"
     Invoke-Scripts-In-Folder -Folder "./database/data_seed/"
     Invoke-Scripts-In-Folder -Folder "./database/data_test/"
     Write-Host "All done."

--- a/database/dependencies/foreign_keys.sql
+++ b/database/dependencies/foreign_keys.sql
@@ -25,7 +25,7 @@ FOREIGN KEY (category_id) REFERENCES dbo.Categories(id);
 -- Transactions -> Transactions (self-referencing for parent transactions)
 ALTER TABLE dbo.Transactions
 ADD CONSTRAINT FK_Transactions_ParentTransaction
-FOREIGN KEY (parent_transaction_id) REFERENCES dbo.Transactions(transaction_id);
+FOREIGN KEY (parent_transaction_id) REFERENCES dbo.Transactions(id);
 
 -- Transactions -> Users
 ALTER TABLE dbo.Transactions

--- a/database/tables/residents.sql
+++ b/database/tables/residents.sql
@@ -9,23 +9,3 @@ CREATE TABLE Residents
 );
 
 GO
-
-DROP VIEW IF EXISTS [dbo].[ResidentsByBuilding];  
-GO
-
-CREATE VIEW ResidentsByBuilding
-AS
-    SELECT
-        r.id,
-        r.name,
-        u.id AS unit_id,
-        u.unit_number,
-        b.id AS building_id,
-        b.name AS building_name,
-        b.code AS building_code
-    FROM
-        Residents r
-        JOIN Units u ON r.unit_id = u.id
-        JOIN Buildings b ON u.building_id = b.id;
-
-GO

--- a/database/tables/transaction_type.sql
+++ b/database/tables/transaction_type.sql
@@ -6,11 +6,3 @@ CREATE TABLE TransactionTypes (
     transaction_type NVARCHAR(30) NOT NULL
 );
 GO
-"""
-SET IDENTITY_INSERT TransactionTypes ON;
-
-IF NOT EXISTS (SELECT 1 FROM TransactionTypes WHERE id = 4)
-INSERT INTO TransactionTypes (id, transaction_type) VALUES (4, 'CHECKOUT_EDIT');
-
-SET IDENTITY_INSERT TransactionTypes OFF;
-GO"""

--- a/database/views/residents.sql
+++ b/database/views/residents.sql
@@ -1,7 +1,7 @@
 DROP VIEW IF EXISTS [dbo].[ResidentsByBuilding];  
 GO
 
-CREATE VIEW ResidentsByBuilding
+CREATE VIEW [dbo].[ResidentsByBuilding]
 AS
     SELECT
         r.id,

--- a/database/views/residents.sql
+++ b/database/views/residents.sql
@@ -1,0 +1,19 @@
+DROP VIEW IF EXISTS [dbo].[ResidentsByBuilding];  
+GO
+
+CREATE VIEW ResidentsByBuilding
+AS
+    SELECT
+        r.id,
+        r.name,
+        u.id AS unit_id,
+        u.unit_number,
+        b.id AS building_id,
+        b.name AS building_name,
+        b.code AS building_code
+    FROM
+        Residents r
+        JOIN Units u ON r.unit_id = u.id
+        JOIN Buildings b ON u.building_id = b.id;
+
+GO


### PR DESCRIPTION
## Summary

- Fix `FK_Transactions_ParentTransaction` to reference `id` instead of non-existent `transaction_id` column
- Move `ResidentsByBuilding` view from `residents.sql` to dedicated `database/views/` folder
- Add `database/views/` folder to bootstrap script execution order
- Clean up `transaction_type.sql` by removing duplicate/commented code

## Test plan

- [ ] Run `database/bootstrap_db.ps1` successfully without foreign key errors
- [ ] Verify `ResidentsByBuilding` view is created correctly
- [ ] Verify all foreign keys are created without errors
- [ ] Verify database schema matches expected structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Schema Updates**
  * Added a view exposing residents grouped by building and unit.
  * Updated the parent/child transaction relationship to reference the correct parent key.
  * Removed an automatic seed insertion for a transaction type and cleaned up table/view definitions.

* **Database Initialization**
  * Bootstrap now runs view creation as part of setup so the residents-by-building view is created during initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->