### PR TITLE
fix: correct Azure SWA auth field from userID to userId (PIT-475) [backport to staging]

### DIFF
--- a/src/components/Checkout/ResidentDetailDialog.test.tsx
+++ b/src/components/Checkout/ResidentDetailDialog.test.tsx
@@ -19,7 +19,7 @@ describe('ResidentDetailDialog', () => {
     id: 1,
     userDetails: 'Test User',
     userRoles: ['volunteer'],
-    userID: 'testuser',
+    userId: 'testuser',
   };
 
   const mockUserContext = {

--- a/src/components/Checkout/WelcomeBasketBuildingDialog.test.tsx
+++ b/src/components/Checkout/WelcomeBasketBuildingDialog.test.tsx
@@ -18,7 +18,7 @@ describe('WelcomeBasketBuildingDialog', () => {
     id: 1,
     userDetails: 'Test User',
     userRoles: ['volunteer'],
-    userID: 'testuser',
+    userId: 'testuser',
   };
 
   const mockUserContext = {

--- a/src/components/inventory/AddItemModal.test.tsx
+++ b/src/components/inventory/AddItemModal.test.tsx
@@ -21,7 +21,7 @@ const originalData: InventoryItem[] = [
 
 const mockUser: ClientPrincipal = {
     userDetails: 'test-user',
-    userID: '123',
+    userId: '123',
     userRoles: ['admin']
 };
 

--- a/src/layout/MainLayout/index.tsx
+++ b/src/layout/MainLayout/index.tsx
@@ -13,10 +13,12 @@ import Drawer from './Drawer';
 import Header from './Header';
 import Breadcrumbs from '../../components/@extended/Breadcrumbs';
 import ScrollTop from '../../components/ScrollTop';
+import SnackbarAlert from '../../components/SnackbarAlert';
 import { DrawerOpenContext } from '../../components/contexts/DrawerOpenContext';
 import { UserContext } from '../../components/contexts/UserContext';
 import { AdminUser, User } from '../../types/interfaces';
 import { useInactivityTimer } from '../../hooks/useInactivityTimer';
+import { useSnackbar } from '../../hooks/useSnackbar';
 import { ENDPOINTS, SETTINGS, USER_ROLES } from '../../types/constants';
 import { getAuthMe } from '../../services/authService';
 import { apiRequest } from '../../services/apiRequest';
@@ -30,6 +32,7 @@ const MainLayout: React.FC = () => {
     useContext(UserContext);
   const [drawerOpen, setDrawerOpen] = useState(true);
   const navigate = useNavigate();
+  const { snackbarState, showSnackbar, handleClose } = useSnackbar();
 
   // Add inactivity timer
   const resetTimer = useInactivityTimer({
@@ -71,7 +74,11 @@ const MainLayout: React.FC = () => {
         }
       } catch (error) {
         console.error('Error in fetchTokenAndVolunteers:', error);
-        navigate('/');
+        const errorMessage = error instanceof Error ? error.message : 'Failed to authenticate user';
+        showSnackbar(`Authentication error: ${errorMessage}`, 'error');
+        setTimeout(() => {
+          navigate('/');
+        }, 3000);
       }
     };
     fetchTokenAndRole();
@@ -195,6 +202,13 @@ const MainLayout: React.FC = () => {
             <Outlet context={{ drawerOpen }} />
           </Box>
         </Box>
+        <SnackbarAlert
+          open={snackbarState.open}
+          onClose={handleClose}
+          severity={snackbarState.severity}
+        >
+          {snackbarState.message}
+        </SnackbarAlert>
       </ScrollTop>
     </DrawerOpenContext.Provider>
   );

--- a/src/layout/MainLayout/index.tsx
+++ b/src/layout/MainLayout/index.tsx
@@ -58,14 +58,15 @@ const MainLayout: React.FC = () => {
           try {
             const createdOrUpdatedAdmin = await upsertAdminUser({
               name: userClaims.userDetails ?? '',
-              email: userClaims.userID ?? '',
+              email: userClaims.userId ?? '',
               claims: userClaims,
             });
             // Now we have an User object with id, name, created_at, last_signed_in
             setLoggedInUserId(createdOrUpdatedAdmin.id);
           } catch (error) {
             console.error('Error in upsertAdminUser:', error);
-            //TODO error handling
+            const originalMessage = error instanceof Error ? error.message : 'Unknown error';
+            throw new Error(`Failed to create/update admin account: ${originalMessage}`);
           }
         }
       } catch (error) {

--- a/src/pages/RootRedirect.test.tsx
+++ b/src/pages/RootRedirect.test.tsx
@@ -46,7 +46,7 @@ const GenericRedirectPage = ({ source }: { source: string }) => (
 const mockUserContextValue = (role: 'admin' | 'volunteer' | null | undefined, isLoading: boolean): UserContextType => ({
   user: role ? {
     userRoles: [role],
-    userID: 'test-user-id',
+    userId: 'test-user-id',
     userDetails: 'test-user-details'
   } : null,
   isLoading,

--- a/src/pages/VolunteerHome/VolunteerHome.test.tsx
+++ b/src/pages/VolunteerHome/VolunteerHome.test.tsx
@@ -47,7 +47,7 @@ vi.mock('../../components/SnackbarAlert.tsx', () => ({
 // Provide a user object that meets the requirements of UserContext
 // (Note: according to the type, userRoles and claims must be provided)
 const mockUser = {
-  userID: '1',
+  userId: '1',
   userDetails: 'Test User',
   userRoles: ['admin'],
   claims: [],

--- a/src/pages/authentication/EnterPinPage.test.tsx
+++ b/src/pages/authentication/EnterPinPage.test.tsx
@@ -30,7 +30,7 @@ vi.mock('./PinInput', () => ({
 
 // Define a helper function to create the required UserContext value
 const createUserContextValue = (overrides = {}) => ({
-  user: { userID: "1", userDetails: "Test", userRoles: ["volunteer"], claims: [] },
+  user: { userId: "1", userDetails: "Test", userRoles: ["volunteer"], claims: [] },
   setUser: vi.fn(),
   loggedInUserId: 123,
   setLoggedInUserId: vi.fn(),

--- a/src/pages/authentication/PickNamePage.test.tsx
+++ b/src/pages/authentication/PickNamePage.test.tsx
@@ -29,7 +29,7 @@ vi.mock('./SpinUpDialog', () => ({
 }));
 
 const createUserContextValue = (overrides = {}) => ({
-  user: { userID: "1", userDetails: "Test User", userRoles: ["volunteer"], claims: [] },
+  user: { userId: "1", userDetails: "Test User", userRoles: ["volunteer"], claims: [] },
   loggedInUserId: null,
   setLoggedInUserId: vi.fn(),
   activeVolunteers: [],

--- a/src/pages/checkout/CheckoutPage.test.tsx
+++ b/src/pages/checkout/CheckoutPage.test.tsx
@@ -7,7 +7,7 @@ import { ENDPOINTS } from '../../types/constants';
 import { BrowserRouter } from 'react-router-dom';
 
 const mockUserContext = {
-  user: { id: 1, userDetails: 'Test User', userRoles: ['volunteer'], userID: "bob" },
+  user: { id: 1, userDetails: 'Test User', userRoles: ['volunteer'], userId: "bob" },
   setUser: vi.fn(),
   loggedInUserId: null,
   setLoggedInUserId: vi.fn(),

--- a/src/pages/history/index.test.tsx
+++ b/src/pages/history/index.test.tsx
@@ -72,7 +72,7 @@ vi.mock('../../components/History/InventoryCard', () => ({
 
 // Mock user context values
 const mockUser = {
-  userID: '1',
+  userId: '1',
   userDetails: 'Test Volunteer',
   userRoles: ['volunteer'],
   claims: [],

--- a/src/pages/people/useUsers.test.tsx
+++ b/src/pages/people/useUsers.test.tsx
@@ -5,7 +5,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Dummy user for context.
 const dummyUser = {
-  userID: "1",
+  userId: "1",
   userDetails: "Test User",
   userRoles: ["volunteer"],
   claims: []

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -64,7 +64,7 @@ export type ResidentFormError = {
 
 export interface ClientPrincipal {
   userDetails: string;
-  userID: string;
+  userId: string;
   userRoles: string[];
 }
 


### PR DESCRIPTION
Backport of #496 to staging.

## Summary
- Fixes admin login failures caused by incorrect `userID` → `userId` field name from Azure SWA auth response
- Adds snackbar error feedback for authentication failures
- Restores granular error context for `upsertAdminUser` failures

> **Note:** The "remove error swallowing" commit was intentionally skipped in this backport to preserve inner try/catch granularity in `MainLayout`.

## Test Plan
- [ ] Manual testing: Admin login on staging
- [ ] Verify error messages display correctly on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)