### PR TITLE
Backport #583 to dev: block test accounts from logging into production

### DIFF
--- a/.github/workflows/azure-static-web-apps-prod.yml
+++ b/.github/workflows/azure-static-web-apps-prod.yml
@@ -85,6 +85,7 @@ jobs:
           output_location: 'dist' # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
         env:
+          VITE_ENVIRONMENT: production
           VITE_CLARITY_PROJECT_ID: ${{ secrets.VITE_CLARITY_PROJECT_ID }}
           VITE_APPINSIGHTS_CONNECTION_STRING: ${{ secrets.VITE_APPINSIGHTS_CONNECTION_STRING }}
 

--- a/.github/workflows/azure-static-web-apps-staging.yml
+++ b/.github/workflows/azure-static-web-apps-staging.yml
@@ -61,6 +61,7 @@ jobs:
           output_location: 'dist' # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
         env:
+          VITE_ENVIRONMENT: staging
           VITE_CLARITY_PROJECT_ID: ${{ secrets.VITE_CLARITY_PROJECT_ID }}
           VITE_APPINSIGHTS_CONNECTION_STRING:
             ${{ secrets.VITE_APPINSIGHTS_CONNECTION_STRING }}

--- a/.github/workflows/azure-static-web-apps-staging.yml
+++ b/.github/workflows/azure-static-web-apps-staging.yml
@@ -54,7 +54,6 @@ jobs:
             }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
           action: 'upload'
-          deployment_environment: 'staging' # this is a reference to the Azure environment for deployment
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: '/' # App source code path
           api_location: '' # Api source code path - optional

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -2,7 +2,7 @@ name: E2E UI Tests
 
 on:
   workflow_run:
-    workflows: ["Azure Static Web Apps Staging"]
+    workflows: ['Azure Static Web Apps Staging']
     types:
       - completed
     branches:
@@ -14,13 +14,15 @@ permissions:
 
 jobs:
   e2e-tests:
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    if:
+      ${{ github.event.workflow_run.conclusion == 'success' || github.event_name
+      == 'workflow_dispatch' }}
 
     runs-on: ubuntu-latest
 
     env:
-      CI: "true"
-      URL: ${{ secrets.URL }}
+      CI: 'true'
+      URL: ${{ secrets.STAGING_URL }}
       ADMIN_USERNAME: ${{ secrets.ADMIN_USERNAME }}
       ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
       VOLUNTEER_USERNAME: ${{ secrets.VOLUNTEER_USERNAME }}
@@ -33,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: '3.10'
 
       - name: Install Chrome
         uses: browser-actions/setup-chrome@v1

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -117,9 +117,11 @@ To promote staging to production:
 Test accounts must never be able to log into production. The app enforces this
 at sign-in: any account that carries the `test` role is refused when the build's
 environment is `production` — the session is torn down (redirect to
-`/.auth/logout` → `login.html`) before any page renders, and a
-`TestAccountBlockedInProduction` event is sent to Application Insights. See the
-guard in [`src/layout/MainLayout/index.tsx`](../src/layout/MainLayout/index.tsx).
+`/.auth/logout` → `login.html`) and a `TestAccountBlockedInProduction` event is
+sent to Application Insights. In a production build the layout renders nothing
+until the guard has cleared the session, so a blocked account never mounts the
+app shell or any page behind it. See the guard in
+[`src/layout/MainLayout/index.tsx`](../src/layout/MainLayout/index.tsx).
 
 > This is a guardrail against *accidental* testing against prod, not a security
 > boundary — a direct API call bypasses the frontend. The durable backstop is

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -111,3 +111,34 @@ To promote staging to production:
 1. Bump the version in `package.json` on `staging`
 2. Open a PR from `staging` → `main` and merge it
 3. The workflow detects the new version tag and deploys automatically
+
+## Preventing test access to production
+
+Test accounts must never be able to log into production. The app enforces this
+at sign-in: any account that carries the `test` role is refused when the build's
+environment is `production` — the session is torn down (redirect to
+`/.auth/logout` → `login.html`) before any page renders, and a
+`TestAccountBlockedInProduction` event is sent to Application Insights. See the
+guard in [`src/layout/MainLayout/index.tsx`](../src/layout/MainLayout/index.tsx).
+
+> This is a guardrail against *accidental* testing against prod, not a security
+> boundary — a direct API call bypasses the frontend. The durable backstop is
+> keeping test accounts and test data out of the production database.
+
+Two pieces make it work:
+
+1. **Environment is injected at build time** via the `VITE_ENVIRONMENT` variable.
+   It is set in each deploy workflow's build step — `production` in
+   [azure-static-web-apps-prod.yml](../.github/workflows/azure-static-web-apps-prod.yml)
+   and `staging` in
+   [azure-static-web-apps-staging.yml](../.github/workflows/azure-static-web-apps-staging.yml).
+   It is a Vite build-time value (must be `VITE_`-prefixed); a SWA runtime
+   Application Setting does **not** reach the bundle. Unset locally, so local dev
+   is treated as non-production and never blocked.
+2. **The `test` role** must be assigned to every account used for automated or
+   manual testing (in addition to its functional `admin`/`volunteer` role). How
+   you assign it depends on the role model — see
+   [aad-swa-roles.md](research/aad-swa-roles.md).
+
+To test the guard locally, start the dev server with the variable set, e.g.
+`VITE_ENVIRONMENT=production swa start`, and sign in with a `test`-role user.

--- a/docs/e2e-automation-test.md
+++ b/docs/e2e-automation-test.md
@@ -141,6 +141,11 @@ VOLUNTEER_PASSWORD=volunteer_test_password
 ⚠️ **Do not commit real or production credentials**  
 Ensure `.env` is included in `.gitignore`.
 
+> **Point the suite at a non-production environment.** The accounts used here
+> carry the `test` role, which the app **blocks from logging into production**
+> (see [deployment-guide.md](deployment-guide.md#preventing-test-access-to-production)).
+> Set `URL` to dev/staging, not prod.
+
 ## Running Tests
 ### Run All Tests
 ```bash

--- a/docs/research/aad-swa-roles.md
+++ b/docs/research/aad-swa-roles.md
@@ -17,7 +17,9 @@ The app has two custom roles, as defined in [login-design.md](../designs/login-d
 | `admin` | Full CRUD access; no PIN required; routed to admin dashboard |
 | `volunteer` | Limited API permissions; requires PIN verification after AAD login; routed to volunteer home |
 
-> **Important**: A user must have exactly one of these roles. Having both causes an error — see [swa-setup.md](../swa-setup.md).
+> **Important**: A user must have exactly one of `admin` or `volunteer`. Having both causes an error — see [swa-setup.md](../swa-setup.md).
+
+There is also an additive `test` role, **orthogonal** to the exactly-one rule above. Accounts used for automated or manual testing carry `test` alongside their functional `admin`/`volunteer` role. The app refuses any account with the `test` role when it runs in the `production` environment — this keeps test accounts from accidentally operating against prod. See [deployment-guide.md](../deployment-guide.md#preventing-test-access-to-production). If you adopt the group-based model below, create a third group (e.g. `plymouth-housing-test`) and map it to the `test` role.
 
 These roles currently flow into the DAB API layer via the `X-MS-API-ROLE` header on every REST request. DAB enforces permissions per role in `dab/dab-config.json`. See [authorization_roles.md](authorization_roles.md) for the prior investigation into this.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plymouth-housing",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plymouth-housing",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@ant-design/colors": "^8.0.1",
         "@ant-design/icons": "^5.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plymouth-housing",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "engines": {
     "node": ">=22.x"

--- a/src/layout/MainLayout/index.test.tsx
+++ b/src/layout/MainLayout/index.test.tsx
@@ -1,0 +1,195 @@
+/**
+ *  MainLayout/index.test.tsx
+ *
+ *  Covers the guardrail that refuses test-role accounts in production.
+ *
+ *  @copyright 2026 Digital Aid Seattle
+ *
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import MainLayout from './index';
+import { UserContext } from '../../components/contexts/UserContext';
+import { UserContextType } from '../../types/interfaces';
+
+const LOGOUT_URL = '/.auth/logout?post_logout_redirect_uri=/login.html';
+
+// ENVIRONMENT is a build-time constant, so it is swapped per test through a
+// hoisted holder the module mock reads on every access.
+const env = vi.hoisted(() => ({ value: 'development' }));
+
+vi.mock('../../types/constants', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../types/constants')>();
+  return {
+    ...actual,
+    get ENVIRONMENT() {
+      return env.value;
+    },
+  };
+});
+
+const { getAuthMe } = vi.hoisted(() => ({ getAuthMe: vi.fn() }));
+const { trackEvent } = vi.hoisted(() => ({ trackEvent: vi.fn() }));
+const { apiRequest } = vi.hoisted(() => ({ apiRequest: vi.fn() }));
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }));
+
+vi.mock('../../services/authService', () => ({ getAuthMe }));
+vi.mock('../../utils/appInsights', () => ({ trackEvent }));
+vi.mock('../../services/apiRequest', () => ({ apiRequest }));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+    Outlet: () => <div>Outlet Content</div>,
+  };
+});
+
+// The chrome around the outlet is irrelevant here; stub it out so the test
+// exercises the guard rather than MUI layout internals.
+vi.mock('./Header', () => ({ default: () => <div>Header</div> }));
+vi.mock('./Drawer', () => ({ default: () => <div>Drawer</div> }));
+vi.mock('../../components/@extended/Breadcrumbs', () => ({
+  default: () => <div>Breadcrumbs</div>,
+}));
+
+const contextValue = (): UserContextType => ({
+  user: null,
+  setUser: vi.fn(),
+  loggedInUserId: null,
+  setLoggedInUserId: vi.fn(),
+  activeVolunteers: [],
+  setActiveVolunteers: vi.fn(),
+  isLoading: false,
+});
+
+const renderLayout = () =>
+  render(
+    <UserContext.Provider value={contextValue()}>
+      <MemoryRouter>
+        <MainLayout />
+      </MemoryRouter>
+    </UserContext.Provider>,
+  );
+
+const authAs = (userRoles: string[] | undefined) =>
+  getAuthMe.mockResolvedValue({
+    clientPrincipal: {
+      userId: 'user@example.com',
+      userDetails: 'Test User',
+      userRoles,
+    },
+  });
+
+describe('MainLayout - production test-account guard', () => {
+  let clearSpy: ReturnType<typeof vi.spyOn>;
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    env.value = 'development';
+    apiRequest.mockResolvedValue({ value: [{ id: 1 }] });
+    clearSpy = vi
+      .spyOn(Storage.prototype, 'clear')
+      .mockImplementation(() => {});
+
+    originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { href: '' },
+    });
+  });
+
+  afterEach(() => {
+    clearSpy.mockRestore();
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('blocks a test account in production', async () => {
+    env.value = 'production';
+    authAs(['volunteer', 'test']);
+
+    renderLayout();
+
+    await waitFor(() =>
+      expect(trackEvent).toHaveBeenCalledWith('TestAccountBlockedInProduction', {
+        environment: 'production',
+        userDetails: 'Test User',
+        userRoles: 'volunteer,test',
+      }),
+    );
+    expect(clearSpy).toHaveBeenCalled();
+    expect(window.location.href).toBe(LOGOUT_URL);
+  });
+
+  it('renders nothing and skips role processing for a blocked account', async () => {
+    env.value = 'production';
+    authAs(['admin', 'test']);
+
+    const { container } = renderLayout();
+
+    await waitFor(() => expect(trackEvent).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText('Outlet Content')).not.toBeInTheDocument();
+    // The admin upsert and the volunteer redirect must never run.
+    expect(apiRequest).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('allows a test account outside production', async () => {
+    env.value = 'staging';
+    authAs(['volunteer', 'test']);
+
+    renderLayout();
+
+    expect(await screen.findByText('Outlet Content')).toBeInTheDocument();
+    expect(trackEvent).not.toHaveBeenCalled();
+    expect(window.location.href).toBe('');
+    // Volunteer without a logged-in id still goes to the name picker.
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/pick-your-name'));
+  });
+
+  it('allows a non-test account in production', async () => {
+    env.value = 'production';
+    authAs(['admin']);
+
+    renderLayout();
+
+    expect(await screen.findByText('Outlet Content')).toBeInTheDocument();
+    expect(trackEvent).not.toHaveBeenCalled();
+    expect(window.location.href).toBe('');
+    // Admin processing continues as usual.
+    await waitFor(() => expect(apiRequest).toHaveBeenCalled());
+  });
+
+  it('allows an account with no roles in production', async () => {
+    env.value = 'production';
+    authAs(undefined);
+
+    renderLayout();
+
+    expect(await screen.findByText('Outlet Content')).toBeInTheDocument();
+    expect(trackEvent).not.toHaveBeenCalled();
+    expect(window.location.href).toBe('');
+  });
+
+  it('renders the layout when the auth lookup fails in production', async () => {
+    env.value = 'production';
+    getAuthMe.mockRejectedValue(new Error('auth down'));
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    renderLayout();
+
+    expect(await screen.findByText('Outlet Content')).toBeInTheDocument();
+    expect(window.location.href).toBe('');
+    consoleError.mockRestore();
+  });
+});

--- a/src/layout/MainLayout/index.tsx
+++ b/src/layout/MainLayout/index.tsx
@@ -19,8 +19,9 @@ import { UserContext } from '../../components/contexts/UserContext';
 import { AdminUser, User } from '../../types/interfaces';
 import { useInactivityTimer } from '../../hooks/useInactivityTimer';
 import { useSnackbar } from '../../hooks/useSnackbar';
-import { ENDPOINTS, SETTINGS, USER_ROLES } from '../../types/constants';
+import { ENDPOINTS, ENVIRONMENT, SETTINGS, USER_ROLES } from '../../types/constants';
 import { getAuthMe } from '../../services/authService';
+import { trackEvent } from '../../utils/appInsights';
 import { apiRequest } from '../../services/apiRequest';
 
 const requestCache = new Map<string, Promise<AdminUser>>();
@@ -138,6 +139,25 @@ const MainLayout: React.FC = () => {
         const { clientPrincipal } = payload;
         const userClaims = clientPrincipal;
         setUser(userClaims || null);
+
+        // Guardrail: test-only accounts must never operate against production.
+        // This prevents the accidental "testing against prod" case by refusing
+        // the session and logging the account back out. It is not a security
+        // boundary (a direct API call bypasses it) — the real boundary is the
+        // absence of these accounts/data in the production database.
+        const isProduction = ENVIRONMENT === 'production';
+        const hasTestRole = userClaims?.userRoles?.includes(USER_ROLES.TEST);
+        if (isProduction && hasTestRole) {
+          trackEvent('TestAccountBlockedInProduction', {
+            environment: ENVIRONMENT,
+            userDetails: userClaims?.userDetails ?? '',
+            userRoles: (userClaims?.userRoles ?? []).join(','),
+          });
+          localStorage.clear();
+          window.location.href =
+            '/.auth/logout?post_logout_redirect_uri=/login.html';
+          return;
+        }
 
         if (userClaims?.userRoles?.includes('volunteer') && !loggedInUserId) {
           navigate('/pick-your-name');

--- a/src/layout/MainLayout/index.tsx
+++ b/src/layout/MainLayout/index.tsx
@@ -35,6 +35,10 @@ const MainLayout: React.FC = () => {
   const navigate = useNavigate();
   const { snackbarState, showSnackbar, handleClose } = useSnackbar();
   const navigateTimeoutRef = useRef<number | null>(null);
+  // In production nothing is rendered until the test-account guard below has
+  // run, so a blocked session never mounts the app shell or any child route.
+  // Outside production there is nothing to decide, so rendering is not held up.
+  const [guardCleared, setGuardCleared] = useState(ENVIRONMENT !== 'production');
 
   // Add inactivity timer
   const resetTimer = useInactivityTimer({
@@ -138,18 +142,22 @@ const MainLayout: React.FC = () => {
         const payload = await getAuthMe();
         const { clientPrincipal } = payload;
         const userClaims = clientPrincipal;
-        setUser(userClaims || null);
 
         // Guardrail: test-only accounts must never operate against production.
         // This prevents the accidental "testing against prod" case by refusing
-        // the session and logging the account back out. It is not a security
-        // boundary (a direct API call bypasses it) — the real boundary is the
-        // absence of these accounts/data in the production database.
+        // the session and logging the account back out. It runs before the user
+        // is stored and before `guardCleared` opens, so no protected UI mounts.
+        // It is not a security boundary (a direct API call bypasses it) — the
+        // real boundary is the absence of these accounts/data in the production
+        // database.
         const isProduction = ENVIRONMENT === 'production';
         const hasTestRole = userClaims?.userRoles?.includes(USER_ROLES.TEST);
         if (isProduction && hasTestRole) {
           trackEvent('TestAccountBlockedInProduction', {
             environment: ENVIRONMENT,
+            // Identifying the account is the point of the event — we need to
+            // know *which* test account hit production. Consistent with the
+            // PIN_Submission events, which already carry volunteer names.
             userDetails: userClaims?.userDetails ?? '',
             userRoles: (userClaims?.userRoles ?? []).join(','),
           });
@@ -158,6 +166,9 @@ const MainLayout: React.FC = () => {
             '/.auth/logout?post_logout_redirect_uri=/login.html';
           return;
         }
+
+        setUser(userClaims || null);
+        setGuardCleared(true);
 
         if (userClaims?.userRoles?.includes('volunteer') && !loggedInUserId) {
           navigate('/pick-your-name');
@@ -181,6 +192,8 @@ const MainLayout: React.FC = () => {
         }
       } catch (error) {
         console.error('Error in fetchTokenAndVolunteers:', error);
+        // The guard could not reach a verdict; render so the error is visible.
+        setGuardCleared(true);
         const errorMessage = error instanceof Error ? error.message : 'Failed to authenticate user';
         showSnackbar(`Authentication error: ${errorMessage}`, 'error');
         navigateTimeoutRef.current = window.setTimeout(() => {
@@ -210,6 +223,12 @@ const MainLayout: React.FC = () => {
   useEffect(() => {
     setDrawerOpen(!matchDownLG);  
   }, [matchDownLG]);
+
+  // Hold the app shell (and every child route) until the guard has cleared the
+  // session. A blocked account stays here until the logout redirect takes over.
+  if (!guardCleared) {
+    return null;
+  }
 
   return (
     <DrawerOpenContext.Provider value={{ drawerOpen, setDrawerOpen }}>

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -6,6 +6,11 @@
  */
 export const VITE_APPLICATION_NAME = 'Plymouth Housing';
 
+// Deployment environment, injected at build time per workflow (see the
+// azure-static-web-apps-*.yml build steps). Unset locally, so local dev and any
+// non-production build are treated as non-production and never blocked below.
+export const ENVIRONMENT = import.meta.env.VITE_ENVIRONMENT ?? 'development';
+
 export const API_HEADERS = {
   Accept: 'application/json',
   'Content-Type': 'application/json;charset=utf-8',
@@ -61,6 +66,11 @@ export const SETTINGS = {
 export const USER_ROLES = {
   ADMIN: 'admin',
   VOLUNTEER: 'volunteer',
+  // Marks an account as test-only. Assigned to the accounts the E2E suite and
+  // manual testers use, in addition to their functional admin/volunteer role.
+  // The app refuses any account carrying this role when ENVIRONMENT is
+  // 'production' (see MainLayout).
+  TEST: 'test',
 } as const;
 
 export const ROLE_PAGES = {


### PR DESCRIPTION
## Backport of #583

The production test-account guard was merged straight into `main` (#583). This backports the same five commits to ``dev`` so the branch does not regress the guard on its next promotion.

Cherry-picked cleanly — the guard diff is byte-identical to what landed on `main`: 9 files, +296/-9.

Also includes a **version bump to 1.5.1**, matching the bump going into `main` (#591), so this branch does not sit behind on the next promotion.

## What it does

Any account carrying the `test` role is refused when the app runs in the `production` environment. The session is torn down (`/.auth/logout` → `login.html`) before any page renders, and a `TestAccountBlockedInProduction` event goes to Application Insights.

- **`src/layout/MainLayout/index.tsx`** — the guard, plus a `guardCleared` gate so a blocked account never mounts the app shell.
- **`src/layout/MainLayout/index.test.tsx`** — 6 tests covering production/staging × test/non-test/no roles.
- **`src/types/constants.ts`** — `ENVIRONMENT` (build-time `VITE_ENVIRONMENT`, defaults to `development`) and `USER_ROLES.TEST`.
- **deploy workflows** — inject `VITE_ENVIRONMENT: production` / `staging`; e2e `URL` now reads `secrets.STAGING_URL`.
- **docs** — "Preventing test access to production" in the deployment guide, plus notes in the roles research and E2E guides.

Not a security boundary — it stops the *accidental* case. A direct API call bypasses the frontend; the durable backstop is keeping test accounts and data out of the production DB.

## Verification

- `tsc --noEmit` clean, `npm run build` succeeds.
- Full suite green: 40 files / 368 tests passed.
- No new ESLint findings versus the base branch.
- Version bump is `package.json` + `package-lock.json` root fields only, via `npm version 1.5.1 --no-git-tag-version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)