### PR TITLE
fix: make E2E locator case-insensitive

### DIFF
--- a/tests/utilities/locators.py
+++ b/tests/utilities/locators.py
@@ -105,7 +105,7 @@ class CheckoutPageLocators:
     UNIT_OPTIONS = (By.XPATH, "//ul[@id='select-unit-number-listbox']//li")
     NAME_OPTIONS = (By.XPATH, "//ul[@id='resident-name-autocomplete-listbox']//li")
 
-    CONTINUE_BUTTON = (By.XPATH, '//button[contains(text(),"continue")]')
+    CONTINUE_BUTTON = (By.XPATH, '//button[contains(translate(text(), "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz"), "continue")]')
 
     PROCEED_TO_CHECKOUT = (By.XPATH, '//button[contains(translate(text(), "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz"), "proceed to checkout")]')
     CONFIRM = (By.XPATH, '//*[text()="Confirm"]')


### PR DESCRIPTION
## Fix remaining E2E locators (follow-up to #577)

#577 merged the review findings but missed this commit (it was pushed after #577 had already merged), so the failing checkout smoke test is still broken on `dev`.

Fixing issues with renaming of buttons and other fields and texts in the code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkout automation so the “Continue” button is recognized regardless of capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->