### PR TITLE
PIT-521: Fix PIN bypass via back navigation and add attempt-clear UX

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,10 @@ const App: React.FC = () => {
   const [activeVolunteers, setActiveVolunteers] = usePersistentState<User[]>('activeVolunteers', []);
   const [pinVerified, setPinVerified] = React.useState<boolean>(false);
 
+  useEffect(() => {
+    setPinVerified(false);
+  }, [loggedInUserId]);
+  
   useAuthorization(user, Object.values(USER_ROLES));
 
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ const App: React.FC = () => {
   const [user, setUser] = usePersistentState<ClientPrincipal | null>('user', null);
   const [loggedInUserId, setLoggedInUserId] = usePersistentState<number | null>('loggedInUserId', null);
   const [activeVolunteers, setActiveVolunteers] = usePersistentState<User[]>('activeVolunteers', []);
+  const [pinVerified, setPinVerified] = usePersistentState<boolean>('pinVerified', false);
 
   useAuthorization(user, Object.values(USER_ROLES));
 
@@ -40,9 +41,11 @@ const App: React.FC = () => {
       setLoggedInUserId,
       activeVolunteers,
       setActiveVolunteers,
+      pinVerified,
+      setPinVerified,
       isLoading: user === null,
     }),
-    [user, setUser, loggedInUserId, setLoggedInUserId, activeVolunteers, setActiveVolunteers]
+    [user, setUser, loggedInUserId, setLoggedInUserId, activeVolunteers, setActiveVolunteers, pinVerified, setPinVerified]
   );
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ const App: React.FC = () => {
   const [user, setUser] = usePersistentState<ClientPrincipal | null>('user', null);
   const [loggedInUserId, setLoggedInUserId] = usePersistentState<number | null>('loggedInUserId', null);
   const [activeVolunteers, setActiveVolunteers] = usePersistentState<User[]>('activeVolunteers', []);
-  const [pinVerified, setPinVerified] = usePersistentState<boolean>('pinVerified', false);
+  const [pinVerified, setPinVerified] = React.useState<boolean>(false);
 
   useAuthorization(user, Object.values(USER_ROLES));
 

--- a/src/components/AddVolunteerModal/AddVolunteerModal.test.tsx
+++ b/src/components/AddVolunteerModal/AddVolunteerModal.test.tsx
@@ -24,6 +24,8 @@ const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
       activeVolunteers: [],
       setActiveVolunteers: vi.fn(),
       isLoading: false,
+      pinVerified: false,
+      setPinVerified: vi.fn(),
     }}
   >
     {children}

--- a/src/components/Checkout/ResidentDetailDialog.test.tsx
+++ b/src/components/Checkout/ResidentDetailDialog.test.tsx
@@ -36,6 +36,8 @@ describe('ResidentDetailDialog', () => {
     activeVolunteers: [],
     setActiveVolunteers: vi.fn(),
     isLoading: false,
+    pinVerified: false,
+    setPinVerified: vi.fn(),
   };
 
   const mockBuildings = [

--- a/src/components/Checkout/WelcomeBasketBuildingDialog.test.tsx
+++ b/src/components/Checkout/WelcomeBasketBuildingDialog.test.tsx
@@ -35,6 +35,8 @@ describe('WelcomeBasketBuildingDialog', () => {
     activeVolunteers: [],
     setActiveVolunteers: vi.fn(),
     isLoading: false,
+    pinVerified: false,
+    setPinVerified: vi.fn(),
   };
 
   const mockBuildings = [

--- a/src/components/contexts/UserContext.ts
+++ b/src/components/contexts/UserContext.ts
@@ -15,5 +15,7 @@ export const UserContext = createContext<UserContextType>({
   activeVolunteers: [],
   setActiveVolunteers: () => {},
   isLoading: true,
+  pinVerified: false,
+  setPinVerified: () => {},
 });
 

--- a/src/components/inventory/AddItemModal.test.tsx
+++ b/src/components/inventory/AddItemModal.test.tsx
@@ -39,6 +39,8 @@ const userContextValue = {
     activeVolunteers: [],
     setActiveVolunteers: vi.fn(),
     isLoading: false,
+    pinVerified: false,
+    setPinVerified: vi.fn(),
 };
 
 const renderComponent = () => {

--- a/src/layout/MainLayout/Header/HeaderContent/HeaderContent.test.tsx
+++ b/src/layout/MainLayout/Header/HeaderContent/HeaderContent.test.tsx
@@ -33,6 +33,8 @@ const renderWithRoles = (userRoles: string[]) =>
         activeVolunteers: [],
         setActiveVolunteers: vi.fn(),
         isLoading: false,
+        pinVerified: false,
+        setPinVerified: vi.fn(),
       }}
     >
       <MemoryRouter>

--- a/src/layout/MainLayout/index.test.tsx
+++ b/src/layout/MainLayout/index.test.tsx
@@ -64,6 +64,8 @@ const contextValue = (): UserContextType => ({
   activeVolunteers: [],
   setActiveVolunteers: vi.fn(),
   isLoading: false,
+  pinVerified: false,
+  setPinVerified: vi.fn(),
 });
 
 const renderLayout = () =>

--- a/src/pages/RootRedirect.test.tsx
+++ b/src/pages/RootRedirect.test.tsx
@@ -55,15 +55,22 @@ const GenericRedirectPage = ({ source }: { source: string }) => (
 );
 
 
-const mockUserContextValue = (role: 'admin' | 'volunteer' | null | undefined, isLoading: boolean, pinVerified = true): UserContextType => ({
-  user: role ? {
-    userRoles: [role],
-    userId: 'test-user-id',
-    userDetails: 'test-user-details'
-  } : null,
+const mockUserContextValue = (
+  role: 'admin' | 'volunteer' | null | undefined,
+  isLoading: boolean,
+  pinVerified = true,
+  loggedInUserId: number | null = null,
+): UserContextType => ({
+  user: role
+    ? {
+        userRoles: [role],
+        userId: 'test-user-id',
+        userDetails: 'test-user-details',
+      }
+    : null,
   isLoading,
   setUser: vi.fn(),
-  loggedInUserId: null,
+  loggedInUserId,
   setLoggedInUserId: vi.fn(),
   activeVolunteers: [],
   setActiveVolunteers: vi.fn(),
@@ -85,6 +92,7 @@ const renderWithRouter = (contextValue: any, { route = '/' } = {}) => {
           <Route path="/volunteer-home" element={<VolunteerHomePage />} />
           <Route path="/admin-home" element={<AdminHomePage />} />
           <Route path="/pick-your-name" element={<div>Pick Your Name Page</div>} />
+          <Route path="/enter-your-pin" element={<div>Enter Your PIN Page</div>} />
           <Route path="/404" element={<div data-testid="page-404">404 Page</div>} />
           <Route path="/:source" element={<GenericRedirectPage source={route.slice(1)} />} />
         </Routes>
@@ -160,6 +168,40 @@ describe('RootRedirect', () => {
   });
 });
 
+describe('RootRedirect - pinVerified gating', () => {
+  it('redirects volunteer with no selected volunteer to /pick-your-name', () => {
+    const contextValue = mockUserContextValue('volunteer', false, false, null);
+    renderWithRouter(contextValue, { route: '/volunteer-home' });
+    expect(screen.getByText('Pick Your Name Page')).toBeInTheDocument();
+  });
+
+  it('redirects selected volunteer to /enter-your-pin when pinVerified is false', () => {
+    const contextValue = mockUserContextValue('volunteer', false, false, 123);
+    renderWithRouter(contextValue, { route: '/volunteer-home' });
+    expect(screen.queryByText('Volunteer Home Page')).not.toBeInTheDocument();
+    expect(screen.getByText('Enter Your PIN Page')).toBeInTheDocument();
+  });
+
+  it('allows volunteer through to dashboard when pinVerified is true', () => {
+    const contextValue = mockUserContextValue('volunteer', false, true, 123);
+    renderWithRouter(contextValue, { route: '/volunteer-home' });
+    expect(screen.getByText('Volunteer Home Page')).toBeInTheDocument();
+  });
+
+  it('admin is unaffected by pinVerified being false', () => {
+    const contextValue = mockUserContextValue('admin', false, false, null);
+    renderWithRouter(contextValue, { route: '/admin-home' });
+    expect(screen.getByText('Admin Home Page')).toBeInTheDocument();
+  });
+
+  it('blocks volunteer with no PIN verification from shared pages', () => {
+    const contextValue = mockUserContextValue('volunteer', false, false, 123);
+    renderWithRouter(contextValue, { route: '/inventory' });
+    expect(screen.queryByText('Inventory Page Content')).not.toBeInTheDocument();
+    expect(screen.getByText('Enter Your PIN Page')).toBeInTheDocument();
+  });
+});
+
 describe('RootRedirect - invalid userRole handling', () => {
   let mockLocalStorageClear: any;
   let originalLocation: Location;
@@ -173,32 +215,6 @@ describe('RootRedirect - invalid userRole handling', () => {
       value: {
         href: ''
       }
-    });
-  });
-
-  describe('RootRedirect - pinVerified gating', () => {
-    it('redirects volunteer to /pick-your-name when pinVerified is false', () => {
-      const contextValue = mockUserContextValue('volunteer', false, false);
-      renderWithRouter(contextValue, { route: '/volunteer-home' });
-      expect(screen.getByText('Pick Your Name Page')).toBeInTheDocument();
-    });
-  
-    it('allows volunteer through to dashboard when pinVerified is true', () => {
-      const contextValue = mockUserContextValue('volunteer', false, true);
-      renderWithRouter(contextValue, { route: '/volunteer-home' });
-      expect(screen.getByText('Volunteer Home Page')).toBeInTheDocument();
-    });
-  
-    it('admin is unaffected by pinVerified being false', () => {
-      const contextValue = mockUserContextValue('admin', false, false);
-      renderWithRouter(contextValue, { route: '/admin-home' });
-      expect(screen.getByText('Admin Home Page')).toBeInTheDocument();
-    });
-  
-    it('volunteer with pinVerified false is blocked from shared pages too', () => {
-      const contextValue = mockUserContextValue('volunteer', false, false);
-      renderWithRouter(contextValue, { route: '/inventory' });
-      expect(screen.queryByText('Inventory Page Content')).not.toBeInTheDocument();
     });
   });
 

--- a/src/pages/RootRedirect.test.tsx
+++ b/src/pages/RootRedirect.test.tsx
@@ -84,6 +84,7 @@ const renderWithRouter = (contextValue: any, { route = '/' } = {}) => {
           <Route path="/people" element={<PeoplePage />} />
           <Route path="/volunteer-home" element={<VolunteerHomePage />} />
           <Route path="/admin-home" element={<AdminHomePage />} />
+          <Route path="/pick-your-name" element={<div>Pick Your Name Page</div>} />
           <Route path="/404" element={<div data-testid="page-404">404 Page</div>} />
           <Route path="/:source" element={<GenericRedirectPage source={route.slice(1)} />} />
         </Routes>
@@ -179,7 +180,7 @@ describe('RootRedirect - invalid userRole handling', () => {
     it('redirects volunteer to /pick-your-name when pinVerified is false', () => {
       const contextValue = mockUserContextValue('volunteer', false, false);
       renderWithRouter(contextValue, { route: '/volunteer-home' });
-      expect(screen.queryByText('Volunteer Home Page')).not.toBeInTheDocument();
+      expect(screen.getByText('Pick Your Name Page')).toBeInTheDocument();
     });
   
     it('allows volunteer through to dashboard when pinVerified is true', () => {

--- a/src/pages/RootRedirect.test.tsx
+++ b/src/pages/RootRedirect.test.tsx
@@ -55,7 +55,7 @@ const GenericRedirectPage = ({ source }: { source: string }) => (
 );
 
 
-const mockUserContextValue = (role: 'admin' | 'volunteer' | null | undefined, isLoading: boolean): UserContextType => ({
+const mockUserContextValue = (role: 'admin' | 'volunteer' | null | undefined, isLoading: boolean, pinVerified = true): UserContextType => ({
   user: role ? {
     userRoles: [role],
     userId: 'test-user-id',
@@ -67,6 +67,8 @@ const mockUserContextValue = (role: 'admin' | 'volunteer' | null | undefined, is
   setLoggedInUserId: vi.fn(),
   activeVolunteers: [],
   setActiveVolunteers: vi.fn(),
+  pinVerified,
+  setPinVerified: vi.fn(),
 });
 
 const renderWithRouter = (contextValue: any, { route = '/' } = {}) => {
@@ -170,6 +172,32 @@ describe('RootRedirect - invalid userRole handling', () => {
       value: {
         href: ''
       }
+    });
+  });
+
+  describe('RootRedirect - pinVerified gating', () => {
+    it('redirects volunteer to /pick-your-name when pinVerified is false', () => {
+      const contextValue = mockUserContextValue('volunteer', false, false);
+      renderWithRouter(contextValue, { route: '/volunteer-home' });
+      expect(screen.queryByText('Volunteer Home Page')).not.toBeInTheDocument();
+    });
+  
+    it('allows volunteer through to dashboard when pinVerified is true', () => {
+      const contextValue = mockUserContextValue('volunteer', false, true);
+      renderWithRouter(contextValue, { route: '/volunteer-home' });
+      expect(screen.getByText('Volunteer Home Page')).toBeInTheDocument();
+    });
+  
+    it('admin is unaffected by pinVerified being false', () => {
+      const contextValue = mockUserContextValue('admin', false, false);
+      renderWithRouter(contextValue, { route: '/admin-home' });
+      expect(screen.getByText('Admin Home Page')).toBeInTheDocument();
+    });
+  
+    it('volunteer with pinVerified false is blocked from shared pages too', () => {
+      const contextValue = mockUserContextValue('volunteer', false, false);
+      renderWithRouter(contextValue, { route: '/inventory' });
+      expect(screen.queryByText('Inventory Page Content')).not.toBeInTheDocument();
     });
   });
 

--- a/src/pages/RootRedirect.tsx
+++ b/src/pages/RootRedirect.tsx
@@ -17,7 +17,7 @@ interface RootRedirectProps {
 }
 
 export const RootRedirect: React.FC<RootRedirectProps> = ({ source, children }) => {
-  const { user, isLoading } = React.useContext(UserContext);
+  const { user, isLoading, pinVerified } = React.useContext(UserContext);
 
   // This handles the situation when the userContext does not have a user set yet. 
   if (isLoading) {
@@ -33,6 +33,10 @@ export const RootRedirect: React.FC<RootRedirectProps> = ({ source, children }) 
     }  
   }else{
       return <LogoutRedirect />;  
+  }
+
+  if (userRole === 'volunteer' && !pinVerified) {
+    return <Navigate to="/pick-your-name" replace />;
   }
 
   const alternateRole = userRole === 'admin' ? 'volunteer' : 'admin';

--- a/src/pages/RootRedirect.tsx
+++ b/src/pages/RootRedirect.tsx
@@ -17,7 +17,7 @@ interface RootRedirectProps {
 }
 
 export const RootRedirect: React.FC<RootRedirectProps> = ({ source, children }) => {
-  const { user, isLoading, pinVerified } = React.useContext(UserContext);
+  const { user, isLoading, pinVerified, loggedInUserId } = React.useContext(UserContext);
 
   // This handles the situation when the userContext does not have a user set yet. 
   if (isLoading) {
@@ -36,7 +36,12 @@ export const RootRedirect: React.FC<RootRedirectProps> = ({ source, children }) 
   }
 
   if (userRole === 'volunteer' && !pinVerified) {
-    return <Navigate to="/pick-your-name" replace />;
+    return (
+      <Navigate
+        to={loggedInUserId !== null ? '/enter-your-pin' : '/pick-your-name'}
+        replace
+      />
+    );
   }
 
   const alternateRole = userRole === 'admin' ? 'volunteer' : 'admin';

--- a/src/pages/VolunteerHome/VolunteerHome.test.tsx
+++ b/src/pages/VolunteerHome/VolunteerHome.test.tsx
@@ -52,6 +52,8 @@ const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
       activeVolunteers: [],
       setActiveVolunteers: vi.fn(),
       isLoading: false,
+      pinVerified: false,
+      setPinVerified: vi.fn(),
     }}
   >
     {children}

--- a/src/pages/authentication/EnterPinPage.test.tsx
+++ b/src/pages/authentication/EnterPinPage.test.tsx
@@ -43,6 +43,8 @@ const createUserContextValue = (overrides = {}) => ({
   activeVolunteers: [],
   setActiveVolunteers: vi.fn(),
   isLoading: false,
+  pinVerified: false,
+  setPinVerified: vi.fn(),
   ...overrides,
 });
 
@@ -85,9 +87,8 @@ describe('EnterPinPage Component', () => {
   });
 
   test('handles valid PIN and navigates to volunteer-home', async () => {
-    // Set up fetch mocks:
-    // 1st call: verifying the PIN (returns valid)
-    // 2nd call: updating last signed-in (succeeds)
+    const mockSetPinVerified = vi.fn();
+  
     (global.fetch as any) = vi.fn()
       .mockResolvedValueOnce({
         ok: true,
@@ -97,30 +98,56 @@ describe('EnterPinPage Component', () => {
         ok: true,
         json: async () => ({}),
       });
-
+  
     render(
-      <UserContext.Provider value={createUserContextValue()}>
+      <UserContext.Provider value={createUserContextValue({ setPinVerified: mockSetPinVerified })}>
         <EnterPinPage />
       </UserContext.Provider>
     );
-
-    // Simulate entering a complete PIN via the mocked PinInput.
+  
     const pinInput = screen.getByTestId('pin-input');
     fireEvent.change(pinInput, { target: { value: '1234' } });
-
-    // Click the Continue button.
+  
     const continueButton = screen.getByRole('button', { name: /Continue/i });
     fireEvent.click(continueButton);
-
-    // Wait for the success snackbar message to appear.
+  
     await waitFor(() => {
       expect(screen.getByText(/Login successful! Redirecting.../i)).toBeInTheDocument();
     });
-
-    // Expect navigation to volunteer-home.
+  
+    expect(mockSetPinVerified).toHaveBeenCalledWith(true);
     expect(mockNavigate).toHaveBeenCalledWith('/volunteer-home');
-    // Verify that both fetch calls were made.
     expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not set pinVerified when PIN is invalid', async () => {
+    const mockSetPinVerified = vi.fn();
+  
+    (global.fetch as any) = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ value: [{ IsValid: false, ErrorMessage: "Incorrect PIN." }] }),
+    });
+  
+    render(
+      <UserContext.Provider value={createUserContextValue({ setPinVerified: mockSetPinVerified })}>
+        <EnterPinPage />
+      </UserContext.Provider>
+    );
+  
+    const pinInput = screen.getByTestId('pin-input');
+    fireEvent.change(pinInput, { target: { value: '9999' } });
+  
+    const continueButton = screen.getByRole('button', { name: /Continue/i });
+    fireEvent.click(continueButton);
+  
+    await waitFor(() => {
+      expect(screen.getByText((content) =>
+        content.replace(/\s+/g, ' ').includes('Incorrect PIN.')
+      )).toBeInTheDocument();
+    });
+  
+    expect(mockSetPinVerified).not.toHaveBeenCalledWith(true);
+    expect(mockNavigate).not.toHaveBeenCalledWith('/volunteer-home');
   });
 
   test('handles invalid PIN and shows error snackbar', async () => {
@@ -157,6 +184,34 @@ describe('EnterPinPage Component', () => {
     expect(mockNavigate).not.toHaveBeenCalledWith('/volunteer-home');
   });
   
+  test('increments pinAttempt and remounts PinInput after an invalid PIN', async () => {
+    (global.fetch as any) = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ value: [{ IsValid: false, ErrorMessage: "Incorrect PIN." }] }),
+    });
+  
+    render(
+      <UserContext.Provider value={createUserContextValue()}>
+        <EnterPinPage />
+      </UserContext.Provider>
+    );
+  
+    const pinInputBefore = screen.getByTestId('pin-input');
+    fireEvent.change(pinInputBefore, { target: { value: '9999' } });
+  
+    const continueButton = screen.getByRole('button', { name: /Continue/i });
+    fireEvent.click(continueButton);
+  
+    await waitFor(() => {
+      expect(screen.getByText((content) =>
+        content.replace(/\s+/g, ' ').includes('Incorrect PIN.')
+      )).toBeInTheDocument();
+    });
+  
+    // Confirm PinInput remounted with a fresh instance (key changed)
+    const pinInputAfter = screen.getByTestId('pin-input');
+    expect(pinInputAfter).not.toBe(pinInputBefore);
+  });
 
   test('navigates back to /pick-your-name when back link is clicked', async () => {
     render(

--- a/src/pages/authentication/EnterPinPage.tsx
+++ b/src/pages/authentication/EnterPinPage.tsx
@@ -19,8 +19,9 @@ import { useSnackbar } from '../../hooks/useSnackbar';
 
 const EnterPinPage: React.FC = () => {
   const [pin, setPin] = useState<string[]>(() => Array(4).fill(''));
+  const [pinAttempt, setPinAttempt] = useState<number>(0);
   const { snackbarState, showSnackbar, handleClose } = useSnackbar();
-  const { loggedInUserId, user, activeVolunteers } = useContext(UserContext);
+  const { loggedInUserId, user, activeVolunteers, setPinVerified } = useContext(UserContext);
   const navigate = useNavigate();
 
   const handlePinChange = useCallback((newPin: string[]) => {
@@ -162,6 +163,7 @@ const EnterPinPage: React.FC = () => {
         if (loggedInUserId !== null) {
           await updateLastSignedIn(loggedInUserId); // Update last signed-in date after successful login
         }
+        setPinVerified(true);
         navigate('/volunteer-home');
       } else if (result) {
         trackEvent('PIN_Submission', {
@@ -176,7 +178,7 @@ const EnterPinPage: React.FC = () => {
           `${getVolunteerName(loggedInUserId)}: ${result.ErrorMessage || 'Incorrect PIN. Please try again.'}`,
           'warning',
         );
-        document.getElementById('pin-input-3')?.focus();
+        setPinAttempt((prev) => prev + 1);
       }
       // If result is null, verifyPin() already displayed an error message, so don't show another
     } else {
@@ -231,7 +233,7 @@ const EnterPinPage: React.FC = () => {
           </Typography>
           <Box sx={{ marginBottom: 4 }}>
             <PinInput
-              key={loggedInUserId}
+              key={`${loggedInUserId}-${pinAttempt}`}
               onPinChange={handlePinChange}
               onSubmit={handleNextClick}
             />

--- a/src/pages/authentication/EnterPinPage.tsx
+++ b/src/pages/authentication/EnterPinPage.tsx
@@ -178,6 +178,7 @@ const EnterPinPage: React.FC = () => {
           `${getVolunteerName(loggedInUserId)}: ${result.ErrorMessage || 'Incorrect PIN. Please try again.'}`,
           'warning',
         );
+        setPin(Array(4).fill(''));
         setPinAttempt((prev) => prev + 1);
       }
       // If result is null, verifyPin() already displayed an error message, so don't show another

--- a/src/pages/authentication/PickNamePage.test.tsx
+++ b/src/pages/authentication/PickNamePage.test.tsx
@@ -42,6 +42,8 @@ const createUserContextValue = (overrides = {}) => ({
   setActiveVolunteers: vi.fn(),
   setUser: vi.fn(),
   isLoading: false,
+  pinVerified: false,
+  setPinVerified: vi.fn(),
   ...overrides,
 });
 
@@ -174,6 +176,31 @@ describe('PickNamePage Component', () => {
       expect(
         screen.getByText(/Failed to load volunteer list. Please try again later./i)
       ).toBeInTheDocument();
+    });
+  });
+
+  test('resets loggedInUserId and pinVerified on mount (back-navigation regression)', async () => {
+    const mockSetLoggedInUserId = vi.fn();
+    const mockSetPinVerified = vi.fn();
+    const volunteers = [{ id: 1, name: 'Alice' }];
+    mockFetchWithRetry.mockResolvedValue({ value: volunteers });
+  
+    render(
+      <UserContext.Provider
+        value={createUserContextValue({
+          loggedInUserId: 1, // simulate stale value left over from a prior selection
+          pinVerified: false,
+          setLoggedInUserId: mockSetLoggedInUserId,
+          setPinVerified: mockSetPinVerified,
+        })}
+      >
+        <PickNamePage />
+      </UserContext.Provider>
+    );
+  
+    await waitFor(() => {
+      expect(mockSetLoggedInUserId).toHaveBeenCalledWith(null);
+      expect(mockSetPinVerified).toHaveBeenCalledWith(false);
     });
   });
 });

--- a/src/pages/authentication/PickNamePage.tsx
+++ b/src/pages/authentication/PickNamePage.tsx
@@ -33,8 +33,7 @@ const PickYourNamePage: React.FC = () => {
   useEffect(() => {
     setLoggedInUserId(null);
     setPinVerified(false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [setLoggedInUserId, setPinVerified]);
   
   useEffect(() => {
     if (!user) return;

--- a/src/pages/authentication/PickNamePage.tsx
+++ b/src/pages/authentication/PickNamePage.tsx
@@ -24,12 +24,17 @@ import { trackException } from '../../utils/appInsights';
 import { useSnackbar } from '../../hooks/useSnackbar';
 
 const PickYourNamePage: React.FC = () => {
-  const { user, loggedInUserId, setLoggedInUserId, activeVolunteers, setActiveVolunteers } = useContext(UserContext);
+  const { user, loggedInUserId, setLoggedInUserId, activeVolunteers, setActiveVolunteers, setPinVerified } = useContext(UserContext);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const { snackbarState, showSnackbar, handleClose } = useSnackbar();
 
   const navigate = useNavigate();
 
+  useEffect(() => {
+    setLoggedInUserId(null);
+    setPinVerified(false);
+  }, [])
+  
   useEffect(() => {
     if (!user) return;
     

--- a/src/pages/authentication/PickNamePage.tsx
+++ b/src/pages/authentication/PickNamePage.tsx
@@ -33,7 +33,8 @@ const PickYourNamePage: React.FC = () => {
   useEffect(() => {
     setLoggedInUserId(null);
     setPinVerified(false);
-  }, [])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   
   useEffect(() => {
     if (!user) return;

--- a/src/pages/authentication/PickNamePage.tsx
+++ b/src/pages/authentication/PickNamePage.tsx
@@ -33,7 +33,9 @@ const PickYourNamePage: React.FC = () => {
   useEffect(() => {
     setLoggedInUserId(null);
     setPinVerified(false);
-  }, [setLoggedInUserId, setPinVerified]);
+    // Intentionally run only when entering the name-selection page.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   
   useEffect(() => {
     if (!user) return;

--- a/src/pages/catalog/index.test.tsx
+++ b/src/pages/catalog/index.test.tsx
@@ -37,6 +37,8 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
       activeVolunteers: [],
       setActiveVolunteers: vi.fn(),
       isLoading: false,
+      pinVerified: false,
+      setPinVerified: vi.fn(),
     }}
   >
     {children}

--- a/src/pages/catalog/useCatalog.test.tsx
+++ b/src/pages/catalog/useCatalog.test.tsx
@@ -26,6 +26,8 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
       activeVolunteers: [],
       setActiveVolunteers: vi.fn(),
       isLoading: false,
+      pinVerified: false,
+      setPinVerified: vi.fn(),
     }}
   >
     {children}

--- a/src/pages/checkout/CheckoutPage.test.tsx
+++ b/src/pages/checkout/CheckoutPage.test.tsx
@@ -19,7 +19,9 @@ const mockUserContext = {
   setLoggedInUserId: vi.fn(),
   activeVolunteers: [],
   setActiveVolunteers: vi.fn(),
-  isLoading: false
+  isLoading: false,
+  pinVerified: false,
+  setPinVerified: vi.fn(),
 };
 
 describe('CheckoutPage', async () => {

--- a/src/pages/history/index.test.tsx
+++ b/src/pages/history/index.test.tsx
@@ -155,6 +155,8 @@ const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
         activeVolunteers: [],
         setActiveVolunteers: vi.fn(),
         isLoading: false,
+        pinVerified: false,
+        setPinVerified: vi.fn(),
       }}
     >
       {children}

--- a/src/pages/inventory/Inventory.test.tsx
+++ b/src/pages/inventory/Inventory.test.tsx
@@ -65,6 +65,8 @@ const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
       activeVolunteers: [],
       setActiveVolunteers: vi.fn(),
       isLoading: false,
+      pinVerified: false,
+      setPinVerified: vi.fn(),
     }}
   >
     {children}

--- a/src/pages/people/useUsers.test.tsx
+++ b/src/pages/people/useUsers.test.tsx
@@ -27,7 +27,9 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
       setLoggedInUserId: vi.fn(),
       activeVolunteers: [],
       setActiveVolunteers: vi.fn(),
-      isLoading: false
+      isLoading: false,
+      pinVerified: false,
+      setPinVerified: vi.fn(),
     }}
   >
     {children}

--- a/src/pages/residents/index.test.tsx
+++ b/src/pages/residents/index.test.tsx
@@ -45,6 +45,8 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => (
       activeVolunteers: [],
       setActiveVolunteers: vi.fn(),
       isLoading: false,
+      pinVerified: false,
+      setPinVerified: vi.fn(),
     }}
   >
     {children}

--- a/src/pages/residents/useResidentsByBuilding.test.ts
+++ b/src/pages/residents/useResidentsByBuilding.test.ts
@@ -30,6 +30,8 @@ const wrapper = ({ children }: { children: React.ReactNode }) =>
       activeVolunteers: [],
       setActiveVolunteers: vi.fn(),
       isLoading: false,
+      pinVerified: false,
+      setPinVerified: vi.fn(),
     },
     children,
   });

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -85,6 +85,8 @@ export interface UserContextType {
   activeVolunteers: User[];
   setActiveVolunteers: (activeVolunteers: User[]) => void;
   isLoading: boolean;
+  pinVerified: boolean;
+  setPinVerified: (verified: boolean) => void;
 }
 
 // BaseUser defines the common properties shared by all user types.


### PR DESCRIPTION
## Description
Fixes a security bug where pressing browser back from the PIN entry screen left the previously selected resident and enabled Continue button intact, allowing a volunteer's dashboard to be reached without ever entering a valid PIN.

Root cause: `loggedInUserId` is persisted in `localStorage`, so it survives back-navigation (and more — reloads, browser restarts). `RootRedirect` only checked AAD role, with no concept of PIN verification, so any protected route could be reached once `loggedInUserId` was set, regardless of whether a PIN was ever validated. This means the bug wasn't limited to the specific back-button repro — direct URL navigation to `/volunteer-home` post-AAD-login could bypass it too.

**Please pay attention to:** the new `pinVerified` gate in `RootRedirect.tsx` — this is the actual security fix. The `PickYourNamePage` mount-reset is a complementary UX fix for the exact repro steps, but `RootRedirect` is what closes the bypass for good, since every protected route in `routes.tsx` is wrapped in it.

## Jira Ticket
- Closes: [PIT-521](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-521)

## Type of Change
**Type:** Bug fix

## Changes Made
- Added `pinVerified: boolean` and `setPinVerified` to `UserContext`, initialized as non-persistent React state and defaulting to `false`.
- `EnterPinPage` sets `pinVerified(true)` only on successful PIN verification (`result.IsValid === true`).
- `RootRedirect` now prevents unverified volunteers from accessing guarded routes, redirecting unverified volunteers to `/enter-your-pin` when a volunteer is already selected, or `/pick-your-name` when no volunteer is selected.
- `PickYourNamePage` resets `loggedInUserId` and `pinVerified` on mount so returning to name selection starts with no selected volunteer and no PIN verification.
- Admin access is unaffected because the PIN verification gate applies only to `userRole === 'volunteer'`.
- Bonus fix: wrong PIN entries now clear on-screen digits and refocus automatically (via `pinAttempt` counter folded into `PinInput`'s `key`), instead of requiring manual backspacing.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have run prettier on the code
- [x] I have performed a self-review of my code
- [x] I have commented my code only in hard-to-understand areas
- [x] My changes generate no new warnings in Chrome Dev Tools
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## QA Instructions, Screenshots, Recordings
1. **Normal flow (regression check):** Log in as volunteer → Pick Your Name → select volunteer → Continue → enter correct PIN → should land on `/volunteer-home` normally.
2. **Original bug repro:** Pick Your Name → select resident → Continue → on PIN screen, press browser **back** → confirm Pick Your Name shows no resident selected and Continue is disabled.
3. **Bypass attempt:** After AAD login, manually navigate to `/volunteer-home` directly via URL without completing PIN entry → confirm redirect to `/pick-your-name`.
4. **Admin flow:** Log in as admin → confirm normal landing on `/admin-home`, no PIN screen ever shown.
5. **Wrong PIN:** Enter an incorrect PIN → confirm warning message shows, input clears automatically, and dashboard is not reached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added PIN verification to the volunteer sign-in flow.
  - Successful PIN entry grants access to volunteer pages.
  - Unverified volunteers are redirected to PIN entry before accessing pages.
  - Failed PIN attempts clear the input for another try.
  - PIN verification resets when returning to volunteer name selection.

- **Bug Fixes**
  - Prevented stale user and PIN verification state from carrying over between sessions.
  - Admin access remains unaffected by volunteer PIN verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->