### PR TITLE
chore: upgrade action-gh-release to v3 for Node.js 24 support

### DIFF
--- a/.github/workflows/azure-static-web-apps-prod.yml
+++ b/.github/workflows/azure-static-web-apps-prod.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Create GitHub Release
       if: steps.check-tag.outputs.TAG_EXISTS == 'false'
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: ${{ steps.package-version.outputs.PACKAGE_VERSION }}
         generate_release_notes: true


### PR DESCRIPTION
## Description

This PR upgrades the `softprops/action-gh-release` GitHub Action from v2 to v3 to address Node.js 20 deprecation warnings and prepare for the Node.js 24 enforcement deadline (June 2nd, 2026).

GitHub is deprecating Node.js 20 actions, and v3 of this action provides native Node.js 24 support. This is a maintenance update with no functional changes to the workflow behavior.

## Jira Ticket
- N/A (maintenance/infrastructure update)

## Type of Change
**Type:** Configuration

## Changes Made
- Updated `softprops/action-gh-release` from `v2` to `v3` in production deployment workflow
- Resolves deprecation warning: "Node.js 20 actions are deprecated"

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have run prettier on the code (N/A - YAML file)
- [x] I have performed a self-review of my code
- [x] I have commented my code only in hard-to-understand areas (N/A - minimal change)
- [x] I have updated the documentation accordingly (N/A - no docs impact)
- [x] My changes generate no new warnings in Chrome Dev Tools (N/A - workflow change)
- [x] I have added unit tests that prove my fix is effective or that my feature works (N/A - workflow change)
- [x] New and existing unit tests pass locally with my changes (N/A - workflow change)

## QA Instructions, Screenshots, Recordings

**Testing:**
This change affects the GitHub Actions workflow that runs on pushes to `main` branch. To verify:

1. The next production deployment should complete without Node.js 20 deprecation warnings
2. The "Create GitHub Release" step should function identically to before
3. No changes to application behavior or deployment process

**What to look for:**
- ✅ No deprecation warnings in GitHub Actions logs
- ✅ Release creation works as expected when a new version tag is pushed
- ✅ Workflow completes successfully

**Reference:**
- [softprops/action-gh-release v3 release notes](https://github.com/softprops/action-gh-release/releases)
- [GitHub Node.js 20 deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to use the latest version of release automation tools, maintaining consistent release process functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->