### PR TITLE
PIT-517: Close sidebar drawer on nav on tablet

### DIFF
--- a/src/layout/MainLayout/Drawer/DrawerContent/Navigation/NavItem.tsx
+++ b/src/layout/MainLayout/Drawer/DrawerContent/Navigation/NavItem.tsx
@@ -14,6 +14,7 @@ import {
   ListItemIcon,
   ListItemText,
   Typography,
+  useMediaQuery,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 
@@ -33,10 +34,16 @@ const NavItem: React.FC<NavItemProps> = ({ item, level }) => {
   const location = useLocation();
   const { pathname } = location;
 
-  const { drawerOpen } = useContext(DrawerOpenContext);
+  const { drawerOpen, setDrawerOpen } = useContext(DrawerOpenContext);
   const { activeMenuItem, setActiveMenuItem } = useContext(
     ActiveMenuItemContext,
   );
+
+  // PIT-517: below the lg breakpoint the drawer is rendered as a temporary
+  // overlay (see MainLayout/Drawer/index.tsx). Match the same breakpoint here
+  // so navigating on tablet auto-closes the drawer. Above lg the drawer is
+  // permanent and stays put.
+  const matchDownLG = useMediaQuery(theme.breakpoints.down('lg'));
 
   // active menu item on page load
   useEffect(() => {
@@ -66,6 +73,13 @@ const NavItem: React.FC<NavItemProps> = ({ item, level }) => {
 
   const itemHandler = (id: string) => {
     setActiveMenuItem(id);
+    // PIT-517: on tablet the drawer overlays the page. Close it on nav so
+    // the newly-loaded page is actually visible without a manual dismiss.
+    // NavCollapse (parent-with-submenu) does not call this, so expanding a
+    // submenu still leaves the drawer open.
+    if (matchDownLG) {
+      setDrawerOpen(false);
+    }
   };
 
   const textColor = 'text.primary';

--- a/src/layout/MainLayout/Drawer/DrawerContent/Navigation/NavItem.tsx
+++ b/src/layout/MainLayout/Drawer/DrawerContent/Navigation/NavItem.tsx
@@ -39,10 +39,6 @@ const NavItem: React.FC<NavItemProps> = ({ item, level }) => {
     ActiveMenuItemContext,
   );
 
-  // PIT-517: below the lg breakpoint the drawer is rendered as a temporary
-  // overlay (see MainLayout/Drawer/index.tsx). Match the same breakpoint here
-  // so navigating on tablet auto-closes the drawer. Above lg the drawer is
-  // permanent and stays put.
   const matchDownLG = useMediaQuery(theme.breakpoints.down('lg'));
 
   // active menu item on page load
@@ -73,10 +69,6 @@ const NavItem: React.FC<NavItemProps> = ({ item, level }) => {
 
   const itemHandler = (id: string) => {
     setActiveMenuItem(id);
-    // PIT-517: on tablet the drawer overlays the page. Close it on nav so
-    // the newly-loaded page is actually visible without a manual dismiss.
-    // NavCollapse (parent-with-submenu) does not call this, so expanding a
-    // submenu still leaves the drawer open.
     if (matchDownLG) {
       setDrawerOpen(false);
     }


### PR DESCRIPTION
# Description

On tablet the sidebar drawer is rendered as a temporary overlay (see [`MainLayout/Drawer/index.tsx`](../blob/dev/src/layout/MainLayout/Drawer/index.tsx)). Before this change, tapping a nav item navigated to the new page but left the drawer open on top of it, forcing the user to dismiss it manually. Now the drawer auto-closes on nav below the `lg` breakpoint. Desktop is unchanged.

## Jira Ticket
- Closes: [PIT-517](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-517)

## Type of Change
**Type:** Bug fix

## Changes Made

- [`NavItem.tsx`](../blob/dev/src/layout/MainLayout/Drawer/DrawerContent/Navigation/NavItem.tsx) — the `itemHandler` click callback now checks `useMediaQuery(theme.breakpoints.down('lg'))` and calls `setDrawerOpen(false)` when true. Same breakpoint that Drawer uses to decide temporary vs. permanent, so the "close on nav" behavior lines up exactly with when the drawer is a temporary overlay.
- No change to `NavCollapse` (the parent-with-submenu component), so tapping a parent to expand a submenu still leaves the drawer open, which is the intended behavior.

## How to verify

In Chrome DevTools:
1. Open the app, hit F12, toggle device toolbar (Ctrl+Shift+M), pick a tablet preset (e.g. iPad Air)
2. Reload
3. Tap the hamburger to open the sidebar
4. Tap any leaf nav item (e.g. Checkout, History) → page loads **and** sidebar closes
5. Tap a parent item with a submenu (e.g. Inventory) → submenu expands, sidebar stays open
6. Switch to a desktop viewport → sidebar behavior unchanged (permanent mini drawer)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code only in hard-to-understand areas
- [ ] My changes generate no new warnings in Chrome Dev Tools *(not verified locally)*
- [ ] New and existing unit tests pass locally with my changes *(Windows EMFILE limit prevents running the full suite locally; relying on CI. TypeScript passes cleanly.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
