### PR TITLE
Backport #596 to dev: stop staging deploys from overwriting production

### DIFF
--- a/.github/workflows/azure-static-web-apps-staging.yml
+++ b/.github/workflows/azure-static-web-apps-staging.yml
@@ -54,6 +54,18 @@ jobs:
             }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
           action: 'upload'
+          # REQUIRED -- do not remove. This token points at the same Static Web
+          # App as the production workflow, so without an explicit target
+          # environment the action uploads to the app's *default (production)*
+          # environment and staging silently replaces the live site. That is
+          # what happened on 2026-08-03, after commit 19b402d dropped this line.
+          #
+          # @v1 logs "Unexpected input(s) 'deployment_environment'" because the
+          # ambiguous ref now resolves to the 2021 tag, whose action.yml predates
+          # the input. The warning is cosmetic: the value still reaches the
+          # container as INPUT_DEPLOYMENT_ENVIRONMENT and is honoured. Do not
+          # "fix" the warning by removing the input.
+          deployment_environment: 'staging'
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: '/' # App source code path
           api_location: '' # Api source code path - optional

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plymouth-housing",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plymouth-housing",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "dependencies": {
         "@ant-design/colors": "^8.0.1",
         "@ant-design/icons": "^5.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plymouth-housing",
   "private": true,
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "engines": {
     "node": ">=22.x"


### PR DESCRIPTION
Backport of #596 to `dev`, so the fix is not lost the next time `dev` merges forward into `staging`.

## What this fixes

The staging workflow's SWA token points at the **same Static Web App as production** (`..._SALMON_ISLAND_01BE9BF1E`). With no explicit target environment, `Azure/static-web-apps-deploy` uploads to the app's *default (production)* environment regardless of branch — so a push to `staging` replaced the live production site on 2026-08-03.

Restores `deployment_environment: 'staging'`, dropped by commit `19b402d` in response to a cosmetic `Unexpected input(s)` warning, together with a comment explaining why the warning must not be acted on again.

## Contents

- `.github/workflows/azure-static-web-apps-staging.yml` — identical to the merged staging version, verified byte-for-byte.
- `package.json` / `package-lock.json` — `1.5.1` → `1.5.2`, matching `staging`, so `dev` does not regress the version on the next forward merge.

Only the staging workflow needed the change: `azure-static-web-apps-dev.yml` runs CI without an SWA deploy step, and `azure-static-web-apps-prod.yml` is *supposed* to target the default environment.

## Verifying after merge

Nothing deploys from `dev` for this path — the fix takes effect when `dev` reaches `staging`. The staging deploy run must then log a **region-bearing** hostname:

```
Visit your site at: https://salmon-island-01be9bf1e-staging.westus2.5.azurestaticapps.net
```

A region-less hostname means the input did not take and production was overwritten again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 1.5.2.
  * Improved staging deployment configuration to ensure releases are deployed to the intended staging environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->