### PR TITLE
chore: group Dependabot npm updates into a single PR

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,12 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 10
+    # Bundle all surviving updates into a single PR per run to cut noise.
+    # Dependabot applies `ignore` first, then groups whatever remains.
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
     # Ignore patch updates (e.g., 1.0.0 -> 1.0.1)
     # This allows: major updates, minor updates, and security updates
     ignore:


### PR DESCRIPTION
## What

Bundle all surviving npm version updates into a **single grouped PR per run** instead of one PR per dependency, to cut Dependabot noise.

```yaml
groups:
  npm-dependencies:
    patterns:
      - "*"
```

The existing `semver-patch` ignore rule is unchanged — Dependabot applies `ignore` first, then groups whatever remains, so patches never enter the group.

## Why

The last monthly run opened ~9 separate PRs. Grouping collapses them into one, which is far easier to review and merge.

## Notes

- Dependabot reads config from the **default branch**, so this only takes effect once merged to `main`.
- Security updates and the patch-ignore behavior are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to bundle eligible npm dependency updates into a single pull request per update cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->