### PR TITLE
feat: mohamed/464: add inline editing of resident names to Residents page

### DIFF
--- a/src/pages/residents/index.test.tsx
+++ b/src/pages/residents/index.test.tsx
@@ -4,7 +4,7 @@
  *  @copyright 2026 Digital Aid Seattle
  *
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import ResidentsPage from './index';
@@ -72,7 +72,12 @@ const buildingData = [
 describe('ResidentsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockHook.mockReturnValue({ data: [], isLoading: false, error: null });
+    mockHook.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      updateResidentName: vi.fn(),
+    });
   });
 
   test('renders building dropdown', async () => {
@@ -104,6 +109,7 @@ describe('ResidentsPage', () => {
       data: buildingData,
       isLoading: false,
       error: null,
+      updateResidentName: vi.fn(),
     });
 
     render(
@@ -115,7 +121,8 @@ describe('ResidentsPage', () => {
     await waitFor(() => {
       expect(screen.getByText('101')).toBeInTheDocument();
       expect(screen.getByText('Alice Smith')).toBeInTheDocument();
-      expect(screen.getByText('Bob Jones, Carol Jones')).toBeInTheDocument();
+      expect(screen.getByText('Bob Jones')).toBeInTheDocument();
+      expect(screen.getByText('Carol Jones')).toBeInTheDocument();
     });
   });
 
@@ -124,6 +131,7 @@ describe('ResidentsPage', () => {
       data: buildingData,
       isLoading: false,
       error: null,
+      updateResidentName: vi.fn(),
     });
 
     render(
@@ -139,7 +147,12 @@ describe('ResidentsPage', () => {
   });
 
   test('shows loading spinner while fetching', () => {
-    mockHook.mockReturnValue({ data: [], isLoading: true, error: null });
+    mockHook.mockReturnValue({
+      data: [],
+      isLoading: true,
+      error: null,
+      updateResidentName: vi.fn(),
+    });
 
     render(
       <Wrapper>
@@ -155,6 +168,7 @@ describe('ResidentsPage', () => {
       data: [],
       isLoading: false,
       error: 'Failed to load residents',
+      updateResidentName: vi.fn(),
     });
 
     render(
@@ -175,6 +189,7 @@ describe('ResidentsPage', () => {
       data: buildingData,
       isLoading: false,
       error: null,
+      updateResidentName: vi.fn(),
     });
 
     render(
@@ -188,6 +203,62 @@ describe('ResidentsPage', () => {
       expect(screen.getByText('202')).toBeInTheDocument();
       expect(screen.getByText('303')).toBeInTheDocument();
     });
+  });
+
+  test('edits a resident name', async () => {
+    const updateResidentName = vi.fn().mockResolvedValue(undefined);
+    mockHook.mockReturnValue({
+      data: buildingData,
+      isLoading: false,
+      error: null,
+      updateResidentName,
+    });
+
+    render(
+      <Wrapper>
+        <ResidentsPage />
+      </Wrapper>,
+    );
+
+    await waitFor(() => screen.getByText('Alice Smith'));
+    fireEvent.click(screen.getByLabelText('Edit Alice Smith'));
+
+    const input = screen.getByDisplayValue('Alice Smith');
+    fireEvent.change(input, { target: { value: 'Alice Smyth' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+    await waitFor(() => {
+      expect(updateResidentName).toHaveBeenCalledWith(1, 'Alice Smyth');
+      expect(screen.getByRole('alert')).toHaveTextContent('Resident name updated.');
+    });
+  });
+
+  test('shows error when editing a resident name to empty', async () => {
+    const updateResidentName = vi.fn();
+    mockHook.mockReturnValue({
+      data: buildingData,
+      isLoading: false,
+      error: null,
+      updateResidentName,
+    });
+
+    render(
+      <Wrapper>
+        <ResidentsPage />
+      </Wrapper>,
+    );
+
+    await waitFor(() => screen.getByText('Alice Smith'));
+    fireEvent.click(screen.getByLabelText('Edit Alice Smith'));
+
+    const input = screen.getByDisplayValue('Alice Smith');
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Name cannot be empty.');
+    });
+    expect(updateResidentName).not.toHaveBeenCalled();
   });
 
   test('renders search input alongside building dropdown', async () => {

--- a/src/pages/residents/index.tsx
+++ b/src/pages/residents/index.tsx
@@ -4,7 +4,7 @@
  *  @copyright 2026 Digital Aid Seattle
  *
  */
-import { useState, useEffect, useContext } from 'react';
+import { useState, useEffect, useContext, useRef } from 'react';
 import {
   Autocomplete,
   Box,
@@ -65,6 +65,7 @@ const ResidentsPage = () => {
     message: '',
     severity: 'success',
   });
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
 
   const { data, isLoading, error: residentsError, updateResidentName } =
     useResidentsByBuilding(selectedBuildingId);
@@ -125,6 +126,7 @@ const ResidentsPage = () => {
   };
 
   const handleEditClick = (resident: { id: number; name: string }) => {
+    if (isSaving) return;
     setEditId(resident.id);
     setEditValue(resident.name);
   };
@@ -241,7 +243,10 @@ const ResidentsPage = () => {
                               value={editValue}
                               onChange={(e) => setEditValue(e.target.value)}
                               onKeyDown={handleEditKeyDown}
-                              onBlur={handleEditSave}
+                              onBlur={(e) => {
+                                if (e.relatedTarget === cancelButtonRef.current) return;
+                                handleEditSave();
+                              }}
                               autoFocus
                               disabled={isSaving}
                               slotProps={{ htmlInput: { maxLength: 255 } }}
@@ -257,6 +262,7 @@ const ResidentsPage = () => {
                               <CheckIcon fontSize="small" />
                             </IconButton>
                             <IconButton
+                              ref={cancelButtonRef}
                               size="large"
                               onMouseDown={(e) => e.preventDefault()}
                               onClick={handleEditCancel}

--- a/src/pages/residents/index.tsx
+++ b/src/pages/residents/index.tsx
@@ -10,6 +10,7 @@ import {
   Box,
   CircularProgress,
   FormControl,
+  IconButton,
   InputLabel,
   MenuItem,
   Select,
@@ -24,8 +25,11 @@ import {
   Typography,
 } from '@mui/material';
 import { createFilterOptions } from '@mui/material/Autocomplete';
+import EditIcon from '@mui/icons-material/Edit';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
 import { UserContext } from '../../components/contexts/UserContext';
-import { Building } from '../../types/interfaces';
+import { Building, SnackbarState } from '../../types/interfaces';
 import { getBuildings, getAllResidents } from '../../services/residentService';
 import { useResidentsByBuilding } from './useResidentsByBuilding';
 import SnackbarAlert from '../../components/SnackbarAlert';
@@ -53,8 +57,17 @@ const ResidentsPage = () => {
   const [buildingsError, setBuildingsError] = useState<string | null>(null);
   const [allResidentsLoading, setAllResidentsLoading] = useState(false);
   const [allResidentsError, setAllResidentsError] = useState<string | null>(null);
+  const [editId, setEditId] = useState<number | null>(null);
+  const [editValue, setEditValue] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [editSnackbar, setEditSnackbar] = useState<SnackbarState>({
+    open: false,
+    message: '',
+    severity: 'success',
+  });
 
-  const { data, isLoading, error: residentsError } = useResidentsByBuilding(selectedBuildingId);
+  const { data, isLoading, error: residentsError, updateResidentName } =
+    useResidentsByBuilding(selectedBuildingId);
 
   let visibleData = data;
   if (filteredUnitId !== null) {
@@ -108,6 +121,45 @@ const ResidentsPage = () => {
     } else if (reason === 'clear' || reason === 'reset') {
       setSearchInput('');
       setFilteredUnitId(null);
+    }
+  };
+
+  const handleEditClick = (resident: { id: number; name: string }) => {
+    setEditId(resident.id);
+    setEditValue(resident.name);
+  };
+
+  const handleEditCancel = () => {
+    setEditId(null);
+    setEditValue('');
+  };
+
+  const handleEditKeyDown = async (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      await handleEditSave();
+    } else if (e.key === 'Escape') {
+      handleEditCancel();
+    }
+  };
+
+  const handleEditSave = async () => {
+    if (editId === null) return;
+
+    if (!editValue.trim()) {
+      setEditSnackbar({ open: true, message: 'Name cannot be empty.', severity: 'error' });
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await updateResidentName(editId, editValue.trim());
+      setEditSnackbar({ open: true, message: 'Resident name updated.', severity: 'success' });
+      setEditId(null);
+      setEditValue('');
+    } catch {
+      setEditSnackbar({ open: true, message: 'Failed to update resident name.', severity: 'error' });
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -180,7 +232,52 @@ const ResidentsPage = () => {
                       —
                     </Typography>
                   ) : (
-                    residents.map((r) => r.name).join(', ')
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+                      {residents.map((r) =>
+                        editId === r.id ? (
+                          <Box key={r.id} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <TextField
+                              size="small"
+                              value={editValue}
+                              onChange={(e) => setEditValue(e.target.value)}
+                              onKeyDown={handleEditKeyDown}
+                              onBlur={handleEditSave}
+                              autoFocus
+                              disabled={isSaving}
+                              slotProps={{ htmlInput: { maxLength: 255 } }}
+                              sx={{ width: 180 }}
+                            />
+                            <IconButton
+                              size="large"
+                              onMouseDown={(e) => e.preventDefault()}
+                              onClick={handleEditSave}
+                              disabled={isSaving}
+                            >
+                              <CheckIcon fontSize="small" />
+                            </IconButton>
+                            <IconButton
+                              size="large"
+                              onMouseDown={(e) => e.preventDefault()}
+                              onClick={handleEditCancel}
+                              disabled={isSaving}
+                            >
+                              <CloseIcon fontSize="small" />
+                            </IconButton>
+                          </Box>
+                        ) : (
+                          <Box key={r.id} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                            <Typography variant="body2">{r.name}</Typography>
+                            <IconButton
+                              size="large"
+                              onClick={() => handleEditClick(r)}
+                              aria-label={`Edit ${r.name}`}
+                            >
+                              <EditIcon fontSize="small" />
+                            </IconButton>
+                          </Box>
+                        ),
+                      )}
+                    </Box>
                   )}
                 </TableCell>
               </TableRow>
@@ -205,6 +302,13 @@ const ResidentsPage = () => {
           {allResidentsError}
         </SnackbarAlert>
       )}
+      <SnackbarAlert
+        open={editSnackbar.open}
+        severity={editSnackbar.severity}
+        onClose={() => setEditSnackbar((prev) => ({ ...prev, open: false }))}
+      >
+        {editSnackbar.message}
+      </SnackbarAlert>
     </Box>
   );
 };

--- a/src/pages/residents/index.tsx
+++ b/src/pages/residents/index.tsx
@@ -143,7 +143,7 @@ const ResidentsPage = () => {
   };
 
   const handleEditSave = async () => {
-    if (editId === null) return;
+    if (editId === null || isSaving) return;
 
     if (!editValue.trim()) {
       setEditSnackbar({ open: true, message: 'Name cannot be empty.', severity: 'error' });
@@ -252,6 +252,7 @@ const ResidentsPage = () => {
                               onMouseDown={(e) => e.preventDefault()}
                               onClick={handleEditSave}
                               disabled={isSaving}
+                              aria-label="Save"
                             >
                               <CheckIcon fontSize="small" />
                             </IconButton>
@@ -260,6 +261,7 @@ const ResidentsPage = () => {
                               onMouseDown={(e) => e.preventDefault()}
                               onClick={handleEditCancel}
                               disabled={isSaving}
+                              aria-label="Cancel"
                             >
                               <CloseIcon fontSize="small" />
                             </IconButton>

--- a/src/pages/residents/useResidentsByBuilding.test.ts
+++ b/src/pages/residents/useResidentsByBuilding.test.ts
@@ -4,7 +4,7 @@
  *  @copyright 2026 Digital Aid Seattle
  *
  */
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import React from 'react';
 import { UserContext } from '../../components/contexts/UserContext';
@@ -131,6 +131,51 @@ describe('useResidentsByBuilding', () => {
 
     expect(result.current.error).toBe('Failed to load residents');
     expect(result.current.data).toEqual([]);
+  });
+
+  it('updates a resident name locally after a successful save', async () => {
+    vi.mocked(residentService.getResidentsByBuilding).mockResolvedValue(
+      mockRows,
+    );
+    vi.mocked(residentService.updateResident).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useResidentsByBuilding(1), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.updateResidentName(1, 'Alicia');
+    });
+
+    expect(residentService.updateResident).toHaveBeenCalledWith(
+      dummyUser,
+      1,
+      'Alicia',
+    );
+    const unit2 = result.current.data.find((d) => d.unit.unit_number === '2');
+    expect(unit2?.residents.map((r) => r.name)).toEqual(['Alicia', 'Bob']);
+  });
+
+  it('propagates the error and leaves data unchanged when the update fails', async () => {
+    vi.mocked(residentService.getResidentsByBuilding).mockResolvedValue(
+      mockRows,
+    );
+    vi.mocked(residentService.updateResident).mockRejectedValue(
+      new Error('Network error'),
+    );
+
+    const { result } = renderHook(() => useResidentsByBuilding(1), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await expect(
+        result.current.updateResidentName(1, 'Alicia'),
+      ).rejects.toThrow('Network error');
+    });
+
+    const unit2 = result.current.data.find((d) => d.unit.unit_number === '2');
+    expect(unit2?.residents.map((r) => r.name)).toEqual(['Alice', 'Bob']);
   });
 
   it('refetches when buildingId changes', async () => {

--- a/src/pages/residents/useResidentsByBuilding.ts
+++ b/src/pages/residents/useResidentsByBuilding.ts
@@ -4,10 +4,10 @@
  *  @copyright 2026 Digital Aid Seattle
  *
  */
-import { useState, useEffect, useContext } from 'react';
+import { useState, useEffect, useContext, useCallback } from 'react';
 import { UserContext } from '../../components/contexts/UserContext';
 import { Unit } from '../../types/interfaces';
-import { getResidentsByBuilding } from '../../services/residentService';
+import { getResidentsByBuilding, updateResident } from '../../services/residentService';
 
 export type UnitWithResidents = {
   unit: Unit;
@@ -74,5 +74,18 @@ export function useResidentsByBuilding(buildingId: number | null) {
     };
   }, [buildingId, user]);
 
-  return { data, isLoading, error };
+  const updateResidentName = useCallback(
+    async (id: number, name: string) => {
+      await updateResident(user, id, name);
+      setData((prev) =>
+        prev.map((u) => ({
+          ...u,
+          residents: u.residents.map((r) => (r.id === id ? { ...r, name } : r)),
+        })),
+      );
+    },
+    [user],
+  );
+
+  return { data, isLoading, error, updateResidentName };
 }

--- a/src/services/residentService.test.tsx
+++ b/src/services/residentService.test.tsx
@@ -12,6 +12,7 @@ import {
   getResidents,
   findResident,
   addResident,
+  updateResident,
   getResidentsByBuilding,
   getAllResidents,
   getLastResidentVisit,
@@ -184,6 +185,37 @@ describe('residentService', () => {
       });
 
       await expect(addResident(user, name, unitId)).rejects.toThrow('Error');
+    });
+  });
+
+  describe('updateResident', () => {
+    const id = 1;
+    const name = 'Alice Smyth';
+
+    it('should update a resident successfully', async () => {
+      (fetch as Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ value: [{ id, name }] }),
+      });
+
+      await updateResident(user, id, name);
+
+      expect(fetch).toHaveBeenCalledWith(`${ENDPOINTS.RESIDENTS}/id/${id}`, {
+        method: 'PATCH',
+        headers: { ...API_HEADERS, 'X-MS-API-ROLE': 'admin' },
+        body: JSON.stringify({ name }),
+      });
+    });
+
+    it('should throw an error if the request fails', async () => {
+      (fetch as Mock).mockResolvedValue({
+        ok: false,
+        statusText: 'Error',
+        clone: () => ({ json: () => Promise.reject(new Error()), text: () => Promise.resolve('') }),
+      });
+
+      await expect(updateResident(user, id, name)).rejects.toThrow('Error');
     });
   });
 

--- a/src/services/residentService.ts
+++ b/src/services/residentService.ts
@@ -96,6 +96,20 @@ export async function addResident(user: ClientPrincipal | null, name: string, un
   }
 }
 
+export async function updateResident(user: ClientPrincipal | null, id: number, name: string) {
+  try {
+    await apiRequest({
+      url: `${ENDPOINTS.RESIDENTS}/id/${id}`,
+      role: getRole(user),
+      method: 'PATCH',
+      body: { name },
+    });
+  } catch (error) {
+    console.error('Error updating resident:', error);
+    throw error;
+  }
+}
+
 export async function getResidentsByBuilding(user: ClientPrincipal | null, buildingId: number) {
   try {
     const result = await apiRequest<Array<{


### PR DESCRIPTION
## Description

Adds the ability to edit a resident's name directly from the Residents page table. Each resident row now shows an edit icon that switches the row into an inline text field;

## Jira Ticket
- Closes: [PIT-464](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-464)

## Type of Change
**Type:** New feature

## Changes Made
- Added inline edit UI for resident names in `ResidentsPage` (edit/save/cancel icons, keyboard support via Enter/Escape, save-on-blur)
- Added client-side validation preventing an empty resident name from being saved
- Added `updateResident` to `residentService.ts` (`PATCH /residents/id/{id}`)
- Added `updateResidentName` to the `useResidentsByBuilding` hook, which patches local state after a successful save
- Added success/error snackbar feedback for the edit flow
- Added unit tests for `updateResident` and `updateResidentName` (success and failure paths)

## Checklist
- [x] My code follows the project's style guidelines

- [x] I have performed a self-review of my code
- [x] I have commented my code only in hard-to-understand areas
- [x] My changes generate no new warnings in Chrome Dev Tools
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## QA Instructions, Screenshots, Recordings

1. Go to the Residents page and select a building with residents.
2. Click the edit (pencil) icon next to a resident's name.
3. Type a new name and press **Enter** — confirm a "Resident name updated." success snackbar appears and the new name is shown.
4. Repeat, but click the ✓ (check) icon instead of pressing Enter — same result.
5. Click the edit icon again, change the name, then click elsewhere on the page (blur) — confirm it also saves.
6. Click the edit icon, change the name, then press **Escape** (or click ✕) — confirm the change is discarded and the original name remains.
7. Click the edit icon, clear the name entirely, then click away — confirm a "Name cannot be empty." error snackbar appears and no request is sent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline editing for resident names in the residents list.
  * Residents can save via click, Enter, or leaving the field, and cancel with Escape.
  * Added success and error notifications when updating a resident name.
  * Updated the residents display to render each resident as a separate entry.
* **Bug Fixes**
  * Prevented saving when a resident name is empty.
  * Kept existing resident data unchanged if a name update fails.
* **Tests**
  * Expanded coverage for name update success and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->