### PR TITLE
chore: bump version to 1.3.5 [backport to dev]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plymouth-housing",
   "private": true,
-  "version": "1.3.4",
+  "version": "1.3.5",
   "type": "module",
   "engines": {
     "node": ">=22.x"


### PR DESCRIPTION
## Summary
- Backport of version bump `1.3.4 → 1.3.5` from main (commit `ad4264f`, PR #496)

## Test plan
- [ ] Verify `package.json` version is `1.3.5` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.3.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->