### PR TITLE
chore: bump version to 1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plymouth-housing",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plymouth-housing",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@ant-design/colors": "^8.0.1",
         "@ant-design/icons": "^5.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plymouth-housing",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "engines": {
     "node": ">=22.x"


### PR DESCRIPTION
## Why

#583 (production test-account guard) merged into `main` without a version bump. The prod deploy workflow reads the version from `package.json` and skips the deploy when a matching tag already exists — `v1.5.0` was already cut, so the guard is on `main` but **not deployed to production**.

## What

Patch bump `1.5.0` → `1.5.1` in `package.json` and `package-lock.json`, via `npm version 1.5.1 --no-git-tag-version`.

Merging this gives the workflow a new version to tag, which cuts `v1.5.1`, generates the release, and deploys the guard to production.

Note: npm also added the missing trailing newline at the end of `package.json` — that is the only other change in the diff.

## Verification

Version-only change; no source files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
