### PR TITLE
fix: correct Azure SWA auth field from userID to userId (PIT-475) [backport to dev]

### DIFF
--- a/docs/designs/transaction-design.md
+++ b/docs/designs/transaction-design.md
@@ -159,7 +159,7 @@ END;
 - **Request Body:**  
   ```json
   {
-    "userID": 123,
+    "userId": 123,
     "transactionGUID": "abc123",
     "totalAmount": 100.00,
     "transactionType": "Add",
@@ -175,13 +175,13 @@ END;
   ```
   
 **Get Transaction History**
-- **Endpoint:** GET /api/transactions?userID=123
+- **Endpoint:** GET /api/transactions?userId=123
 - **Response:**  
   ```json
   [
     {
       "transactionID": 789,
-      "userID": 123,
+      "userId": 123,
       "transactionGUID": "abc123",
       "totalAmount": 100.00,
       "transactionType": "Add",
@@ -198,7 +198,7 @@ END;
 - The backend returns the `transaction_id` for the front-end to confirm that transaction was successfully logged in the backend.
 
 #### When an admin views the Transaction History page:
-- Front-end sends a GET request to the `/api/transactions` endpoint with the `userID` parameter.
+- Front-end sends a GET request to the `/api/transactions` endpoint with the `userId` parameter.
 - The API retrieves all transactions associated with the `user_id` from the `Transactions` table.
 - The API returns the transaction history to the front-end for display.
 - The front-end groups the results by the TransactionGUID and renders the grouped data in a table with expandable rows for items details.

--- a/src/components/Checkout/ResidentDetailDialog.test.tsx
+++ b/src/components/Checkout/ResidentDetailDialog.test.tsx
@@ -19,7 +19,7 @@ describe('ResidentDetailDialog', () => {
     id: 1,
     userDetails: 'Test User',
     userRoles: ['volunteer'],
-    userID: 'testuser',
+    userId: 'testuser',
   };
 
   const mockUserContext = {

--- a/src/components/Checkout/WelcomeBasketBuildingDialog.test.tsx
+++ b/src/components/Checkout/WelcomeBasketBuildingDialog.test.tsx
@@ -18,7 +18,7 @@ describe('WelcomeBasketBuildingDialog', () => {
     id: 1,
     userDetails: 'Test User',
     userRoles: ['volunteer'],
-    userID: 'testuser',
+    userId: 'testuser',
   };
 
   const mockUserContext = {

--- a/src/components/inventory/AddItemModal.test.tsx
+++ b/src/components/inventory/AddItemModal.test.tsx
@@ -21,7 +21,7 @@ const originalData: InventoryItem[] = [
 
 const mockUser: ClientPrincipal = {
     userDetails: 'test-user',
-    userID: '123',
+    userId: '123',
     userRoles: ['admin']
 };
 

--- a/src/layout/MainLayout/index.tsx
+++ b/src/layout/MainLayout/index.tsx
@@ -13,10 +13,12 @@ import Drawer from './Drawer';
 import Header from './Header';
 import Breadcrumbs from '../../components/@extended/Breadcrumbs';
 import ScrollTop from '../../components/ScrollTop';
+import SnackbarAlert from '../../components/SnackbarAlert';
 import { DrawerOpenContext } from '../../components/contexts/DrawerOpenContext';
 import { UserContext } from '../../components/contexts/UserContext';
 import { AdminUser, User } from '../../types/interfaces';
 import { useInactivityTimer } from '../../hooks/useInactivityTimer';
+import { useSnackbar } from '../../hooks/useSnackbar';
 import { ENDPOINTS, SETTINGS, USER_ROLES } from '../../types/constants';
 import { getAuthMe } from '../../services/authService';
 import { apiRequest } from '../../services/apiRequest';
@@ -30,6 +32,7 @@ const MainLayout: React.FC = () => {
     useContext(UserContext);
   const [drawerOpen, setDrawerOpen] = useState(true);
   const navigate = useNavigate();
+  const { snackbarState, showSnackbar, handleClose } = useSnackbar();
 
   // Add inactivity timer
   const resetTimer = useInactivityTimer({
@@ -71,7 +74,11 @@ const MainLayout: React.FC = () => {
         }
       } catch (error) {
         console.error('Error in fetchTokenAndVolunteers:', error);
-        navigate('/');
+        const errorMessage = error instanceof Error ? error.message : 'Failed to authenticate user';
+        showSnackbar(`Authentication error: ${errorMessage}`, 'error');
+        setTimeout(() => {
+          navigate('/');
+        }, 3000);
       }
     };
     fetchTokenAndRole();
@@ -195,6 +202,13 @@ const MainLayout: React.FC = () => {
             <Outlet context={{ drawerOpen }} />
           </Box>
         </Box>
+        <SnackbarAlert
+          open={snackbarState.open}
+          onClose={handleClose}
+          severity={snackbarState.severity}
+        >
+          {snackbarState.message}
+        </SnackbarAlert>
       </ScrollTop>
     </DrawerOpenContext.Provider>
   );

--- a/src/layout/MainLayout/index.tsx
+++ b/src/layout/MainLayout/index.tsx
@@ -4,7 +4,7 @@
  *  @copyright 2024 Digital Aid Seattle
  *
  */
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 import { Box, Toolbar, useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
@@ -33,6 +33,7 @@ const MainLayout: React.FC = () => {
   const [drawerOpen, setDrawerOpen] = useState(true);
   const navigate = useNavigate();
   const { snackbarState, showSnackbar, handleClose } = useSnackbar();
+  const navigateTimeoutRef = useRef<number | null>(null);
 
   // Add inactivity timer
   const resetTimer = useInactivityTimer({
@@ -76,12 +77,20 @@ const MainLayout: React.FC = () => {
         console.error('Error in fetchTokenAndVolunteers:', error);
         const errorMessage = error instanceof Error ? error.message : 'Failed to authenticate user';
         showSnackbar(`Authentication error: ${errorMessage}`, 'error');
-        setTimeout(() => {
+        navigateTimeoutRef.current = window.setTimeout(() => {
+          navigateTimeoutRef.current = null;
           navigate('/');
         }, 3000);
       }
     };
     fetchTokenAndRole();
+
+    return () => {
+      if (navigateTimeoutRef.current !== null) {
+        clearTimeout(navigateTimeoutRef.current);
+        navigateTimeoutRef.current = null;
+      }
+    };
 
     // The effect is intended to run only once on mount.
     /* eslint-disable-next-line react-hooks/exhaustive-deps */

--- a/src/layout/MainLayout/index.tsx
+++ b/src/layout/MainLayout/index.tsx
@@ -58,14 +58,15 @@ const MainLayout: React.FC = () => {
           try {
             const createdOrUpdatedAdmin = await upsertAdminUser({
               name: userClaims.userDetails ?? '',
-              email: userClaims.userID ?? '',
+              email: userClaims.userId ?? '',
               claims: userClaims,
             });
             // Now we have an User object with id, name, created_at, last_signed_in
             setLoggedInUserId(createdOrUpdatedAdmin.id);
           } catch (error) {
             console.error('Error in upsertAdminUser:', error);
-            //TODO error handling
+            const originalMessage = error instanceof Error ? error.message : 'Unknown error';
+            throw new Error(`Failed to create/update admin account: ${originalMessage}`);
           }
         }
       } catch (error) {

--- a/src/pages/RootRedirect.test.tsx
+++ b/src/pages/RootRedirect.test.tsx
@@ -46,7 +46,7 @@ const GenericRedirectPage = ({ source }: { source: string }) => (
 const mockUserContextValue = (role: 'admin' | 'volunteer' | null | undefined, isLoading: boolean): UserContextType => ({
   user: role ? {
     userRoles: [role],
-    userID: 'test-user-id',
+    userId: 'test-user-id',
     userDetails: 'test-user-details'
   } : null,
   isLoading,

--- a/src/pages/VolunteerHome/VolunteerHome.test.tsx
+++ b/src/pages/VolunteerHome/VolunteerHome.test.tsx
@@ -47,7 +47,7 @@ vi.mock('../../components/SnackbarAlert.tsx', () => ({
 // Provide a user object that meets the requirements of UserContext
 // (Note: according to the type, userRoles and claims must be provided)
 const mockUser = {
-  userID: '1',
+  userId: '1',
   userDetails: 'Test User',
   userRoles: ['admin'],
   claims: [],

--- a/src/pages/authentication/EnterPinPage.test.tsx
+++ b/src/pages/authentication/EnterPinPage.test.tsx
@@ -30,7 +30,7 @@ vi.mock('./PinInput', () => ({
 
 // Define a helper function to create the required UserContext value
 const createUserContextValue = (overrides = {}) => ({
-  user: { userID: "1", userDetails: "Test", userRoles: ["volunteer"], claims: [] },
+  user: { userId: "1", userDetails: "Test", userRoles: ["volunteer"], claims: [] },
   setUser: vi.fn(),
   loggedInUserId: 123,
   setLoggedInUserId: vi.fn(),

--- a/src/pages/authentication/PickNamePage.test.tsx
+++ b/src/pages/authentication/PickNamePage.test.tsx
@@ -29,7 +29,7 @@ vi.mock('./SpinUpDialog', () => ({
 }));
 
 const createUserContextValue = (overrides = {}) => ({
-  user: { userID: "1", userDetails: "Test User", userRoles: ["volunteer"], claims: [] },
+  user: { userId: "1", userDetails: "Test User", userRoles: ["volunteer"], claims: [] },
   loggedInUserId: null,
   setLoggedInUserId: vi.fn(),
   activeVolunteers: [],

--- a/src/pages/catalog/index.test.tsx
+++ b/src/pages/catalog/index.test.tsx
@@ -6,10 +6,10 @@ import { UserContext } from '../../components/contexts/UserContext';
 import * as useCatalogModule from './useCatalog';
 
 const dummyUser = {
-  userID: "1",
-  userDetails: "Test Admin",
-  userRoles: ["admin"],
-  claims: []
+  userId: '1',
+  userDetails: 'Test Admin',
+  userRoles: ['admin'],
+  claims: [],
 };
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -21,7 +21,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
       setLoggedInUserId: vi.fn(),
       activeVolunteers: [],
       setActiveVolunteers: vi.fn(),
-      isLoading: false
+      isLoading: false,
     }}
   >
     {children}
@@ -136,7 +136,9 @@ describe('Catalog Component', () => {
     render(<Catalog />, { wrapper });
 
     expect(screen.getByText('Test Item')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /add item/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /add item/i }),
+    ).toBeInTheDocument();
   });
 
   test('switches to Categories tab when clicked', () => {
@@ -165,7 +167,9 @@ describe('Catalog Component', () => {
     const categoriesTab = screen.getByText('Categories');
     fireEvent.click(categoriesTab);
 
-    expect(screen.getByRole('button', { name: /add category/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /add category/i }),
+    ).toBeInTheDocument();
     expect(screen.getByText('Food')).toBeInTheDocument();
     expect(screen.getByText('Hygiene')).toBeInTheDocument();
   });
@@ -207,9 +211,7 @@ describe('Catalog Component', () => {
       },
     ];
 
-    const mockCategories = [
-      { id: 1, name: 'Food', item_limit: 3 },
-    ];
+    const mockCategories = [{ id: 1, name: 'Food', item_limit: 3 }];
 
     const mockUseCatalog = {
       items: mockItems,

--- a/src/pages/catalog/useCatalog.test.tsx
+++ b/src/pages/catalog/useCatalog.test.tsx
@@ -4,7 +4,7 @@ import { UserContext } from '../../components/contexts/UserContext';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const dummyUser = {
-  userID: '1',
+  userId: '1',
   userDetails: 'Test Admin',
   userRoles: ['admin'],
   claims: [],

--- a/src/pages/checkout/CheckoutPage.test.tsx
+++ b/src/pages/checkout/CheckoutPage.test.tsx
@@ -7,7 +7,7 @@ import { ENDPOINTS } from '../../types/constants';
 import { BrowserRouter } from 'react-router-dom';
 
 const mockUserContext = {
-  user: { id: 1, userDetails: 'Test User', userRoles: ['volunteer'], userID: "bob" },
+  user: { id: 1, userDetails: 'Test User', userRoles: ['volunteer'], userId: "bob" },
   setUser: vi.fn(),
   loggedInUserId: null,
   setLoggedInUserId: vi.fn(),

--- a/src/pages/history/index.test.tsx
+++ b/src/pages/history/index.test.tsx
@@ -72,7 +72,7 @@ vi.mock('../../components/History/InventoryCard', () => ({
 
 // Mock user context values
 const mockUser = {
-  userID: '1',
+  userId: '1',
   userDetails: 'Test Volunteer',
   userRoles: ['volunteer'],
   claims: [],

--- a/src/pages/people/useUsers.test.tsx
+++ b/src/pages/people/useUsers.test.tsx
@@ -5,7 +5,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Dummy user for context.
 const dummyUser = {
-  userID: "1",
+  userId: "1",
   userDetails: "Test User",
   userRoles: ["volunteer"],
   claims: []

--- a/src/pages/residents/index.test.tsx
+++ b/src/pages/residents/index.test.tsx
@@ -23,7 +23,7 @@ import { useResidentsByBuilding } from './useResidentsByBuilding';
 const mockHook = vi.mocked(useResidentsByBuilding);
 
 const dummyUser = {
-  userID: '1',
+  userId: '1',
   userDetails: 'Test',
   userRoles: ['admin'],
   claims: [],

--- a/src/pages/residents/useResidentsByBuilding.test.ts
+++ b/src/pages/residents/useResidentsByBuilding.test.ts
@@ -7,7 +7,12 @@ import * as residentService from '../../services/residentService';
 
 vi.mock('../../services/residentService');
 
-const dummyUser = { userID: '1', userDetails: 'Test User', userRoles: ['admin'], claims: [] };
+const dummyUser = {
+  userId: '1',
+  userDetails: 'Test User',
+  userRoles: ['admin'],
+  claims: [],
+};
 
 const wrapper = ({ children }: { children: React.ReactNode }) =>
   React.createElement(UserContext.Provider, {
@@ -24,9 +29,33 @@ const wrapper = ({ children }: { children: React.ReactNode }) =>
   });
 
 const mockRows = [
-  { id: 1, name: 'Alice', unit_id: 10, unit_number: '2',  building_id: 1, building_name: 'B', building_code: 'B1' },
-  { id: 2, name: 'Bob',   unit_id: 10, unit_number: '2',  building_id: 1, building_name: 'B', building_code: 'B1' },
-  { id: 3, name: 'Carol', unit_id: 20, unit_number: '10', building_id: 1, building_name: 'B', building_code: 'B1' },
+  {
+    id: 1,
+    name: 'Alice',
+    unit_id: 10,
+    unit_number: '2',
+    building_id: 1,
+    building_name: 'B',
+    building_code: 'B1',
+  },
+  {
+    id: 2,
+    name: 'Bob',
+    unit_id: 10,
+    unit_number: '2',
+    building_id: 1,
+    building_name: 'B',
+    building_code: 'B1',
+  },
+  {
+    id: 3,
+    name: 'Carol',
+    unit_id: 20,
+    unit_number: '10',
+    building_id: 1,
+    building_name: 'B',
+    building_code: 'B1',
+  },
 ];
 
 describe('useResidentsByBuilding', () => {
@@ -35,13 +64,17 @@ describe('useResidentsByBuilding', () => {
   });
 
   it('returns empty data when buildingId is null', () => {
-    const { result } = renderHook(() => useResidentsByBuilding(null), { wrapper });
+    const { result } = renderHook(() => useResidentsByBuilding(null), {
+      wrapper,
+    });
     expect(result.current.data).toEqual([]);
     expect(result.current.isLoading).toBe(false);
   });
 
   it('groups flat rows into units with residents', async () => {
-    vi.mocked(residentService.getResidentsByBuilding).mockResolvedValue(mockRows);
+    vi.mocked(residentService.getResidentsByBuilding).mockResolvedValue(
+      mockRows,
+    );
 
     const { result } = renderHook(() => useResidentsByBuilding(1), { wrapper });
 
@@ -54,7 +87,9 @@ describe('useResidentsByBuilding', () => {
   });
 
   it('sorts units numerically by unit_number', async () => {
-    vi.mocked(residentService.getResidentsByBuilding).mockResolvedValue(mockRows);
+    vi.mocked(residentService.getResidentsByBuilding).mockResolvedValue(
+      mockRows,
+    );
 
     const { result } = renderHook(() => useResidentsByBuilding(1), { wrapper });
 
@@ -67,7 +102,9 @@ describe('useResidentsByBuilding', () => {
   it('sets isLoading true while fetching', async () => {
     let resolve: (v: typeof mockRows) => void;
     vi.mocked(residentService.getResidentsByBuilding).mockReturnValue(
-      new Promise((r) => { resolve = r; }),
+      new Promise((r) => {
+        resolve = r;
+      }),
     );
 
     const { result } = renderHook(() => useResidentsByBuilding(1), { wrapper });
@@ -78,7 +115,9 @@ describe('useResidentsByBuilding', () => {
   });
 
   it('sets error when fetch fails', async () => {
-    vi.mocked(residentService.getResidentsByBuilding).mockRejectedValue(new Error('Network error'));
+    vi.mocked(residentService.getResidentsByBuilding).mockRejectedValue(
+      new Error('Network error'),
+    );
 
     const { result } = renderHook(() => useResidentsByBuilding(1), { wrapper });
 
@@ -89,18 +128,27 @@ describe('useResidentsByBuilding', () => {
   });
 
   it('refetches when buildingId changes', async () => {
-    vi.mocked(residentService.getResidentsByBuilding).mockResolvedValue(mockRows);
+    vi.mocked(residentService.getResidentsByBuilding).mockResolvedValue(
+      mockRows,
+    );
 
     const { rerender } = renderHook(({ id }) => useResidentsByBuilding(id), {
       wrapper,
       initialProps: { id: 1 as number | null },
     });
 
-    await waitFor(() => expect(residentService.getResidentsByBuilding).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(residentService.getResidentsByBuilding).toHaveBeenCalledTimes(1),
+    );
 
     rerender({ id: 2 });
 
-    await waitFor(() => expect(residentService.getResidentsByBuilding).toHaveBeenCalledTimes(2));
-    expect(residentService.getResidentsByBuilding).toHaveBeenLastCalledWith(dummyUser, 2);
+    await waitFor(() =>
+      expect(residentService.getResidentsByBuilding).toHaveBeenCalledTimes(2),
+    );
+    expect(residentService.getResidentsByBuilding).toHaveBeenLastCalledWith(
+      dummyUser,
+      2,
+    );
   });
 });

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -64,7 +64,7 @@ export type ResidentFormError = {
 
 export interface ClientPrincipal {
   userDetails: string;
-  userID: string;
+  userId: string;
   userRoles: string[];
 }
 


### PR DESCRIPTION
Backport of #496 to dev.

## Summary
- Fixes admin login failures caused by incorrect `userID` → `userId` field name from Azure SWA auth response
- Adds snackbar error feedback for authentication failures
- Restores granular error context for `upsertAdminUser` failures

> **Note:** The "remove error swallowing" commit was intentionally skipped in this backport to preserve inner try/catch granularity in `MainLayout`.

## Test Plan
- [ ] Manual testing: Admin login on dev
- [ ] Verify error messages display correctly on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized user identifier naming conventions across the codebase.

* **New Features**
  * Integrated snackbar notifications into the main application layout for displaying system alerts.

* **Improvements**
  * Enhanced authentication error handling to display error messages via notifications before navigation, with a brief delay to allow users to read the alert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->