### PR TITLE
chore: configure dependabot to ignore patch updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 10
+    # Ignore patch updates (e.g., 1.0.0 -> 1.0.1)
+    # This allows: major updates, minor updates, and security updates
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
## Summary
- Configures Dependabot to ignore patch-level updates (e.g., 1.0.0 -> 1.0.1)
- Reduces PR noise while maintaining awareness of meaningful updates
- Still creates PRs for major updates, minor updates, and security updates

## Changes
- Updated `.github/dependabot.yaml` to add ignore rules for `semver-patch` updates
- Dependabot will now only create PRs for:
  - Major version bumps (1.x.x -> 2.0.0)
  - Minor version bumps (1.1.x -> 1.2.0)
  - Security updates (always, regardless of version level)

## Rationale
This configuration strikes a balance between staying up-to-date and reducing maintenance overhead. Minor updates often include new features, deprecation warnings, and performance improvements that are valuable to track, while patch updates are typically small bug fixes that create noise without much value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to refine automated update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->