### PR TITLE
fix: stop staging deploys from overwriting production

### DIFF
--- a/.github/workflows/azure-static-web-apps-staging.yml
+++ b/.github/workflows/azure-static-web-apps-staging.yml
@@ -54,6 +54,18 @@ jobs:
             }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
           action: 'upload'
+          # REQUIRED -- do not remove. This token points at the same Static Web
+          # App as the production workflow, so without an explicit target
+          # environment the action uploads to the app's *default (production)*
+          # environment and staging silently replaces the live site. That is
+          # what happened on 2026-08-03, after commit 19b402d dropped this line.
+          #
+          # @v1 logs "Unexpected input(s) 'deployment_environment'" because the
+          # ambiguous ref now resolves to the 2021 tag, whose action.yml predates
+          # the input. The warning is cosmetic: the value still reaches the
+          # container as INPUT_DEPLOYMENT_ENVIRONMENT and is honoured. Do not
+          # "fix" the warning by removing the input.
+          deployment_environment: 'staging'
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: '/' # App source code path
           api_location: '' # Api source code path - optional

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plymouth-housing",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plymouth-housing",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "dependencies": {
         "@ant-design/colors": "^8.0.1",
         "@ant-design/icons": "^5.5.2",
@@ -2307,9 +2307,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2327,9 +2324,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2347,9 +2341,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2367,9 +2358,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2387,9 +2375,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2407,9 +2392,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plymouth-housing",
   "private": true,
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "engines": {
     "node": ">=22.x"


### PR DESCRIPTION
## Problem

A `test`-role account signed into **production** and was let straight in, even though the production test-account guard shipped in v1.5.1.

The guard itself is fine. The bundle being served from the production host was built with `VITE_ENVIRONMENT=staging`, so `ENVIRONMENT === 'production'` evaluated to `false` and the guard correctly declined to fire. Confirmed by reading the live bundle: `KT = "staging"`.

## Root cause

The staging workflow uses the **same Static Web App token as production** (`..._SALMON_ISLAND_01BE9BF1E`). With no explicit target environment, `Azure/static-web-apps-deploy` uploads to the app's *default (production)* environment regardless of branch.

Commit `19b402d` (2026-07-28) removed `deployment_environment: 'staging'` in response to an `Unexpected input(s)` warning. The next push to `staging` (2026-08-03, PR #589) therefore replaced the live production site with a staging build.

Run logs, before and after the removal:

| Run | `deployment_environment` | Deployed to |
|---|---|---|
| Jul 28, pre-removal | present (warning printed) | `salmon-island-01be9bf1e-staging.westus2.5.azurestaticapps.net` |
| Aug 3, post-removal | absent | `salmon-island-01be9bf1e.5.azurestaticapps.net` ← production |

The Jul 28 run proves the warning is cosmetic: it printed `Unexpected input(s) 'deployment_environment'` **and** still passed `INPUT_DEPLOYMENT_ENVIRONMENT` into the container and deployed to the staging hostname. The warning exists because GitHub's ambiguous-ref resolution now resolves `@v1` to the 2021 tag, whose `action.yml` predates the input.

## Changes

- Restore `deployment_environment: 'staging'`, with a comment explaining that the token targets the production app and that the warning must not be acted on again.
- Bump `1.5.1` → `1.5.2` so the production workflow's tag gate (`tag_exists == 'false'`) permits a real production build to replace the staging bundle currently live.

## Verifying after merge

The staging deploy run must log:

```
Visit your site at: https://salmon-island-01be9bf1e-staging.westus2.5.azurestaticapps.net
```

A **region-less** hostname there means the input did not take and production was overwritten again.

## Note

Production keeps serving the staging bundle — and keeps admitting `test`-role accounts — until this reaches `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)