### PR TITLE
fix: correct Azure SWA auth field from userID to userId (PIT-475)

### DIFF
--- a/docs/designs/transaction-design.md
+++ b/docs/designs/transaction-design.md
@@ -159,7 +159,7 @@ END;
 - **Request Body:**  
   ```json
   {
-    "userID": 123,
+    "userId": 123,
     "transactionGUID": "abc123",
     "totalAmount": 100.00,
     "transactionType": "Add",
@@ -175,13 +175,13 @@ END;
   ```
   
 **Get Transaction History**
-- **Endpoint:** GET /api/transactions?userID=123
+- **Endpoint:** GET /api/transactions?userId=123
 - **Response:**  
   ```json
   [
     {
       "transactionID": 789,
-      "userID": 123,
+      "userId": 123,
       "transactionGUID": "abc123",
       "totalAmount": 100.00,
       "transactionType": "Add",
@@ -198,7 +198,7 @@ END;
 - The backend returns the `transaction_id` for the front-end to confirm that transaction was successfully logged in the backend.
 
 #### When an admin views the Transaction History page:
-- Front-end sends a GET request to the `/api/transactions` endpoint with the `userID` parameter.
+- Front-end sends a GET request to the `/api/transactions` endpoint with the `userId` parameter.
 - The API retrieves all transactions associated with the `user_id` from the `Transactions` table.
 - The API returns the transaction history to the front-end for display.
 - The front-end groups the results by the TransactionGUID and renders the grouped data in a table with expandable rows for items details.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plymouth-housing",
   "private": true,
-  "version": "1.3.4",
+  "version": "1.3.5",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000",

--- a/src/components/Checkout/ResidentDetailDialog.test.tsx
+++ b/src/components/Checkout/ResidentDetailDialog.test.tsx
@@ -19,7 +19,7 @@ describe('ResidentDetailDialog', () => {
     id: 1,
     userDetails: 'Test User',
     userRoles: ['volunteer'],
-    userID: 'testuser',
+    userId: 'testuser',
   };
 
   const mockUserContext = {

--- a/src/components/Checkout/WelcomeBasketBuildingDialog.test.tsx
+++ b/src/components/Checkout/WelcomeBasketBuildingDialog.test.tsx
@@ -18,7 +18,7 @@ describe('WelcomeBasketBuildingDialog', () => {
     id: 1,
     userDetails: 'Test User',
     userRoles: ['volunteer'],
-    userID: 'testuser',
+    userId: 'testuser',
   };
 
   const mockUserContext = {

--- a/src/components/inventory/AddItemModal.test.tsx
+++ b/src/components/inventory/AddItemModal.test.tsx
@@ -21,7 +21,7 @@ const originalData: InventoryItem[] = [
 
 const mockUser: ClientPrincipal = {
     userDetails: 'test-user',
-    userID: '123',
+    userId: '123',
     userRoles: ['admin']
 };
 

--- a/src/layout/MainLayout/index.tsx
+++ b/src/layout/MainLayout/index.tsx
@@ -55,18 +55,13 @@ const MainLayout: React.FC = () => {
         }
 
         if (userClaims?.userRoles?.includes('admin')) {
-          try {
-            const createdOrUpdatedAdmin = await upsertAdminUser({
-              name: userClaims.userDetails ?? '',
-              email: userClaims.userId ?? '',
-              claims: userClaims,
-            });
-            // Now we have an User object with id, name, created_at, last_signed_in
-            setLoggedInUserId(createdOrUpdatedAdmin.id);
-          } catch (error) {
-            console.error('Error in upsertAdminUser:', error);
-            //TODO error handling
-          }
+          const createdOrUpdatedAdmin = await upsertAdminUser({
+            name: userClaims.userDetails ?? '',
+            email: userClaims.userId ?? '',
+            claims: userClaims,
+          });
+          // Now we have an User object with id, name, created_at, last_signed_in
+          setLoggedInUserId(createdOrUpdatedAdmin.id);
         }
       } catch (error) {
         console.error('Error in fetchTokenAndVolunteers:', error);

--- a/src/layout/MainLayout/index.tsx
+++ b/src/layout/MainLayout/index.tsx
@@ -13,10 +13,12 @@ import Drawer from './Drawer';
 import Header from './Header';
 import Breadcrumbs from '../../components/@extended/Breadcrumbs';
 import ScrollTop from '../../components/ScrollTop';
+import SnackbarAlert from '../../components/SnackbarAlert';
 import { DrawerOpenContext } from '../../components/contexts/DrawerOpenContext';
 import { UserContext } from '../../components/contexts/UserContext';
 import { AdminUser, User } from '../../types/interfaces';
 import { useInactivityTimer } from '../../hooks/useInactivityTimer';
+import { useSnackbar } from '../../hooks/useSnackbar';
 import { ENDPOINTS, SETTINGS, USER_ROLES } from '../../types/constants';
 import { getAuthMe } from '../../services/authService';
 import { apiRequest } from '../../services/apiRequest';
@@ -30,6 +32,7 @@ const MainLayout: React.FC = () => {
     useContext(UserContext);
   const [drawerOpen, setDrawerOpen] = useState(true);
   const navigate = useNavigate();
+  const { snackbarState, showSnackbar, handleClose } = useSnackbar();
 
   // Add inactivity timer
   const resetTimer = useInactivityTimer({
@@ -65,7 +68,11 @@ const MainLayout: React.FC = () => {
         }
       } catch (error) {
         console.error('Error in fetchTokenAndVolunteers:', error);
-        navigate('/');
+        const errorMessage = error instanceof Error ? error.message : 'Failed to authenticate user';
+        showSnackbar(`Authentication error: ${errorMessage}`, 'error');
+        setTimeout(() => {
+          navigate('/');
+        }, 3000);
       }
     };
     fetchTokenAndRole();
@@ -189,6 +196,13 @@ const MainLayout: React.FC = () => {
             <Outlet context={{ drawerOpen }} />
           </Box>
         </Box>
+        <SnackbarAlert
+          open={snackbarState.open}
+          onClose={handleClose}
+          severity={snackbarState.severity}
+        >
+          {snackbarState.message}
+        </SnackbarAlert>
       </ScrollTop>
     </DrawerOpenContext.Provider>
   );

--- a/src/layout/MainLayout/index.tsx
+++ b/src/layout/MainLayout/index.tsx
@@ -58,13 +58,19 @@ const MainLayout: React.FC = () => {
         }
 
         if (userClaims?.userRoles?.includes('admin')) {
-          const createdOrUpdatedAdmin = await upsertAdminUser({
-            name: userClaims.userDetails ?? '',
-            email: userClaims.userId ?? '',
-            claims: userClaims,
-          });
-          // Now we have an User object with id, name, created_at, last_signed_in
-          setLoggedInUserId(createdOrUpdatedAdmin.id);
+          try {
+            const createdOrUpdatedAdmin = await upsertAdminUser({
+              name: userClaims.userDetails ?? '',
+              email: userClaims.userId ?? '',
+              claims: userClaims,
+            });
+            // Now we have an User object with id, name, created_at, last_signed_in
+            setLoggedInUserId(createdOrUpdatedAdmin.id);
+          } catch (error) {
+            console.error('Error in upsertAdminUser:', error);
+            const originalMessage = error instanceof Error ? error.message : 'Unknown error';
+            throw new Error(`Failed to create/update admin account: ${originalMessage}`);
+          }
         }
       } catch (error) {
         console.error('Error in fetchTokenAndVolunteers:', error);

--- a/src/layout/MainLayout/index.tsx
+++ b/src/layout/MainLayout/index.tsx
@@ -58,7 +58,7 @@ const MainLayout: React.FC = () => {
           try {
             const createdOrUpdatedAdmin = await upsertAdminUser({
               name: userClaims.userDetails ?? '',
-              email: userClaims.userID ?? '',
+              email: userClaims.userId ?? '',
               claims: userClaims,
             });
             // Now we have an User object with id, name, created_at, last_signed_in

--- a/src/pages/RootRedirect.test.tsx
+++ b/src/pages/RootRedirect.test.tsx
@@ -46,7 +46,7 @@ const GenericRedirectPage = ({ source }: { source: string }) => (
 const mockUserContextValue = (role: 'admin' | 'volunteer' | null | undefined, isLoading: boolean): UserContextType => ({
   user: role ? {
     userRoles: [role],
-    userID: 'test-user-id',
+    userId: 'test-user-id',
     userDetails: 'test-user-details'
   } : null,
   isLoading,

--- a/src/pages/VolunteerHome/VolunteerHome.test.tsx
+++ b/src/pages/VolunteerHome/VolunteerHome.test.tsx
@@ -47,7 +47,7 @@ vi.mock('../../components/SnackbarAlert.tsx', () => ({
 // Provide a user object that meets the requirements of UserContext
 // (Note: according to the type, userRoles and claims must be provided)
 const mockUser = {
-  userID: '1',
+  userId: '1',
   userDetails: 'Test User',
   userRoles: ['admin'],
   claims: [],

--- a/src/pages/authentication/EnterPinPage.test.tsx
+++ b/src/pages/authentication/EnterPinPage.test.tsx
@@ -30,7 +30,7 @@ vi.mock('./PinInput', () => ({
 
 // Define a helper function to create the required UserContext value
 const createUserContextValue = (overrides = {}) => ({
-  user: { userID: "1", userDetails: "Test", userRoles: ["volunteer"], claims: [] },
+  user: { userId: "1", userDetails: "Test", userRoles: ["volunteer"], claims: [] },
   setUser: vi.fn(),
   loggedInUserId: 123,
   setLoggedInUserId: vi.fn(),

--- a/src/pages/authentication/PickNamePage.test.tsx
+++ b/src/pages/authentication/PickNamePage.test.tsx
@@ -29,7 +29,7 @@ vi.mock('./SpinUpDialog', () => ({
 }));
 
 const createUserContextValue = (overrides = {}) => ({
-  user: { userID: "1", userDetails: "Test User", userRoles: ["volunteer"], claims: [] },
+  user: { userId: "1", userDetails: "Test User", userRoles: ["volunteer"], claims: [] },
   loggedInUserId: null,
   setLoggedInUserId: vi.fn(),
   activeVolunteers: [],

--- a/src/pages/checkout/CheckoutPage.test.tsx
+++ b/src/pages/checkout/CheckoutPage.test.tsx
@@ -7,7 +7,7 @@ import { ENDPOINTS } from '../../types/constants';
 import { BrowserRouter } from 'react-router-dom';
 
 const mockUserContext = {
-  user: { id: 1, userDetails: 'Test User', userRoles: ['volunteer'], userID: "bob" },
+  user: { id: 1, userDetails: 'Test User', userRoles: ['volunteer'], userId: "bob" },
   setUser: vi.fn(),
   loggedInUserId: null,
   setLoggedInUserId: vi.fn(),

--- a/src/pages/history/index.test.tsx
+++ b/src/pages/history/index.test.tsx
@@ -72,7 +72,7 @@ vi.mock('../../components/History/InventoryCard', () => ({
 
 // Mock user context values
 const mockUser = {
-  userID: '1',
+  userId: '1',
   userDetails: 'Test Volunteer',
   userRoles: ['volunteer'],
   claims: [],

--- a/src/pages/people/useUsers.test.tsx
+++ b/src/pages/people/useUsers.test.tsx
@@ -5,7 +5,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Dummy user for context.
 const dummyUser = {
-  userID: "1",
+  userId: "1",
   userDetails: "Test User",
   userRoles: ["volunteer"],
   claims: []

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -64,7 +64,7 @@ export type ResidentFormError = {
 
 export interface ClientPrincipal {
   userDetails: string;
-  userID: string;
+  userId: string;
   userRoles: string[];
 }
 


### PR DESCRIPTION
## Summary
Fixes admin login failures in staging/prod caused by incorrect field name mapping from Azure Static Web Apps authentication response.

## Root Cause
- Azure SWA returns `userId` (camelCase) in the `/.auth/me` response
- TypeScript interface incorrectly defined it as `userID` (PascalCase)
- PR #454 (March 16, 2026) changed code to match the wrong interface
- This caused admin email to be empty when creating/looking up users
- Result: 409 conflicts and failed logins with no user feedback

## Changes
1. **Fix field name casing** - Changed `ClientPrincipal.userID` to `userId` to match Azure's actual response
2. **Remove error swallowing** - Errors now properly propagate instead of being silently caught
3. **Add user feedback** - Integrated snackbar to show error messages before redirect
4. **Restore error granularity** - Re-added specific error context for `upsertAdminUser` failures while avoiding duplicate messages

## Impact
- ✅ Admin users can now log in successfully on staging/prod
- ✅ Clear error messages shown to users when authentication fails
- ✅ Better error tracking/debugging with specific error contexts
- ✅ No silent failures or broken states

## Test Plan
- [x] TypeScript build passes
- [x] Updated all test files to use correct field name
- [ ] Manual testing: Admin login on staging
- [ ] Verify error messages display correctly on failure
- [ ] Verify checkout/inventory actions work after successful login

## Notes
- Only affected admin users (volunteers use different auth flow)
- Bug introduced in commit 9a3127e, merged via PR #454
- E2E tests don't cover admin actions (only login UI checks), so this wasn't caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)