### PR TITLE
feat: implement pagination with rows per page selection in Inventory and People page

### DIFF
--- a/src/components/inventory/InventoryTable.tsx
+++ b/src/components/inventory/InventoryTable.tsx
@@ -81,24 +81,51 @@ const InventoryTable: React.FC<InventoryTableProps> = ({
   };
 
   return (
-    <Box id="inventory-container" sx={{ mt: 2, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
-      <TableContainer component={Paper} sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
-        <Table stickyHeader sx={{ tableLayout: 'fixed', minWidth: 1150, '& .MuiTableCell-root': { px: 1.5 } }}>
+    <Box
+      id="inventory-container"
+      sx={{
+        mt: 2,
+        flex: 1,
+        minHeight: 0,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <TableContainer
+        component={Paper}
+        sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}
+      >
+        <Table
+          stickyHeader
+          sx={{
+            tableLayout: 'fixed',
+            minWidth: 1150,
+            '& .MuiTableCell-root': { px: 1.5 },
+          }}
+        >
           <TableHead>
             <TableRow sx={{ height: '64px' }}>
               {renderSortableHeader('name', 'Name', '16%')}
-              <TableCell sx={{ fontWeight: 'bold', width: '30%' }}>Description</TableCell>
+              <TableCell sx={{ fontWeight: 'bold', width: '30%' }}>
+                Description
+              </TableCell>
               {renderSortableHeader('type', 'Type', '10%')}
               {renderSortableHeader('category', 'Category', '12%')}
               {renderSortableHeader('status', 'Status', '13%')}
               {renderSortableHeader('quantity', 'Quantity', '9%', 'center')}
-              <TableCell sx={{ fontWeight: 'bold', width: '10%', textAlign: 'right' }}>Adjust</TableCell>
+              <TableCell
+                sx={{ fontWeight: 'bold', width: '10%', textAlign: 'right' }}
+              >
+                Adjust
+              </TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             {paginatedItems.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={7} align="center">No items to display</TableCell>
+                <TableCell colSpan={7} align="center">
+                  No items to display
+                </TableCell>
               </TableRow>
             ) : (
               paginatedItems.map((row, index) => (
@@ -109,24 +136,64 @@ const InventoryTable: React.FC<InventoryTableProps> = ({
                     boxShadow: '0px -1px 0px 0px rgb(212, 212, 212);',
                   }}
                 >
-                  <TableCell sx={{ width: '16%', whiteSpace: 'normal', overflowWrap: 'normal' }}>{row.name}</TableCell>
-                  <TableCell sx={{ width: '30%', whiteSpace: 'normal', overflowWrap: 'normal' }}>{row.description}</TableCell>
-                  <TableCell sx={{ width: '10%', whiteSpace: 'normal', overflowWrap: 'normal' }}>{row.type}</TableCell>
-                  <TableCell sx={{ width: '12%', whiteSpace: 'normal', overflowWrap: 'normal' }}>{row.category}</TableCell>
+                  <TableCell
+                    sx={{
+                      width: '16%',
+                      whiteSpace: 'normal',
+                      overflowWrap: 'normal',
+                    }}
+                  >
+                    {row.name}
+                  </TableCell>
+                  <TableCell
+                    sx={{
+                      width: '30%',
+                      whiteSpace: 'normal',
+                      overflowWrap: 'normal',
+                    }}
+                  >
+                    {row.description}
+                  </TableCell>
+                  <TableCell
+                    sx={{
+                      width: '10%',
+                      whiteSpace: 'normal',
+                      overflowWrap: 'normal',
+                    }}
+                  >
+                    {row.type}
+                  </TableCell>
+                  <TableCell
+                    sx={{
+                      width: '12%',
+                      whiteSpace: 'normal',
+                      overflowWrap: 'normal',
+                    }}
+                  >
+                    {row.category}
+                  </TableCell>
                   <TableCell sx={{ width: '13%' }}>
                     <Chip
                       label={row.status}
                       sx={{
                         maxWidth: '100%',
                         height: 'auto',
-                        backgroundColor: row.status === 'Out of Stock' ? '#FDECEA'
-                          : row.status === 'Low Stock' ? '#FFF9C4'
-                          : row.status === 'Needs Review' ? '#fff5e8ff'
-                          : '#E6F4EA',
-                        color: row.status === 'Out of Stock' ? '#D32F2F'
-                          : row.status === 'Low Stock' ? '#6A4E23'
-                          : row.status === 'Needs Review' ? '#663C00'
-                          : '#357A38',
+                        backgroundColor:
+                          row.status === 'Out of Stock'
+                            ? '#FDECEA'
+                            : row.status === 'Low Stock'
+                              ? '#FFF9C4'
+                              : row.status === 'Needs Review'
+                                ? '#fff5e8ff'
+                                : '#E6F4EA',
+                        color:
+                          row.status === 'Out of Stock'
+                            ? '#D32F2F'
+                            : row.status === 'Low Stock'
+                              ? '#6A4E23'
+                              : row.status === 'Needs Review'
+                                ? '#663C00'
+                                : '#357A38',
                         borderRadius: '8px',
                         '& .MuiChip-label': {
                           px: 1,
@@ -138,10 +205,30 @@ const InventoryTable: React.FC<InventoryTableProps> = ({
                       }}
                     />
                   </TableCell>
-                  <TableCell sx={{ width: '9%', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', textAlign: 'center' }}>
-                    {row.quantity >= 0 ? row.quantity : <WarningAmberIcon color="warning"/>}
+                  <TableCell
+                    sx={{
+                      width: '9%',
+                      overflow: 'hidden',
+                      whiteSpace: 'nowrap',
+                      textOverflow: 'ellipsis',
+                      textAlign: 'center',
+                    }}
+                  >
+                    {row.quantity >= 0 ? (
+                      row.quantity
+                    ) : (
+                      <WarningAmberIcon color="warning" />
+                    )}
                   </TableCell>
-                  <TableCell sx={{ width: '10%', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', textAlign: 'right' }}>
+                  <TableCell
+                    sx={{
+                      width: '10%',
+                      overflow: 'hidden',
+                      whiteSpace: 'nowrap',
+                      textOverflow: 'ellipsis',
+                      textAlign: 'right',
+                    }}
+                  >
                     <Button
                       aria-label="Override quantity"
                       onClick={() => {
@@ -159,17 +246,21 @@ const InventoryTable: React.FC<InventoryTableProps> = ({
         </Table>
       </TableContainer>
       <Box sx={{ display: 'flex', alignItems: 'center', mt: 1 }}>
-        <Box sx={{ flex: 1 }} />
-        <Pagination
-          count={Math.ceil(items.length / rowsPerPage)}
-          page={page + 1}
-          onChange={(_, newPage) => setPage(newPage - 1)}
-        />
-        <Box sx={{ flex: 1, display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 1 }}>
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+          }}
+        >
           <Typography variant="body2">Rows per page:</Typography>
           <Select
             variant="standard"
-            sx={{ '&::before': { borderBottom: 'none' }, '&:hover:not(.Mui-disabled)::before': { borderBottom: 'none' } }}
+            sx={{
+              '&::before': { borderBottom: 'none' },
+              '&:hover:not(.Mui-disabled)::before': { borderBottom: 'none' },
+            }}
             value={rowsPerPage}
             onChange={(e) => {
               setRowsPerPage(Number(e.target.value));
@@ -181,10 +272,18 @@ const InventoryTable: React.FC<InventoryTableProps> = ({
             }}
           >
             {SETTINGS.rowsPerPageOptions.map((option) => (
-              <MenuItem key={option} value={option}>{option}</MenuItem>
+              <MenuItem key={option} value={option}>
+                {option}
+              </MenuItem>
             ))}
           </Select>
         </Box>
+
+        <Pagination
+          count={Math.ceil(items.length / rowsPerPage)}
+          page={page + 1}
+          onChange={(_, newPage) => setPage(newPage - 1)}
+        />
       </Box>
     </Box>
   );

--- a/src/components/inventory/InventoryTable.tsx
+++ b/src/components/inventory/InventoryTable.tsx
@@ -4,14 +4,15 @@
  *  @copyright 2026 Digital Aid Seattle
  *
  */
-import React from 'react';
-import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Chip, Box, Button, TableSortLabel } from '@mui/material';
+import React, { useState, useEffect } from 'react';
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Chip, Box, Button, TableSortLabel, Pagination, MenuItem, Select, Typography } from '@mui/material';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import { InventoryItem } from '../../types/interfaces.ts';
 import SettingsIcon from '@mui/icons-material/Settings';
+import { SETTINGS } from '../../types/constants';
 
 interface InventoryTableProps {
-  currentItems: InventoryItem[];
+  items: InventoryItem[];
   sortDirection: 'asc' | 'desc' | 'original';
   sortColumn: keyof InventoryItem | null;
   handleSort: (column: keyof InventoryItem) => void;
@@ -29,16 +30,21 @@ const getAriaSortValue = (
 };
 
 const InventoryTable: React.FC<InventoryTableProps> = ({
-  currentItems,
+  items,
   sortDirection,
   sortColumn,
   handleSort,
   setAdjustModal,
   setItemToEdit,
 }) => {
-  if (!currentItems?.length) {
-    return <Box>No items to display</Box>;
-  }
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(SETTINGS.itemsPerPage);
+
+  useEffect(() => {
+    setPage(0);
+  }, [items]);
+
+  const paginatedItems = items.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage);
 
   const renderSortableHeader = (
     key: keyof InventoryItem,
@@ -90,62 +96,96 @@ const InventoryTable: React.FC<InventoryTableProps> = ({
             </TableRow>
           </TableHead>
           <TableBody>
-            {currentItems.map((row, index) => (
-              <TableRow
-                key={index}
-                sx={{
-                  height: '64px',
-                  boxShadow: '0px -1px 0px 0px rgb(212, 212, 212);',
-                }}
-              >
-                <TableCell sx={{ width: '16%', whiteSpace: 'normal', overflowWrap: 'normal' }}>{row.name}</TableCell>
-                <TableCell sx={{ width: '30%', whiteSpace: 'normal', overflowWrap: 'normal' }}>{row.description}</TableCell>
-                <TableCell sx={{ width: '10%', whiteSpace: 'normal', overflowWrap: 'normal' }}>{row.type}</TableCell>
-                <TableCell sx={{ width: '12%', whiteSpace: 'normal', overflowWrap: 'normal' }}>{row.category}</TableCell>
-                <TableCell sx={{ width: '13%' }}>
-                  <Chip
-                    label={row.status}
-                    sx={{
-                      maxWidth: '100%',
-                      height: 'auto',
-                      backgroundColor: row.status === 'Out of Stock' ? '#FDECEA'
-                        : row.status === 'Low Stock' ? '#FFF9C4'
-                        : row.status === 'Needs Review' ? '#fff5e8ff'
-                        : '#E6F4EA',
-                      color: row.status === 'Out of Stock' ? '#D32F2F'
-                        : row.status === 'Low Stock' ? '#6A4E23'
-                        : row.status === 'Needs Review' ? '#663C00'
-                        : '#357A38',
-                      borderRadius: '8px',
-                      '& .MuiChip-label': {
-                        px: 1,
-                        py: 0.5,
-                        whiteSpace: 'normal',
-                        overflowWrap: 'normal',
-                        textAlign: 'center',
-                      },
-                    }}
-                  />
-                </TableCell>
-                <TableCell sx={{ width: '9%', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', textAlign: 'center' }}>
-                  {row.quantity >= 0 ? row.quantity : <WarningAmberIcon color="warning"/>}
-                </TableCell>
-                <TableCell sx={{ width: '10%', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', textAlign: 'right' }}>
-                  <Button
-                    aria-label="Override quantity"
-                    onClick={() => {
-                      setItemToEdit(row);
-                      setAdjustModal(true);
-                    }}
-                  >
-                    <SettingsIcon color="secondary" />
-                  </Button>
-                </TableCell>
+            {paginatedItems.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} align="center">No items to display</TableCell>
               </TableRow>
-            ))}
+            ) : (
+              paginatedItems.map((row, index) => (
+                <TableRow
+                  key={index}
+                  sx={{
+                    height: '64px',
+                    boxShadow: '0px -1px 0px 0px rgb(212, 212, 212);',
+                  }}
+                >
+                  <TableCell sx={{ width: '16%', whiteSpace: 'normal', overflowWrap: 'normal' }}>{row.name}</TableCell>
+                  <TableCell sx={{ width: '30%', whiteSpace: 'normal', overflowWrap: 'normal' }}>{row.description}</TableCell>
+                  <TableCell sx={{ width: '10%', whiteSpace: 'normal', overflowWrap: 'normal' }}>{row.type}</TableCell>
+                  <TableCell sx={{ width: '12%', whiteSpace: 'normal', overflowWrap: 'normal' }}>{row.category}</TableCell>
+                  <TableCell sx={{ width: '13%' }}>
+                    <Chip
+                      label={row.status}
+                      sx={{
+                        maxWidth: '100%',
+                        height: 'auto',
+                        backgroundColor: row.status === 'Out of Stock' ? '#FDECEA'
+                          : row.status === 'Low Stock' ? '#FFF9C4'
+                          : row.status === 'Needs Review' ? '#fff5e8ff'
+                          : '#E6F4EA',
+                        color: row.status === 'Out of Stock' ? '#D32F2F'
+                          : row.status === 'Low Stock' ? '#6A4E23'
+                          : row.status === 'Needs Review' ? '#663C00'
+                          : '#357A38',
+                        borderRadius: '8px',
+                        '& .MuiChip-label': {
+                          px: 1,
+                          py: 0.5,
+                          whiteSpace: 'normal',
+                          overflowWrap: 'normal',
+                          textAlign: 'center',
+                        },
+                      }}
+                    />
+                  </TableCell>
+                  <TableCell sx={{ width: '9%', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', textAlign: 'center' }}>
+                    {row.quantity >= 0 ? row.quantity : <WarningAmberIcon color="warning"/>}
+                  </TableCell>
+                  <TableCell sx={{ width: '10%', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', textAlign: 'right' }}>
+                    <Button
+                      aria-label="Override quantity"
+                      onClick={() => {
+                        setItemToEdit(row);
+                        setAdjustModal(true);
+                      }}
+                    >
+                      <SettingsIcon color="secondary" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
           </TableBody>
         </Table>
       </TableContainer>
+      <Box sx={{ display: 'flex', alignItems: 'center', mt: 1 }}>
+        <Box sx={{ flex: 1 }} />
+        <Pagination
+          count={Math.ceil(items.length / rowsPerPage)}
+          page={page + 1}
+          onChange={(_, newPage) => setPage(newPage - 1)}
+        />
+        <Box sx={{ flex: 1, display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 1 }}>
+          <Typography variant="body2">Rows per page:</Typography>
+          <Select
+            variant="standard"
+            sx={{ '&::before': { borderBottom: 'none' }, '&:hover:not(.Mui-disabled)::before': { borderBottom: 'none' } }}
+            value={rowsPerPage}
+            onChange={(e) => {
+              setRowsPerPage(Number(e.target.value));
+              setPage(0);
+            }}
+            MenuProps={{
+              anchorOrigin: { vertical: 'top', horizontal: 'left' },
+              transformOrigin: { vertical: 'bottom', horizontal: 'left' },
+            }}
+          >
+            {SETTINGS.rowsPerPageOptions.map((option) => (
+              <MenuItem key={option} value={option}>{option}</MenuItem>
+            ))}
+          </Select>
+        </Box>
+      </Box>
     </Box>
   );
 };

--- a/src/pages/inventory/index.tsx
+++ b/src/pages/inventory/index.tsx
@@ -10,7 +10,7 @@ import React, {
   useEffect,
   useCallback,
 } from 'react';
-import { Alert, Box, Button, Pagination, Stack } from '@mui/material';
+import { Alert, Box, Button, Stack } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import AddItemModal from '../../components/inventory/AddItemModal.tsx';
 import AdjustQuantityModal from '../../components/inventory/AdjustQuantityModal.tsx';
@@ -19,7 +19,6 @@ import InventoryTable from '../../components/inventory/InventoryTable';
 import { UserContext } from '../../components/contexts/UserContext';
 import { CategoryItem, InventoryItem } from '../../types/interfaces.ts';
 import { getItems, getCategories } from '../../services/itemsService';
-import { SETTINGS } from '../../types/constants';
 import SnackbarAlert from '../../components/SnackbarAlert';
 import { useLocation } from 'react-router-dom';
 
@@ -48,7 +47,6 @@ const Inventory = () => {
     category: null as null | HTMLElement,
     status: null as null | HTMLElement,
   });
-  const [currentPage, setCurrentPage] = useState(1);
   const [error, setError] = useState<string | null>(null);
   const [snackbarState, setSnackbarState] = useState<{
     open: boolean;
@@ -59,13 +57,7 @@ const Inventory = () => {
     message: location.state ? location.state.message : '',
     severity: 'success',
   });
-  const itemsPerPage = SETTINGS.itemsPerPage;
   const [showResults, setShowResults] = useState(false);
-
-  const indexOfLastItem = currentPage * itemsPerPage;
-  const indexOfFirstItem = indexOfLastItem - itemsPerPage;
-  const currentItems = displayData.slice(indexOfFirstItem, indexOfLastItem);
-
 
   const handleAddOpen = () => {
     setAddModal(true);
@@ -131,13 +123,6 @@ const Inventory = () => {
     }));
   };
 
-  const handlePageChange = (
-    _event: React.ChangeEvent<unknown>,
-    value: number,
-  ) => {
-    setCurrentPage(value);
-  };
-
   const negativeItemCount = originalData.filter(
     (item) => item.quantity < 0,
   ).length;
@@ -195,7 +180,6 @@ const Inventory = () => {
     }
 
     setDisplayData(searchFiltered);
-    setCurrentPage(1);
   }, [filters, sortDirection, sortColumn, originalData]);
 
   const fetchData = useCallback(async () => {
@@ -232,17 +216,8 @@ const Inventory = () => {
     const handler = setTimeout(() => {
       handleFilter();
     }, 300); // Reduces calls to filter while typing in search
-    return () => {
-      clearTimeout(handler);
-    };
-  }, [filters, handleFilter]);
-
-  useEffect(() => {
-    const handler = setTimeout(() => {
-      handleFilter();
-    }, 0);
     return () => clearTimeout(handler);
-  }, [sortDirection, handleFilter]);
+  }, [handleFilter]);
 
   useEffect(() => {
     if (error) {
@@ -320,7 +295,7 @@ const Inventory = () => {
       {/* Inventory Table */}
       <Box sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
         <InventoryTable
-          currentItems={currentItems}
+          items={displayData}
           sortDirection={sortDirection}
           sortColumn={sortColumn}
           handleSort={handleSort}
@@ -329,16 +304,6 @@ const Inventory = () => {
         />
       </Box>
 
-      {/* Pagination */}
-      <Box
-        sx={{ display: 'flex', justifyContent: 'center', marginTop: 2 }}
-      >
-        <Pagination
-          count={Math.ceil(displayData.length / itemsPerPage)}
-          page={currentPage}
-          onChange={handlePageChange}
-        />
-      </Box>
       <SnackbarAlert
         open={snackbarState.open}
         onClose={handleSnackbarClose}

--- a/src/pages/people/UserTable.tsx
+++ b/src/pages/people/UserTable.tsx
@@ -94,7 +94,10 @@ const UserTable: React.FC<UserTableProps> = ({
   };
   return (
     <>
-      <TableContainer component={Paper} sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
+      <TableContainer
+        component={Paper}
+        sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}
+      >
         <Table stickyHeader>
           <TableHead>
             <TableRow>
@@ -151,7 +154,10 @@ const UserTable: React.FC<UserTableProps> = ({
                     : 'None'}
                 </TableCell>
                 <TableCell>
-                  <IconButton aria-label="more" onClick={(e) => handleMenuOpen(e, user)}>
+                  <IconButton
+                    aria-label="more"
+                    onClick={(e) => handleMenuOpen(e, user)}
+                  >
                     <MoreVertIcon />
                   </IconButton>
                 </TableCell>
@@ -169,8 +175,9 @@ const UserTable: React.FC<UserTableProps> = ({
           <MenuItem onClick={handleStatusToggle}>
             {selectedUser?.active ? 'Deactivate Role' : 'Activate Role'}
           </MenuItem>
-          {selectedUser?.role !== 'admin'&&(
-          <MenuItem onClick={handleShowPin}>Show PIN</MenuItem>)}
+          {selectedUser?.role !== 'admin' && (
+            <MenuItem onClick={handleShowPin}>Show PIN</MenuItem>
+          )}
         </Menu>
 
         {/* PIN Modal */}
@@ -227,17 +234,21 @@ const UserTable: React.FC<UserTableProps> = ({
         </SnackbarAlert>
       </TableContainer>
       <Box sx={{ display: 'flex', alignItems: 'center', mt: 1 }}>
-        <Box sx={{ flex: 1 }} />
-        <Pagination
-          count={Math.ceil(users.length / rowsPerPage)}
-          page={page + 1}
-          onChange={(_, newPage) => setPage(newPage - 1)}
-        />
-        <Box sx={{ flex: 1, display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 1 }}>
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+          }}
+        >
           <Typography variant="body2">Rows per page:</Typography>
           <Select
             variant="standard"
-            sx={{ '&::before': { borderBottom: 'none' }, '&:hover:not(.Mui-disabled)::before': { borderBottom: 'none' } }}
+            sx={{
+              '&::before': { borderBottom: 'none' },
+              '&:hover:not(.Mui-disabled)::before': { borderBottom: 'none' },
+            }}
             value={rowsPerPage}
             onChange={(e) => {
               setRowsPerPage(Number(e.target.value));
@@ -249,10 +260,17 @@ const UserTable: React.FC<UserTableProps> = ({
             }}
           >
             {SETTINGS.rowsPerPageOptions.map((option) => (
-              <MenuItem key={option} value={option}>{option}</MenuItem>
+              <MenuItem key={option} value={option}>
+                {option}
+              </MenuItem>
             ))}
           </Select>
         </Box>
+        <Pagination
+          count={Math.ceil(users.length / rowsPerPage)}
+          page={page + 1}
+          onChange={(_, newPage) => setPage(newPage - 1)}
+        />
       </Box>
     </>
   );

--- a/src/pages/people/UserTable.tsx
+++ b/src/pages/people/UserTable.tsx
@@ -4,7 +4,7 @@
  *  @copyright 2026 Digital Aid Seattle
  *
  */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Table,
   TableBody,
@@ -20,6 +20,8 @@ import {
   Modal,
   Box,
   Typography,
+  Pagination,
+  Select
 } from '@mui/material';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
@@ -27,6 +29,7 @@ import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import CloseIcon from '@mui/icons-material/Close';
 import { User } from '../../types/interfaces';
 import SnackbarAlert from '../../components/SnackbarAlert';
+import { SETTINGS } from '../../types/constants';
 
 interface UserTableProps {
   users: User[];
@@ -48,6 +51,15 @@ const UserTable: React.FC<UserTableProps> = ({
   const [openPinModal, setOpenPinModal] = useState(false);
   const [selectedPin, setSelectedPin] = useState('');
   const [snackbarOpen, setSnackbarOpen] = useState(false);
+
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(SETTINGS.itemsPerPage);
+
+  useEffect(() => {
+    setPage(0);
+  }, [users]);
+
+  const paginatedUsers = users.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage);
 
   const handleMenuOpen = (
     event: React.MouseEvent<HTMLElement>,
@@ -81,138 +93,168 @@ const UserTable: React.FC<UserTableProps> = ({
     handleMenuClose();
   };
   return (
-    <TableContainer component={Paper} sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
-      <Table stickyHeader>
-        <TableHead>
-          <TableRow>
-            <TableCell
-              sx={{ fontWeight: 'bold', cursor: 'pointer' }}
-              onClick={onNameOrderToggle}
-            >
-              <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                Name
-                {nameOrder === 'asc' ? (
-                  <ArrowUpwardIcon
-                    fontSize="small"
-                    sx={{ ml: 0.5, color: 'gray' }}
-                  />
-                ) : nameOrder === 'desc' ? (
-                  <ArrowDownwardIcon
-                    fontSize="small"
-                    sx={{ ml: 0.5, color: 'gray' }}
-                  />
-                ) : null}
-              </Box>
-            </TableCell>
-            <TableCell sx={{ fontWeight: 'bold' }}>Role</TableCell>
-            <TableCell sx={{ fontWeight: 'bold' }}>Status</TableCell>
-            <TableCell sx={{ fontWeight: 'bold' }}>Date Created</TableCell>
-            <TableCell sx={{ fontWeight: 'bold' }}>
-              Last Signed In Date
-            </TableCell>
-            <TableCell sx={{ fontWeight: 'bold' }}></TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {users.map((user, index) => (
-            <TableRow key={index}>
-              <TableCell>{user.name}</TableCell>
-              <TableCell>{user.role}</TableCell>
-              <TableCell>
-                <Chip
-                  label={user.active ? 'Active' : 'Inactive'}
-                  sx={{
-                    backgroundColor: user.active ? '#E6F4EA' : '#FDECEA',
-                    color: user.active ? '#357A38' : '#D32F2F',
-                    borderRadius: '8px',
-                    px: 1.5,
-                  }}
-                />
+    <>
+      <TableContainer component={Paper} sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
+        <Table stickyHeader>
+          <TableHead>
+            <TableRow>
+              <TableCell
+                sx={{ fontWeight: 'bold', cursor: 'pointer' }}
+                onClick={onNameOrderToggle}
+              >
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                  Name
+                  {nameOrder === 'asc' ? (
+                    <ArrowUpwardIcon
+                      fontSize="small"
+                      sx={{ ml: 0.5, color: 'gray' }}
+                    />
+                  ) : nameOrder === 'desc' ? (
+                    <ArrowDownwardIcon
+                      fontSize="small"
+                      sx={{ ml: 0.5, color: 'gray' }}
+                    />
+                  ) : null}
+                </Box>
               </TableCell>
-              <TableCell>
-                {new Date(user.created_at).toLocaleDateString()}
+              <TableCell sx={{ fontWeight: 'bold' }}>Role</TableCell>
+              <TableCell sx={{ fontWeight: 'bold' }}>Status</TableCell>
+              <TableCell sx={{ fontWeight: 'bold' }}>Date Created</TableCell>
+              <TableCell sx={{ fontWeight: 'bold' }}>
+                Last Signed In Date
               </TableCell>
-              <TableCell>
-                {user.last_signed_in
-                  ? new Date(user.last_signed_in).toLocaleDateString()
-                  : 'None'}
-              </TableCell>
-              <TableCell>
-                <IconButton aria-label="more" onClick={(e) => handleMenuOpen(e, user)}>
-                  <MoreVertIcon />
-                </IconButton>
-              </TableCell>
+              <TableCell sx={{ fontWeight: 'bold' }}></TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHead>
+          <TableBody>
+            {paginatedUsers.map((user, index) => (
+              <TableRow key={index}>
+                <TableCell>{user.name}</TableCell>
+                <TableCell>{user.role}</TableCell>
+                <TableCell>
+                  <Chip
+                    label={user.active ? 'Active' : 'Inactive'}
+                    sx={{
+                      backgroundColor: user.active ? '#E6F4EA' : '#FDECEA',
+                      color: user.active ? '#357A38' : '#D32F2F',
+                      borderRadius: '8px',
+                      px: 1.5,
+                    }}
+                  />
+                </TableCell>
+                <TableCell>
+                  {new Date(user.created_at).toLocaleDateString()}
+                </TableCell>
+                <TableCell>
+                  {user.last_signed_in
+                    ? new Date(user.last_signed_in).toLocaleDateString()
+                    : 'None'}
+                </TableCell>
+                <TableCell>
+                  <IconButton aria-label="more" onClick={(e) => handleMenuOpen(e, user)}>
+                    <MoreVertIcon />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
 
-      {/* Menu for actions */}
-      <Menu
-        anchorEl={anchorEl}
-        open={Boolean(anchorEl)}
-        onClose={handleMenuClose}
-      >
-        <MenuItem onClick={handleStatusToggle}>
-          {selectedUser?.active ? 'Deactivate Role' : 'Activate Role'}
-        </MenuItem>
-        {selectedUser?.role !== 'admin'&&(
-        <MenuItem onClick={handleShowPin}>Show PIN</MenuItem>)}
-      </Menu>
-
-      {/* PIN Modal */}
-      <Modal
-        open={openPinModal}
-        onClose={() => setOpenPinModal(false)}
-        aria-labelledby="pin-modal-title"
-        aria-describedby="pin-modal-description"
-      >
-        <Box
-          sx={{
-            position: 'absolute',
-            top: '50%',
-            left: '50%',
-            transform: 'translate(-50%, -50%)',
-            bgcolor: 'background.paper',
-            borderRadius: '8px',
-            boxShadow: 24,
-            p: 4,
-            outline: 'none',
-            width: 300,
-            textAlign: 'center',
-          }}
+        {/* Menu for actions */}
+        <Menu
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={handleMenuClose}
         >
-          {/* Close Button */}
-          <IconButton
-            aria-label="close"
-            onClick={() => setOpenPinModal(false)}
+          <MenuItem onClick={handleStatusToggle}>
+            {selectedUser?.active ? 'Deactivate Role' : 'Activate Role'}
+          </MenuItem>
+          {selectedUser?.role !== 'admin'&&(
+          <MenuItem onClick={handleShowPin}>Show PIN</MenuItem>)}
+        </Menu>
+
+        {/* PIN Modal */}
+        <Modal
+          open={openPinModal}
+          onClose={() => setOpenPinModal(false)}
+          aria-labelledby="pin-modal-title"
+          aria-describedby="pin-modal-description"
+        >
+          <Box
             sx={{
               position: 'absolute',
-              right: 8,
-              top: 8,
-              color: (theme) => theme.palette.grey[500],
+              top: '50%',
+              left: '50%',
+              transform: 'translate(-50%, -50%)',
+              bgcolor: 'background.paper',
+              borderRadius: '8px',
+              boxShadow: 24,
+              p: 4,
+              outline: 'none',
+              width: 300,
+              textAlign: 'center',
             }}
           >
-            <CloseIcon />
-          </IconButton>
+            {/* Close Button */}
+            <IconButton
+              aria-label="close"
+              onClick={() => setOpenPinModal(false)}
+              sx={{
+                position: 'absolute',
+                right: 8,
+                top: 8,
+                color: (theme) => theme.palette.grey[500],
+              }}
+            >
+              <CloseIcon />
+            </IconButton>
 
-          <Typography id="pin-modal-title" variant="h6" component="h2">
-            PIN Code
-          </Typography>
-          <Typography id="pin-modal-description" sx={{ mt: 2 }}>
-            <strong>{selectedPin}</strong>
-          </Typography>
+            <Typography id="pin-modal-title" variant="h6" component="h2">
+              PIN Code
+            </Typography>
+            <Typography id="pin-modal-description" sx={{ mt: 2 }}>
+              <strong>{selectedPin}</strong>
+            </Typography>
+          </Box>
+        </Modal>
+
+        <SnackbarAlert
+          open={snackbarOpen}
+          onClose={() => setSnackbarOpen(false)}
+          severity="warning"
+        >
+          'PIN not available.'
+        </SnackbarAlert>
+      </TableContainer>
+      <Box sx={{ display: 'flex', alignItems: 'center', mt: 1 }}>
+        <Box sx={{ flex: 1 }} />
+        <Pagination
+          count={Math.ceil(users.length / rowsPerPage)}
+          page={page + 1}
+          onChange={(_, newPage) => setPage(newPage - 1)}
+        />
+        <Box sx={{ flex: 1, display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 1 }}>
+          <Typography variant="body2">Rows per page:</Typography>
+          <Select
+            variant="standard"
+            sx={{ '&::before': { borderBottom: 'none' }, '&:hover:not(.Mui-disabled)::before': { borderBottom: 'none' } }}
+            value={rowsPerPage}
+            onChange={(e) => {
+              setRowsPerPage(Number(e.target.value));
+              setPage(0);
+            }}
+            MenuProps={{
+              anchorOrigin: { vertical: 'top', horizontal: 'left' },
+              transformOrigin: { vertical: 'bottom', horizontal: 'left' },
+            }}
+          >
+            {SETTINGS.rowsPerPageOptions.map((option) => (
+              <MenuItem key={option} value={option}>{option}</MenuItem>
+            ))}
+          </Select>
         </Box>
-      </Modal>
-
-      <SnackbarAlert
-        open={snackbarOpen}
-        onClose={() => setSnackbarOpen(false)}
-        severity="warning"
-      >
-        'PIN not available.'
-      </SnackbarAlert>
-    </TableContainer>
+      </Box>
+    </>
   );
 };
 

--- a/src/pages/people/index.tsx
+++ b/src/pages/people/index.tsx
@@ -5,8 +5,7 @@
  *
  */
 import React, { useState, useEffect } from 'react';
-import { SETTINGS } from '../../types/constants';
-import { Box, Button, Pagination, Stack } from '@mui/material';
+import { Box, Button, Stack } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import UserFilters from './UserFilters';
 import UserTable from './UserTable';
@@ -21,8 +20,6 @@ const UserPage = () => {
   const [nameOrder, setNameOrder] = useState<'asc' | 'desc' | 'original'>(
     'original',
   );
-  const [currentPage, setCurrentPage] = useState(1);
-  const itemsPerPage = SETTINGS.itemsPerPage;
   const [addModalOpen, setAddModalOpen] = useState(false);
   const [snackbarState, setSnackbarState] = useState<{
     open: boolean;
@@ -83,22 +80,9 @@ const UserPage = () => {
     );
   };
 
-  const handlePageChange = (
-    _event: React.ChangeEvent<unknown>,
-    value: number,
-  ) => {
-    setCurrentPage(value);
-  };
-
   const handleSearchChange = (value: string) => {
     setSearch(value);
   };
-
-  // Pagination logic
-  const indexOfLastItem = currentPage * itemsPerPage;
-  const indexOfFirstItem = indexOfLastItem - itemsPerPage;
-  const currentItems = filteredData.slice(indexOfFirstItem, indexOfLastItem);
-  const totalPages = Math.ceil(filteredData.length / itemsPerPage);
 
   const openAddModal = () => setAddModalOpen(true);
   const closeAddModal = () => setAddModalOpen(false);
@@ -159,19 +143,10 @@ const UserPage = () => {
       {/* Users Table */}
       <Box sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
         <UserTable
-          users={currentItems}
+          users={filteredData}
           nameOrder={nameOrder}
           onNameOrderToggle={handleNameOrderToggle}
           onStatusToggle={handleStatusToggle}
-        />
-      </Box>
-
-      {/* Pagination */}
-      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
-        <Pagination
-          count={totalPages}
-          page={currentPage}
-          onChange={handlePageChange}
         />
       </Box>
 

--- a/src/pages/routes.tsx
+++ b/src/pages/routes.tsx
@@ -89,7 +89,7 @@ const routes = [
         element: (
           <RootRedirect source="catalog">
             <MainContainer title="Catalog">
-              <Catalog />,
+              <Catalog />
             </MainContainer>
           </RootRedirect>
         ),

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -46,6 +46,7 @@ export const ENDPOINTS = {
 
 export const SETTINGS = {
   itemsPerPage: 15,
+  rowsPerPageOptions: [10, 15, 25, 50, 100],
   checkout_item_limit: 10,
   api_fetch_limit_items: 10000,
   api_fetch_limit_units: 1000,


### PR DESCRIPTION
## Description

Added the "rows per page" dropdown for people and inventory page

## Jira Ticket
- Closes: [PIT-503](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-503)

## Type of Change
**Type:** New feature

## Changes Made
- Replaced TablePagination with a plain MUI Select using anchorOrigin: top / transformOrigin: bottom. This opens the menu above the trigger, fixing the first-click bug without any hacks.
- Moved all pagination logic into the table components (InventoryTable, UserTable). They receive the full filtered dataset and slice it internally. Parent pages just pass data and handle filtering/sorting.
- Added rowsPerPageOptions to SETTINGS in constants.ts so the options are defined in one place.
- Cleaned up both index.tsx files. Removed dead pagination state, unused imports, and merged the double-firing effect.


## Checklist
- [x] My code follows the project's style guidelines
- [x] I have run [prettier](https://github.com/digitalaidseattle/plymouth-housing#code-formatting) on the code
- [x] I have performed a self-review of my code
- [x] I have commented my code only in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings in Chrome Dev Tools
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## QA Instructions, Screenshots, Recordings
<img width="1351" height="691" alt="image" src="https://github.com/user-attachments/assets/29900eb6-8ae8-4ad3-9b62-83516494bcaa" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client-side pagination to the Inventory and People tables, including page navigation and selectable rows-per-page.
  * Added new rows-per-page options (10, 15, 25, 50, 100).
* **Bug Fixes**
  * Improved empty-table handling so the Inventory table shows “No items to display” when nothing matches the current page.
  * Automatically returns to the first page when filter/sort results change, keeping pagination consistent.
* **Chores**
  * Fixed a minor routes rendering issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->