### PR TITLE
PIT-480: replace admin phone number with staff-guidance copy

### DIFF
--- a/src/pages/authentication/ContactAdminDialog.test.tsx
+++ b/src/pages/authentication/ContactAdminDialog.test.tsx
@@ -12,7 +12,6 @@ import ContactAdminDialog from './ContactAdminDialog';
 // Override environment variables for testing (optional)
 Object.defineProperty(import.meta, 'env', {
   value: {
-    VITE_ADMIN_PHONE_NUMBER: '123-456-7890',
     VITE_ADMIN_EMAIL: 'admin@example.com'
   }
 });
@@ -25,10 +24,10 @@ describe('ContactAdminDialog Component', () => {
     // Verify that the dialog title is rendered
     expect(screen.getByText('Forget your PIN?')).toBeInTheDocument();
 
-    // Instead of verifying exact phone/email values, check for key phrases
-    const content = screen.getByText(/Please call the phone number/i);
+    // Instead of verifying the exact email value, check for key phrases
+    const content = screen.getByText(/Let a staff member know/i);
     expect(content).toBeInTheDocument();
-    expect(content.textContent).toMatch(/or email/i);
+    expect(content.textContent).toMatch(/email/i);
 
     // Verify that the Close button is rendered
     expect(screen.getByRole('button', { name: /Close/i })).toBeInTheDocument();

--- a/src/pages/authentication/ContactAdminDialog.test.tsx
+++ b/src/pages/authentication/ContactAdminDialog.test.tsx
@@ -9,13 +9,6 @@ import '@testing-library/jest-dom';
 import { describe, test, expect, vi } from 'vitest';
 import ContactAdminDialog from './ContactAdminDialog';
 
-// Override environment variables for testing (optional)
-Object.defineProperty(import.meta, 'env', {
-  value: {
-    VITE_ADMIN_EMAIL: 'admin@example.com'
-  }
-});
-
 describe('ContactAdminDialog Component', () => {
   test('renders dialog with correct content when open is true', () => {
     const onClose = vi.fn();
@@ -24,10 +17,10 @@ describe('ContactAdminDialog Component', () => {
     // Verify that the dialog title is rendered
     expect(screen.getByText('Forget your PIN?')).toBeInTheDocument();
 
-    // Instead of verifying the exact email value, check for key phrases
+    // Check for the guidance text
     const content = screen.getByText(/Let a staff member know/i);
     expect(content).toBeInTheDocument();
-    expect(content.textContent).toMatch(/email/i);
+    expect(content.textContent).toMatch(/PH admin nearby can help/i);
 
     // Verify that the Close button is rendered
     expect(screen.getByRole('button', { name: /Close/i })).toBeInTheDocument();

--- a/src/pages/authentication/ContactAdminDialog.test.tsx
+++ b/src/pages/authentication/ContactAdminDialog.test.tsx
@@ -9,6 +9,13 @@ import '@testing-library/jest-dom';
 import { describe, test, expect, vi } from 'vitest';
 import ContactAdminDialog from './ContactAdminDialog';
 
+// Override environment variables for testing
+Object.defineProperty(import.meta, 'env', {
+  value: {
+    VITE_ADMIN_EMAIL: 'admin@example.com'
+  }
+});
+
 describe('ContactAdminDialog Component', () => {
   test('renders dialog with correct content when open is true', () => {
     const onClose = vi.fn();
@@ -20,7 +27,7 @@ describe('ContactAdminDialog Component', () => {
     // Check for the guidance text
     const content = screen.getByText(/Let a staff member know/i);
     expect(content).toBeInTheDocument();
-    expect(content.textContent).toMatch(/PH admin nearby can help/i);
+    expect(content.textContent).toMatch(/email/i);
 
     // Verify that the Close button is rendered
     expect(screen.getByRole('button', { name: /Close/i })).toBeInTheDocument();

--- a/src/pages/authentication/ContactAdminDialog.tsx
+++ b/src/pages/authentication/ContactAdminDialog.tsx
@@ -28,7 +28,8 @@ const ContactAdminDialog: React.FC<ContactAdminDialogProps> = ({
       <DialogTitle>Forget your PIN?</DialogTitle>
       <DialogContent>
         <Typography>
-          Let a staff member know. A PH admin nearby can help.
+          Let a staff member know, or email {import.meta.env.VITE_ADMIN_EMAIL}{' '}
+          of a PH admin who can assist you.
         </Typography>
       </DialogContent>
       <DialogActions>

--- a/src/pages/authentication/ContactAdminDialog.tsx
+++ b/src/pages/authentication/ContactAdminDialog.tsx
@@ -28,9 +28,8 @@ const ContactAdminDialog: React.FC<ContactAdminDialogProps> = ({
       <DialogTitle>Forget your PIN?</DialogTitle>
       <DialogContent>
         <Typography>
-          Please call the phone number {import.meta.env.VITE_ADMIN_PHONE_NUMBER}{' '}
-          or email {import.meta.env.VITE_ADMIN_EMAIL} of a PH admin who can
-          assist you.
+          Let a staff member know, or email {import.meta.env.VITE_ADMIN_EMAIL}{' '}
+          of a PH admin who can assist you.
         </Typography>
       </DialogContent>
       <DialogActions>

--- a/src/pages/authentication/ContactAdminDialog.tsx
+++ b/src/pages/authentication/ContactAdminDialog.tsx
@@ -28,8 +28,7 @@ const ContactAdminDialog: React.FC<ContactAdminDialogProps> = ({
       <DialogTitle>Forget your PIN?</DialogTitle>
       <DialogContent>
         <Typography>
-          Let a staff member know, or email {import.meta.env.VITE_ADMIN_EMAIL}{' '}
-          of a PH admin who can assist you.
+          Let a staff member know. A PH admin nearby can help.
         </Typography>
       </DialogContent>
       <DialogActions>

--- a/src/pages/authentication/EnterPinPage.tsx
+++ b/src/pages/authentication/EnterPinPage.tsx
@@ -231,8 +231,8 @@ const EnterPinPage: React.FC = () => {
               lineHeight: 1.5,
             }}
           >
-            <strong>Forget your pin?</strong> Let a staff member know. A PH
-            admin nearby can help.
+            <strong>Forget your pin?</strong> Let a staff member know or contact
+            IT department at {import.meta.env.VITE_ADMIN_EMAIL}
           </Typography>
           <Box sx={{ marginBottom: 6 }}>
             <PinInput

--- a/src/pages/authentication/EnterPinPage.tsx
+++ b/src/pages/authentication/EnterPinPage.tsx
@@ -231,9 +231,8 @@ const EnterPinPage: React.FC = () => {
               lineHeight: 1.5,
             }}
           >
-            <strong>Forget your pin?</strong> Contact IT department at{' '}
-            {import.meta.env.VITE_ADMIN_PHONE_NUMBER} or{' '}
-            {import.meta.env.VITE_ADMIN_EMAIL}
+            <strong>Forget your pin?</strong> Let a staff member know or contact
+            IT department at {import.meta.env.VITE_ADMIN_EMAIL}
           </Typography>
           <Box sx={{ marginBottom: 6 }}>
             <PinInput

--- a/src/pages/authentication/EnterPinPage.tsx
+++ b/src/pages/authentication/EnterPinPage.tsx
@@ -231,8 +231,8 @@ const EnterPinPage: React.FC = () => {
               lineHeight: 1.5,
             }}
           >
-            <strong>Forget your pin?</strong> Let a staff member know or contact
-            IT department at {import.meta.env.VITE_ADMIN_EMAIL}
+            <strong>Forget your pin?</strong> Let a staff member know. A PH
+            admin nearby can help.
           </Typography>
           <Box sx={{ marginBottom: 6 }}>
             <PinInput

--- a/src/pages/authentication/PickNamePage.test.tsx
+++ b/src/pages/authentication/PickNamePage.test.tsx
@@ -70,7 +70,7 @@ describe('PickNamePage Component', () => {
     });
 
     expect(screen.getByText(/Pick Your Name/i)).toBeInTheDocument();
-    expect(screen.getByText(/contact IT department/i)).toBeInTheDocument();
+    expect(screen.getByText(/Let a staff member know/i)).toBeInTheDocument();
   });
 
   test('navigates to /enter-your-pin when a name is selected and Continue is clicked', async () => {

--- a/src/pages/authentication/PickNamePage.tsx
+++ b/src/pages/authentication/PickNamePage.tsx
@@ -127,7 +127,7 @@ const PickYourNamePage: React.FC = () => {
               }}
             >
               <strong>Can't find your name?</strong> Let a staff member know or
-              contact IT department at {import.meta.env.VITE_ADMIN_PHONE_NUMBER}
+              contact IT department at {import.meta.env.VITE_ADMIN_EMAIL}
             </Typography>
 
             <Autocomplete

--- a/src/pages/authentication/PickNamePage.tsx
+++ b/src/pages/authentication/PickNamePage.tsx
@@ -126,8 +126,7 @@ const PickYourNamePage: React.FC = () => {
                 lineHeight: 1.5,
               }}
             >
-              <strong>Can't find your name?</strong> Let a staff member know. A
-              PH admin nearby can help.
+              <strong>Can't find your name?</strong> Let a staff member know.
             </Typography>
 
             <Autocomplete

--- a/src/pages/authentication/PickNamePage.tsx
+++ b/src/pages/authentication/PickNamePage.tsx
@@ -126,8 +126,8 @@ const PickYourNamePage: React.FC = () => {
                 lineHeight: 1.5,
               }}
             >
-              <strong>Can't find your name?</strong> Let a staff member know or
-              contact IT department at {import.meta.env.VITE_ADMIN_EMAIL}
+              <strong>Can't find your name?</strong> Let a staff member know. A
+              PH admin nearby can help.
             </Typography>
 
             <Autocomplete


### PR DESCRIPTION
## Description

PH does not have a single phone number to give out to users, so the app's references to an admin **phone number** (`VITE_ADMIN_PHONE_NUMBER`) in the auth flow were misleading. This PR removes the phone number and any phone-implicating wording, replacing it with the existing **"Let a staff member know"** guidance pattern.

The admin **email** (`VITE_ADMIN_EMAIL`) was already present on `dev` and is left intact as a valid contact channel — only the phone is removed. (`VITE_ADMIN_PHONE_NUMBER` is now unused in the app, with no other references, env typings, or `.env.example` entries to clean up.)

**Note for reviewers:** These files have pre-existing Prettier formatting debt on `dev` (verified via `prettier --check` on the baseline). I intentionally did **not** run `prettier --write` across them, to keep the diff surgical and avoid churn/conflicts with in-flight PRs. The lines I changed are Prettier-clean.

## Jira Ticket
- Closes: [PIT-480](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-480)

## Type of Change
**Type:** Bug fix (content)

## Changes Made
- `ContactAdminDialog.tsx` — "Forget your PIN?" dialog: phone removed → "Let a staff member know, or email {admin email} of a PH admin who can assist you." (email kept)
- `EnterPinPage.tsx` — "Forget your pin?" hint: phone removed → "Let a staff member know or contact IT department at {admin email}." (email kept)
- `PickNamePage.tsx` — "Can't find your name?" hint (only ever had a phone): → "Let a staff member know."
- `ContactAdminDialog.test.tsx` / `PickNamePage.test.tsx` — updated env mock and assertions to match the new copy.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have run [prettier](https://github.com/digitalaidseattle/plymouth-housing#code-formatting) on the code (changed lines are Prettier-clean; see note above re: pre-existing debt)
- [x] I have performed a self-review of my code
- [x] I have commented my code only in hard-to-understand areas (no comments needed)
- [ ] I have updated the documentation accordingly (N/A — no docs affected)
- [ ] My changes generate no new warnings in Chrome Dev Tools (please verify in browser; static copy change)
- [x] I have added unit tests that prove my fix is effective or that my feature works (updated existing auth tests)
- [x] New and existing unit tests pass locally with my changes

## QA Instructions, Screenshots, Recordings

Run the app locally (`dab start` + `npx swa start`, open http://localhost:4280) and walk the login flow. Confirm no phone number appears (email still shown where it was before):

1. **Pick Your Name** page → "Can't find your name?" → "Let a staff member know."
2. **Enter PIN** page → "Forget your pin?" → "Let a staff member know or contact IT department at {admin email}."
3. **Forget your PIN? dialog** (ContactAdminDialog) → "Let a staff member know, or email {admin email} of a PH admin who can assist you."
