### PR TITLE
fix: address review findings in InventoryTable, UserTable, and E2E locator

### DIFF
--- a/src/components/inventory/InventoryTable.tsx
+++ b/src/components/inventory/InventoryTable.tsx
@@ -128,9 +128,9 @@ const InventoryTable: React.FC<InventoryTableProps> = ({
                 </TableCell>
               </TableRow>
             ) : (
-              paginatedItems.map((row, index) => (
+              paginatedItems.map((row) => (
                 <TableRow
-                  key={index}
+                  key={row.id}
                   sx={{
                     height: '64px',
                     boxShadow: '0px -1px 0px 0px rgb(212, 212, 212);',
@@ -280,7 +280,7 @@ const InventoryTable: React.FC<InventoryTableProps> = ({
         </Box>
 
         <Pagination
-          count={Math.ceil(items.length / rowsPerPage)}
+          count={Math.max(1, Math.ceil(items.length / rowsPerPage))}
           page={page + 1}
           onChange={(_, newPage) => setPage(newPage - 1)}
         />

--- a/src/pages/people/UserTable.tsx
+++ b/src/pages/people/UserTable.tsx
@@ -130,8 +130,8 @@ const UserTable: React.FC<UserTableProps> = ({
             </TableRow>
           </TableHead>
           <TableBody>
-            {paginatedUsers.map((user, index) => (
-              <TableRow key={index}>
+            {paginatedUsers.map((user) => (
+              <TableRow key={user.id}>
                 <TableCell>{user.name}</TableCell>
                 <TableCell>{user.role}</TableCell>
                 <TableCell>
@@ -230,7 +230,7 @@ const UserTable: React.FC<UserTableProps> = ({
           onClose={() => setSnackbarOpen(false)}
           severity="warning"
         >
-          'PIN not available.'
+          PIN not available.
         </SnackbarAlert>
       </TableContainer>
       <Box sx={{ display: 'flex', alignItems: 'center', mt: 1 }}>
@@ -267,7 +267,7 @@ const UserTable: React.FC<UserTableProps> = ({
           </Select>
         </Box>
         <Pagination
-          count={Math.ceil(users.length / rowsPerPage)}
+          count={Math.max(1, Math.ceil(users.length / rowsPerPage))}
           page={page + 1}
           onChange={(_, newPage) => setPage(newPage - 1)}
         />

--- a/tests/utilities/locators.py
+++ b/tests/utilities/locators.py
@@ -107,7 +107,7 @@ class CheckoutPageLocators:
 
     CONTINUE_BUTTON = (By.XPATH, '//button[contains(text(),"continue")]')
 
-    PROCEED_TO_CHECKOUT = (By.XPATH, '//button[contains(text(), "Proceed to Checkout")]')
+    PROCEED_TO_CHECKOUT = (By.XPATH, '//button[contains(translate(text(), "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz"), "proceed to checkout")]')
     CONFIRM = (By.XPATH, '//*[text()="Confirm"]')
 
     SEARCH = (By.XPATH, "//input[@type='search']")


### PR DESCRIPTION
## Fix pre-existing review findings surfaced on #576

Fixes found by GitHub Copilot's review of #576 (chore: promote dev to staging). Merging this into `dev` will carry these fixes into #576 automatically since its head is `dev`.

- `src/pages/people/UserTable.tsx`: use `user.id` instead of array index as the `TableRow` key — paginated rows could otherwise reuse DOM across pages and target the wrong user's PIN/menu actions
- `src/pages/people/UserTable.tsx`: remove stray literal quotes around the "PIN not available." snackbar message
- `src/pages/people/UserTable.tsx` / `src/components/inventory/InventoryTable.tsx`: clamp `Pagination` `count` to at least 1 so a 0-result page doesn't produce an out-of-range `page` prop
- `src/components/inventory/InventoryTable.tsx`: same array-index-as-key fix as UserTable, using `row.id`
- `tests/utilities/locators.py`: make the `PROCEED_TO_CHECKOUT` E2E locator case-insensitive — the button copy now reads "Proceed to checkout" (lowercase c) but the XPath still matched "Checkout", which would break the E2E gate that runs right after the staging deploy



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inventory and user table pagination when no records are available.
  * Stabilized table row rendering to prevent display inconsistencies.
  * Updated the no-PIN notification to display clean, unquoted text.
  * Checkout button detection now works regardless of text capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->