### PR TITLE
fix: correct userId property name in AddVolunteerModal test mock

### DIFF
--- a/src/components/AddVolunteerModal/AddVolunteerModal.test.tsx
+++ b/src/components/AddVolunteerModal/AddVolunteerModal.test.tsx
@@ -142,7 +142,7 @@ describe('AddVolunteerModal', () => {
   });
 
   test('shows generic fallback message for unexpected status codes', async () => {
-    mockErrorWithStatus('Failed to fetch data: I\'m a teapot', 418);
+    mockErrorWithStatus('Failed to fetch data: I\'m a teapot!!', 418);
     renderModal();
     fillFormAndSubmit();
 

--- a/src/components/AddVolunteerModal/AddVolunteerModal.test.tsx
+++ b/src/components/AddVolunteerModal/AddVolunteerModal.test.tsx
@@ -9,7 +9,7 @@ import * as userService from '../../services/userService';
 vi.mock('../../services/userService');
 
 const mockUser = {
-  userID: '1',
+  userId: '1',
   userDetails: 'Admin User',
   userRoles: ['admin'],
 };
@@ -142,7 +142,7 @@ describe('AddVolunteerModal', () => {
   });
 
   test('shows generic fallback message for unexpected status codes', async () => {
-    mockErrorWithStatus('Failed to fetch data: I\'m a teapot!!', 418);
+    mockErrorWithStatus('Failed to fetch data: I\'m a teapot', 418);
     renderModal();
     fillFormAndSubmit();
 


### PR DESCRIPTION
## Summary
- Fix TypeScript build error in AddVolunteerModal test
- Change `userID` to `userId` in mock object to match `ClientPrincipal` interface
- Test was passing at runtime but failing TypeScript compilation

## Problem
The test mock used `userID` but the `ClientPrincipal` interface requires `userId`. Tests passed because runtime JavaScript doesn't enforce types, but the build failed during TypeScript type checking.

## Test plan
- [x] Tests pass
- [x] Build succeeds
- [x] CI pipeline validates the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected test mocks to properly validate user data handling in the volunteer modal, ensuring tests accurately reflect expected behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digitalaidseattle/plymouth-housing/pull/535)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->