### PR TITLE
Block test accounts from logging into production

### DIFF
--- a/.github/workflows/azure-static-web-apps-prod.yml
+++ b/.github/workflows/azure-static-web-apps-prod.yml
@@ -85,6 +85,7 @@ jobs:
           output_location: 'dist' # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
         env:
+          VITE_ENVIRONMENT: production
           VITE_CLARITY_PROJECT_ID: ${{ secrets.VITE_CLARITY_PROJECT_ID }}
           VITE_APPINSIGHTS_CONNECTION_STRING: ${{ secrets.VITE_APPINSIGHTS_CONNECTION_STRING }}
 

--- a/.github/workflows/azure-static-web-apps-staging.yml
+++ b/.github/workflows/azure-static-web-apps-staging.yml
@@ -61,6 +61,7 @@ jobs:
           output_location: 'dist' # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
         env:
+          VITE_ENVIRONMENT: staging
           VITE_CLARITY_PROJECT_ID: ${{ secrets.VITE_CLARITY_PROJECT_ID }}
           VITE_APPINSIGHTS_CONNECTION_STRING:
             ${{ secrets.VITE_APPINSIGHTS_CONNECTION_STRING }}

--- a/.github/workflows/azure-static-web-apps-staging.yml
+++ b/.github/workflows/azure-static-web-apps-staging.yml
@@ -54,7 +54,6 @@ jobs:
             }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
           action: 'upload'
-          deployment_environment: 'staging' # this is a reference to the Azure environment for deployment
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: '/' # App source code path
           api_location: '' # Api source code path - optional

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -2,7 +2,7 @@ name: E2E UI Tests
 
 on:
   workflow_run:
-    workflows: ["Azure Static Web Apps Staging"]
+    workflows: ['Azure Static Web Apps Staging']
     types:
       - completed
     branches:
@@ -14,13 +14,15 @@ permissions:
 
 jobs:
   e2e-tests:
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    if:
+      ${{ github.event.workflow_run.conclusion == 'success' || github.event_name
+      == 'workflow_dispatch' }}
 
     runs-on: ubuntu-latest
 
     env:
-      CI: "true"
-      URL: ${{ secrets.URL }}
+      CI: 'true'
+      URL: ${{ secrets.STAGING_URL }}
       ADMIN_USERNAME: ${{ secrets.ADMIN_USERNAME }}
       ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
       VOLUNTEER_USERNAME: ${{ secrets.VOLUNTEER_USERNAME }}
@@ -33,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: '3.10'
 
       - name: Install Chrome
         uses: browser-actions/setup-chrome@v1

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -117,9 +117,11 @@ To promote staging to production:
 Test accounts must never be able to log into production. The app enforces this
 at sign-in: any account that carries the `test` role is refused when the build's
 environment is `production` — the session is torn down (redirect to
-`/.auth/logout` → `login.html`) before any page renders, and a
-`TestAccountBlockedInProduction` event is sent to Application Insights. See the
-guard in [`src/layout/MainLayout/index.tsx`](../src/layout/MainLayout/index.tsx).
+`/.auth/logout` → `login.html`) and a `TestAccountBlockedInProduction` event is
+sent to Application Insights. In a production build the layout renders nothing
+until the guard has cleared the session, so a blocked account never mounts the
+app shell or any page behind it. See the guard in
+[`src/layout/MainLayout/index.tsx`](../src/layout/MainLayout/index.tsx).
 
 > This is a guardrail against *accidental* testing against prod, not a security
 > boundary — a direct API call bypasses the frontend. The durable backstop is

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -111,3 +111,34 @@ To promote staging to production:
 1. Bump the version in `package.json` on `staging`
 2. Open a PR from `staging` → `main` and merge it
 3. The workflow detects the new version tag and deploys automatically
+
+## Preventing test access to production
+
+Test accounts must never be able to log into production. The app enforces this
+at sign-in: any account that carries the `test` role is refused when the build's
+environment is `production` — the session is torn down (redirect to
+`/.auth/logout` → `login.html`) before any page renders, and a
+`TestAccountBlockedInProduction` event is sent to Application Insights. See the
+guard in [`src/layout/MainLayout/index.tsx`](../src/layout/MainLayout/index.tsx).
+
+> This is a guardrail against *accidental* testing against prod, not a security
+> boundary — a direct API call bypasses the frontend. The durable backstop is
+> keeping test accounts and test data out of the production database.
+
+Two pieces make it work:
+
+1. **Environment is injected at build time** via the `VITE_ENVIRONMENT` variable.
+   It is set in each deploy workflow's build step — `production` in
+   [azure-static-web-apps-prod.yml](../.github/workflows/azure-static-web-apps-prod.yml)
+   and `staging` in
+   [azure-static-web-apps-staging.yml](../.github/workflows/azure-static-web-apps-staging.yml).
+   It is a Vite build-time value (must be `VITE_`-prefixed); a SWA runtime
+   Application Setting does **not** reach the bundle. Unset locally, so local dev
+   is treated as non-production and never blocked.
+2. **The `test` role** must be assigned to every account used for automated or
+   manual testing (in addition to its functional `admin`/`volunteer` role). How
+   you assign it depends on the role model — see
+   [aad-swa-roles.md](research/aad-swa-roles.md).
+
+To test the guard locally, start the dev server with the variable set, e.g.
+`VITE_ENVIRONMENT=production swa start`, and sign in with a `test`-role user.

--- a/docs/e2e-automation-test.md
+++ b/docs/e2e-automation-test.md
@@ -141,6 +141,11 @@ VOLUNTEER_PASSWORD=volunteer_test_password
 ⚠️ **Do not commit real or production credentials**  
 Ensure `.env` is included in `.gitignore`.
 
+> **Point the suite at a non-production environment.** The accounts used here
+> carry the `test` role, which the app **blocks from logging into production**
+> (see [deployment-guide.md](deployment-guide.md#preventing-test-access-to-production)).
+> Set `URL` to dev/staging, not prod.
+
 ## Running Tests
 ### Run All Tests
 ```bash

--- a/docs/research/aad-swa-roles.md
+++ b/docs/research/aad-swa-roles.md
@@ -17,7 +17,9 @@ The app has two custom roles, as defined in [login-design.md](../designs/login-d
 | `admin` | Full CRUD access; no PIN required; routed to admin dashboard |
 | `volunteer` | Limited API permissions; requires PIN verification after AAD login; routed to volunteer home |
 
-> **Important**: A user must have exactly one of these roles. Having both causes an error — see [swa-setup.md](../swa-setup.md).
+> **Important**: A user must have exactly one of `admin` or `volunteer`. Having both causes an error — see [swa-setup.md](../swa-setup.md).
+
+There is also an additive `test` role, **orthogonal** to the exactly-one rule above. Accounts used for automated or manual testing carry `test` alongside their functional `admin`/`volunteer` role. The app refuses any account with the `test` role when it runs in the `production` environment — this keeps test accounts from accidentally operating against prod. See [deployment-guide.md](../deployment-guide.md#preventing-test-access-to-production). If you adopt the group-based model below, create a third group (e.g. `plymouth-housing-test`) and map it to the `test` role.
 
 These roles currently flow into the DAB API layer via the `X-MS-API-ROLE` header on every REST request. DAB enforces permissions per role in `dab/dab-config.json`. See [authorization_roles.md](authorization_roles.md) for the prior investigation into this.
 

--- a/src/layout/MainLayout/index.test.tsx
+++ b/src/layout/MainLayout/index.test.tsx
@@ -1,0 +1,195 @@
+/**
+ *  MainLayout/index.test.tsx
+ *
+ *  Covers the guardrail that refuses test-role accounts in production.
+ *
+ *  @copyright 2026 Digital Aid Seattle
+ *
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import MainLayout from './index';
+import { UserContext } from '../../components/contexts/UserContext';
+import { UserContextType } from '../../types/interfaces';
+
+const LOGOUT_URL = '/.auth/logout?post_logout_redirect_uri=/login.html';
+
+// ENVIRONMENT is a build-time constant, so it is swapped per test through a
+// hoisted holder the module mock reads on every access.
+const env = vi.hoisted(() => ({ value: 'development' }));
+
+vi.mock('../../types/constants', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../types/constants')>();
+  return {
+    ...actual,
+    get ENVIRONMENT() {
+      return env.value;
+    },
+  };
+});
+
+const { getAuthMe } = vi.hoisted(() => ({ getAuthMe: vi.fn() }));
+const { trackEvent } = vi.hoisted(() => ({ trackEvent: vi.fn() }));
+const { apiRequest } = vi.hoisted(() => ({ apiRequest: vi.fn() }));
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }));
+
+vi.mock('../../services/authService', () => ({ getAuthMe }));
+vi.mock('../../utils/appInsights', () => ({ trackEvent }));
+vi.mock('../../services/apiRequest', () => ({ apiRequest }));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+    Outlet: () => <div>Outlet Content</div>,
+  };
+});
+
+// The chrome around the outlet is irrelevant here; stub it out so the test
+// exercises the guard rather than MUI layout internals.
+vi.mock('./Header', () => ({ default: () => <div>Header</div> }));
+vi.mock('./Drawer', () => ({ default: () => <div>Drawer</div> }));
+vi.mock('../../components/@extended/Breadcrumbs', () => ({
+  default: () => <div>Breadcrumbs</div>,
+}));
+
+const contextValue = (): UserContextType => ({
+  user: null,
+  setUser: vi.fn(),
+  loggedInUserId: null,
+  setLoggedInUserId: vi.fn(),
+  activeVolunteers: [],
+  setActiveVolunteers: vi.fn(),
+  isLoading: false,
+});
+
+const renderLayout = () =>
+  render(
+    <UserContext.Provider value={contextValue()}>
+      <MemoryRouter>
+        <MainLayout />
+      </MemoryRouter>
+    </UserContext.Provider>,
+  );
+
+const authAs = (userRoles: string[] | undefined) =>
+  getAuthMe.mockResolvedValue({
+    clientPrincipal: {
+      userId: 'user@example.com',
+      userDetails: 'Test User',
+      userRoles,
+    },
+  });
+
+describe('MainLayout - production test-account guard', () => {
+  let clearSpy: ReturnType<typeof vi.spyOn>;
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    env.value = 'development';
+    apiRequest.mockResolvedValue({ value: [{ id: 1 }] });
+    clearSpy = vi
+      .spyOn(Storage.prototype, 'clear')
+      .mockImplementation(() => {});
+
+    originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { href: '' },
+    });
+  });
+
+  afterEach(() => {
+    clearSpy.mockRestore();
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('blocks a test account in production', async () => {
+    env.value = 'production';
+    authAs(['volunteer', 'test']);
+
+    renderLayout();
+
+    await waitFor(() =>
+      expect(trackEvent).toHaveBeenCalledWith('TestAccountBlockedInProduction', {
+        environment: 'production',
+        userDetails: 'Test User',
+        userRoles: 'volunteer,test',
+      }),
+    );
+    expect(clearSpy).toHaveBeenCalled();
+    expect(window.location.href).toBe(LOGOUT_URL);
+  });
+
+  it('renders nothing and skips role processing for a blocked account', async () => {
+    env.value = 'production';
+    authAs(['admin', 'test']);
+
+    const { container } = renderLayout();
+
+    await waitFor(() => expect(trackEvent).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText('Outlet Content')).not.toBeInTheDocument();
+    // The admin upsert and the volunteer redirect must never run.
+    expect(apiRequest).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('allows a test account outside production', async () => {
+    env.value = 'staging';
+    authAs(['volunteer', 'test']);
+
+    renderLayout();
+
+    expect(await screen.findByText('Outlet Content')).toBeInTheDocument();
+    expect(trackEvent).not.toHaveBeenCalled();
+    expect(window.location.href).toBe('');
+    // Volunteer without a logged-in id still goes to the name picker.
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/pick-your-name'));
+  });
+
+  it('allows a non-test account in production', async () => {
+    env.value = 'production';
+    authAs(['admin']);
+
+    renderLayout();
+
+    expect(await screen.findByText('Outlet Content')).toBeInTheDocument();
+    expect(trackEvent).not.toHaveBeenCalled();
+    expect(window.location.href).toBe('');
+    // Admin processing continues as usual.
+    await waitFor(() => expect(apiRequest).toHaveBeenCalled());
+  });
+
+  it('allows an account with no roles in production', async () => {
+    env.value = 'production';
+    authAs(undefined);
+
+    renderLayout();
+
+    expect(await screen.findByText('Outlet Content')).toBeInTheDocument();
+    expect(trackEvent).not.toHaveBeenCalled();
+    expect(window.location.href).toBe('');
+  });
+
+  it('renders the layout when the auth lookup fails in production', async () => {
+    env.value = 'production';
+    getAuthMe.mockRejectedValue(new Error('auth down'));
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    renderLayout();
+
+    expect(await screen.findByText('Outlet Content')).toBeInTheDocument();
+    expect(window.location.href).toBe('');
+    consoleError.mockRestore();
+  });
+});

--- a/src/layout/MainLayout/index.tsx
+++ b/src/layout/MainLayout/index.tsx
@@ -19,8 +19,9 @@ import { UserContext } from '../../components/contexts/UserContext';
 import { AdminUser, User } from '../../types/interfaces';
 import { useInactivityTimer } from '../../hooks/useInactivityTimer';
 import { useSnackbar } from '../../hooks/useSnackbar';
-import { ENDPOINTS, SETTINGS, USER_ROLES } from '../../types/constants';
+import { ENDPOINTS, ENVIRONMENT, SETTINGS, USER_ROLES } from '../../types/constants';
 import { getAuthMe } from '../../services/authService';
+import { trackEvent } from '../../utils/appInsights';
 import { apiRequest } from '../../services/apiRequest';
 
 const requestCache = new Map<string, Promise<AdminUser>>();
@@ -52,6 +53,25 @@ const MainLayout: React.FC = () => {
         const { clientPrincipal } = payload;
         const userClaims = clientPrincipal;
         setUser(userClaims || null);
+
+        // Guardrail: test-only accounts must never operate against production.
+        // This prevents the accidental "testing against prod" case by refusing
+        // the session and logging the account back out. It is not a security
+        // boundary (a direct API call bypasses it) — the real boundary is the
+        // absence of these accounts/data in the production database.
+        const isProduction = ENVIRONMENT === 'production';
+        const hasTestRole = userClaims?.userRoles?.includes(USER_ROLES.TEST);
+        if (isProduction && hasTestRole) {
+          trackEvent('TestAccountBlockedInProduction', {
+            environment: ENVIRONMENT,
+            userDetails: userClaims?.userDetails ?? '',
+            userRoles: (userClaims?.userRoles ?? []).join(','),
+          });
+          localStorage.clear();
+          window.location.href =
+            '/.auth/logout?post_logout_redirect_uri=/login.html';
+          return;
+        }
 
         if (userClaims?.userRoles?.includes('volunteer') && !loggedInUserId) {
           navigate('/pick-your-name');

--- a/src/layout/MainLayout/index.tsx
+++ b/src/layout/MainLayout/index.tsx
@@ -35,6 +35,10 @@ const MainLayout: React.FC = () => {
   const navigate = useNavigate();
   const { snackbarState, showSnackbar, handleClose } = useSnackbar();
   const navigateTimeoutRef = useRef<number | null>(null);
+  // In production nothing is rendered until the test-account guard below has
+  // run, so a blocked session never mounts the app shell or any child route.
+  // Outside production there is nothing to decide, so rendering is not held up.
+  const [guardCleared, setGuardCleared] = useState(ENVIRONMENT !== 'production');
 
   // Add inactivity timer
   const resetTimer = useInactivityTimer({
@@ -52,18 +56,22 @@ const MainLayout: React.FC = () => {
         const payload = await getAuthMe();
         const { clientPrincipal } = payload;
         const userClaims = clientPrincipal;
-        setUser(userClaims || null);
 
         // Guardrail: test-only accounts must never operate against production.
         // This prevents the accidental "testing against prod" case by refusing
-        // the session and logging the account back out. It is not a security
-        // boundary (a direct API call bypasses it) — the real boundary is the
-        // absence of these accounts/data in the production database.
+        // the session and logging the account back out. It runs before the user
+        // is stored and before `guardCleared` opens, so no protected UI mounts.
+        // It is not a security boundary (a direct API call bypasses it) — the
+        // real boundary is the absence of these accounts/data in the production
+        // database.
         const isProduction = ENVIRONMENT === 'production';
         const hasTestRole = userClaims?.userRoles?.includes(USER_ROLES.TEST);
         if (isProduction && hasTestRole) {
           trackEvent('TestAccountBlockedInProduction', {
             environment: ENVIRONMENT,
+            // Identifying the account is the point of the event — we need to
+            // know *which* test account hit production. Consistent with the
+            // PIN_Submission events, which already carry volunteer names.
             userDetails: userClaims?.userDetails ?? '',
             userRoles: (userClaims?.userRoles ?? []).join(','),
           });
@@ -72,6 +80,9 @@ const MainLayout: React.FC = () => {
             '/.auth/logout?post_logout_redirect_uri=/login.html';
           return;
         }
+
+        setUser(userClaims || null);
+        setGuardCleared(true);
 
         if (userClaims?.userRoles?.includes('volunteer') && !loggedInUserId) {
           navigate('/pick-your-name');
@@ -98,6 +109,8 @@ const MainLayout: React.FC = () => {
         }
       } catch (error) {
         console.error('Error in fetchTokenAndVolunteers:', error);
+        // The guard could not reach a verdict; render so the error is visible.
+        setGuardCleared(true);
         const errorMessage = error instanceof Error ? error.message : 'Failed to authenticate user';
         showSnackbar(`Authentication error: ${errorMessage}`, 'error');
         navigateTimeoutRef.current = window.setTimeout(() => {
@@ -213,6 +226,12 @@ const MainLayout: React.FC = () => {
   useEffect(() => {
     setDrawerOpen(!matchDownLG);
   }, [matchDownLG]);
+
+  // Hold the app shell (and every child route) until the guard has cleared the
+  // session. A blocked account stays here until the logout redirect takes over.
+  if (!guardCleared) {
+    return null;
+  }
 
   return (
     <DrawerOpenContext.Provider value={{ drawerOpen, setDrawerOpen }}>

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -6,6 +6,11 @@
  */
 export const VITE_APPLICATION_NAME = 'Plymouth Housing';
 
+// Deployment environment, injected at build time per workflow (see the
+// azure-static-web-apps-*.yml build steps). Unset locally, so local dev and any
+// non-production build are treated as non-production and never blocked below.
+export const ENVIRONMENT = import.meta.env.VITE_ENVIRONMENT ?? 'development';
+
 export const API_HEADERS = {
   Accept: 'application/json',
   'Content-Type': 'application/json;charset=utf-8',
@@ -60,6 +65,11 @@ export const SETTINGS = {
 export const USER_ROLES = {
   ADMIN: 'admin',
   VOLUNTEER: 'volunteer',
+  // Marks an account as test-only. Assigned to the accounts the E2E suite and
+  // manual testers use, in addition to their functional admin/volunteer role.
+  // The app refuses any account carrying this role when ENVIRONMENT is
+  // 'production' (see MainLayout).
+  TEST: 'test',
 } as const;
 
 export const ROLE_PAGES = {


### PR DESCRIPTION
## Problem

Developers have unintentionally tested against **production** ~5 times. The E2E suite (and manual testing) targets whatever `URL`/environment is set, and nothing stops a test account from operating on prod.

## What this does

Adds a sign-in **guardrail**: any account carrying a new `test` role is refused when the app runs in the `production` environment. The session is torn down (`/.auth/logout` → `login.html`) before any page renders, and a `TestAccountBlockedInProduction` event is sent to Application Insights.

- **`src/layout/MainLayout/index.tsx`** — the guard, right after the session loads and before any role routing.
- **`src/types/constants.ts`** — `ENVIRONMENT` (from build-time `VITE_ENVIRONMENT`, defaults to `development`) and `USER_ROLES.TEST = 'test'`.
- **deploy workflows** — inject `VITE_ENVIRONMENT: production` / `staging` at build time.
- **docs** — new "Preventing test access to production" section in the deployment guide, plus notes in the roles research doc and the E2E test guide.

## Not a security boundary

This stops the *accidental* case, which is the actual problem. A direct API call bypasses the frontend — the durable backstop remains keeping test accounts/data out of the production DB. Called out in the code comment and docs.

## Required follow-up (outside the repo)

Assign the `test` role to the test accounts (e.g. `test-volunteer` / `test-admin`) in addition to their functional `admin`/`volunteer` role, so the guard has something to match. Real accounts get no `test` role and pass through normally.

## Test guidance (for reviewers)

**Manually, in a browser** Use the SWA emulator:

```bash
VITE_ENVIRONMENT=production swa start
```

Vite reads `VITE_`-prefixed vars from the shell in dev, so no env file needs editing (and note `.env.local` in this repo is a file of shell `export` lines, not a Vite env file).

1. Open http://localhost:4280 — the `401 → /.auth/login/aad` override in `staticwebapp.config.json` sends you to the emulator's login form.
2. Set **Roles** to `admin,test`. Expect a blank page and an immediate redirect to `/.auth/logout` → `login.html`, with no flash of the app shell — that is what the `guardCleared` gate is for.
3. Control 1: log in with roles `admin` only → app renders normally (the admin upsert will snackbar an error unless DAB is running; rendering at all is the signal the guard passed the session through).
4. Control 2: restart without the variable (`swa start`) and log in as `admin,test` → not blocked, since the guard only fires when `ENVIRONMENT === 'production'`.

## Verification

- `tsc --noEmit` clean; `eslint --max-warnings 0` passes.
- `npx vitest run src/layout/MainLayout/index.test.tsx` — 6 passed.
- Verified locally with `VITE_ENVIRONMENT=production swa start` and a `test`-role user: `ENVIRONMENT` resolves to `production`, `hasTestRole: true`, session is blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added build-environment awareness (staging vs. production) so the app can adjust behavior accordingly.
  - Implemented a production-only sign-in guard that blocks “test” accounts by signing them out before the app shell renders.
- **Documentation**
  - Expanded the deployment guide with steps to prevent production test access, including local testing instructions.
  - Updated E2E setup and role documentation to explain the new “test” role behavior and constraints.
- **Tests**
  - Added automated tests covering the production test-account guardrail.
- **Chores**
  - Minor CI/workflow updates to align environment variables and staging trigger filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
