### PR TITLE
PIT-521: Preserve PIN verification across refresh and browser reopen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,12 +22,12 @@ const App: React.FC = () => {
   const [user, setUser] = usePersistentState<ClientPrincipal | null>('user', null);
   const [loggedInUserId, setLoggedInUserId] = usePersistentState<number | null>('loggedInUserId', null);
   const [activeVolunteers, setActiveVolunteers] = usePersistentState<User[]>('activeVolunteers', []);
-  const [pinVerified, setPinVerified] = React.useState<boolean>(false);
+  const [pinVerifiedForUserId, setPinVerifiedForUserId] =
+    usePersistentState<number | null>('pinVerifiedForUserId', null);
 
-  useEffect(() => {
-    setPinVerified(false);
-  }, [loggedInUserId]);
-  
+  const pinVerified =
+    loggedInUserId !== null && pinVerifiedForUserId === loggedInUserId;
+
   useAuthorization(user, Object.values(USER_ROLES));
 
   useEffect(() => {
@@ -46,10 +46,10 @@ const App: React.FC = () => {
       activeVolunteers,
       setActiveVolunteers,
       pinVerified,
-      setPinVerified,
+      setPinVerifiedForUserId,
       isLoading: user === null,
     }),
-    [user, setUser, loggedInUserId, setLoggedInUserId, activeVolunteers, setActiveVolunteers, pinVerified, setPinVerified]
+    [user, setUser, loggedInUserId, setLoggedInUserId, activeVolunteers, setActiveVolunteers, pinVerified, setPinVerifiedForUserId]
   );
 
   return (

--- a/src/components/AddVolunteerModal/AddVolunteerModal.test.tsx
+++ b/src/components/AddVolunteerModal/AddVolunteerModal.test.tsx
@@ -25,7 +25,7 @@ const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
       setActiveVolunteers: vi.fn(),
       isLoading: false,
       pinVerified: false,
-      setPinVerified: vi.fn(),
+      setPinVerifiedForUserId: vi.fn(),
     }}
   >
     {children}

--- a/src/components/Checkout/ResidentDetailDialog.test.tsx
+++ b/src/components/Checkout/ResidentDetailDialog.test.tsx
@@ -37,7 +37,7 @@ describe('ResidentDetailDialog', () => {
     setActiveVolunteers: vi.fn(),
     isLoading: false,
     pinVerified: false,
-    setPinVerified: vi.fn(),
+    setPinVerifiedForUserId: vi.fn(),
   };
 
   const mockBuildings = [

--- a/src/components/Checkout/WelcomeBasketBuildingDialog.test.tsx
+++ b/src/components/Checkout/WelcomeBasketBuildingDialog.test.tsx
@@ -36,7 +36,7 @@ describe('WelcomeBasketBuildingDialog', () => {
     setActiveVolunteers: vi.fn(),
     isLoading: false,
     pinVerified: false,
-    setPinVerified: vi.fn(),
+    setPinVerifiedForUserId: vi.fn(),
   };
 
   const mockBuildings = [

--- a/src/components/contexts/UserContext.ts
+++ b/src/components/contexts/UserContext.ts
@@ -16,6 +16,6 @@ export const UserContext = createContext<UserContextType>({
   setActiveVolunteers: () => {},
   isLoading: true,
   pinVerified: false,
-  setPinVerified: () => {},
+  setPinVerifiedForUserId: () => {},
 });
 

--- a/src/components/inventory/AddItemModal.test.tsx
+++ b/src/components/inventory/AddItemModal.test.tsx
@@ -40,7 +40,7 @@ const userContextValue = {
     setActiveVolunteers: vi.fn(),
     isLoading: false,
     pinVerified: false,
-    setPinVerified: vi.fn(),
+    setPinVerifiedForUserId: vi.fn(),
 };
 
 const renderComponent = () => {

--- a/src/layout/MainLayout/Header/HeaderContent/HeaderContent.test.tsx
+++ b/src/layout/MainLayout/Header/HeaderContent/HeaderContent.test.tsx
@@ -34,7 +34,7 @@ const renderWithRoles = (userRoles: string[]) =>
         setActiveVolunteers: vi.fn(),
         isLoading: false,
         pinVerified: false,
-        setPinVerified: vi.fn(),
+        setPinVerifiedForUserId: vi.fn(),
       }}
     >
       <MemoryRouter>

--- a/src/layout/MainLayout/Header/HeaderContent/VolunteerSwitcher.tsx
+++ b/src/layout/MainLayout/Header/HeaderContent/VolunteerSwitcher.tsx
@@ -14,7 +14,7 @@ import {
 const VolunteerSwitcher: React.FC = () => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const navigate = useNavigate();
-  const { loggedInUserId, setLoggedInUserId, activeVolunteers } = useContext(UserContext);
+  const { loggedInUserId, setLoggedInUserId, activeVolunteers, setPinVerifiedForUserId } = useContext(UserContext);
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
@@ -25,6 +25,7 @@ const VolunteerSwitcher: React.FC = () => {
   };
 
   const handleSelect = (selectedVolunteer: number) => {
+    setPinVerifiedForUserId(null);
     setLoggedInUserId(selectedVolunteer);
     navigate('/enter-your-pin');
     handleClose();

--- a/src/layout/MainLayout/index.test.tsx
+++ b/src/layout/MainLayout/index.test.tsx
@@ -65,7 +65,7 @@ const contextValue = (): UserContextType => ({
   setActiveVolunteers: vi.fn(),
   isLoading: false,
   pinVerified: false,
-  setPinVerified: vi.fn(),
+  setPinVerifiedForUserId: vi.fn(),
 });
 
 const renderLayout = () =>

--- a/src/pages/RootRedirect.test.tsx
+++ b/src/pages/RootRedirect.test.tsx
@@ -75,7 +75,7 @@ const mockUserContextValue = (
   activeVolunteers: [],
   setActiveVolunteers: vi.fn(),
   pinVerified,
-  setPinVerified: vi.fn(),
+  setPinVerifiedForUserId: vi.fn(),
 });
 
 const renderWithRouter = (contextValue: any, { route = '/' } = {}) => {

--- a/src/pages/VolunteerHome/VolunteerHome.test.tsx
+++ b/src/pages/VolunteerHome/VolunteerHome.test.tsx
@@ -53,7 +53,7 @@ const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
       setActiveVolunteers: vi.fn(),
       isLoading: false,
       pinVerified: false,
-      setPinVerified: vi.fn(),
+      setPinVerifiedForUserId: vi.fn(),
     }}
   >
     {children}

--- a/src/pages/authentication/EnterPinPage.test.tsx
+++ b/src/pages/authentication/EnterPinPage.test.tsx
@@ -44,7 +44,7 @@ const createUserContextValue = (overrides = {}) => ({
   setActiveVolunteers: vi.fn(),
   isLoading: false,
   pinVerified: false,
-  setPinVerified: vi.fn(),
+  setPinVerifiedForUserId: vi.fn(),
   ...overrides,
 });
 
@@ -87,7 +87,7 @@ describe('EnterPinPage Component', () => {
   });
 
   test('handles valid PIN and navigates to volunteer-home', async () => {
-    const mockSetPinVerified = vi.fn();
+    const mockSetPinVerifiedForUserId = vi.fn();
   
     (global.fetch as any) = vi.fn()
       .mockResolvedValueOnce({
@@ -100,7 +100,7 @@ describe('EnterPinPage Component', () => {
       });
   
     render(
-      <UserContext.Provider value={createUserContextValue({ setPinVerified: mockSetPinVerified })}>
+      <UserContext.Provider value={createUserContextValue({ setPinVerifiedForUserId: mockSetPinVerifiedForUserId })}>
         <EnterPinPage />
       </UserContext.Provider>
     );
@@ -115,13 +115,13 @@ describe('EnterPinPage Component', () => {
       expect(screen.getByText(/Login successful! Redirecting.../i)).toBeInTheDocument();
     });
   
-    expect(mockSetPinVerified).toHaveBeenCalledWith(true);
+    expect(mockSetPinVerifiedForUserId).toHaveBeenCalledWith(123);
     expect(mockNavigate).toHaveBeenCalledWith('/volunteer-home');
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
-  test('does not set pinVerified when PIN is invalid', async () => {
-    const mockSetPinVerified = vi.fn();
+  test('does not set pin verified when PIN is invalid', async () => {
+    const mockSetPinVerifiedForUserId = vi.fn();
   
     (global.fetch as any) = vi.fn().mockResolvedValueOnce({
       ok: true,
@@ -129,7 +129,7 @@ describe('EnterPinPage Component', () => {
     });
   
     render(
-      <UserContext.Provider value={createUserContextValue({ setPinVerified: mockSetPinVerified })}>
+      <UserContext.Provider value={createUserContextValue({ setPinVerifiedForUserId: mockSetPinVerifiedForUserId })}>
         <EnterPinPage />
       </UserContext.Provider>
     );
@@ -146,7 +146,7 @@ describe('EnterPinPage Component', () => {
       )).toBeInTheDocument();
     });
   
-    expect(mockSetPinVerified).not.toHaveBeenCalledWith(true);
+    expect(mockSetPinVerifiedForUserId).not.toHaveBeenCalled();
     expect(mockNavigate).not.toHaveBeenCalledWith('/volunteer-home');
   });
 

--- a/src/pages/authentication/EnterPinPage.tsx
+++ b/src/pages/authentication/EnterPinPage.tsx
@@ -21,7 +21,7 @@ const EnterPinPage: React.FC = () => {
   const [pin, setPin] = useState<string[]>(() => Array(4).fill(''));
   const [pinAttempt, setPinAttempt] = useState<number>(0);
   const { snackbarState, showSnackbar, handleClose } = useSnackbar();
-  const { loggedInUserId, user, activeVolunteers, setPinVerified } = useContext(UserContext);
+  const { loggedInUserId, user, activeVolunteers, setPinVerifiedForUserId } = useContext(UserContext);
   const navigate = useNavigate();
 
   const handlePinChange = useCallback((newPin: string[]) => {
@@ -163,7 +163,9 @@ const EnterPinPage: React.FC = () => {
         if (loggedInUserId !== null) {
           await updateLastSignedIn(loggedInUserId); // Update last signed-in date after successful login
         }
-        setPinVerified(true);
+        if (loggedInUserId !== null) {
+          setPinVerifiedForUserId(loggedInUserId);
+        }
         navigate('/volunteer-home');
       } else if (result) {
         trackEvent('PIN_Submission', {

--- a/src/pages/authentication/PickNamePage.test.tsx
+++ b/src/pages/authentication/PickNamePage.test.tsx
@@ -43,7 +43,7 @@ const createUserContextValue = (overrides = {}) => ({
   setUser: vi.fn(),
   isLoading: false,
   pinVerified: false,
-  setPinVerified: vi.fn(),
+  setPinVerifiedForUserId: vi.fn(),
   ...overrides,
 });
 
@@ -179,19 +179,20 @@ describe('PickNamePage Component', () => {
     });
   });
 
-  test('resets loggedInUserId and pinVerified on mount (back-navigation regression)', async () => {
+  test('resets loggedInUserId and pin verification on mount (back-navigation regression)', async () => {
     const mockSetLoggedInUserId = vi.fn();
-    const mockSetPinVerified = vi.fn();
+    const mockSetPinVerifiedForUserId = vi.fn();
     const volunteers = [{ id: 1, name: 'Alice' }];
+
     mockFetchWithRetry.mockResolvedValue({ value: volunteers });
   
     render(
       <UserContext.Provider
         value={createUserContextValue({
-          loggedInUserId: 1, // simulate stale value left over from a prior selection
-          pinVerified: false,
+          loggedInUserId: 1,
+          pinVerified: true,
           setLoggedInUserId: mockSetLoggedInUserId,
-          setPinVerified: mockSetPinVerified,
+          setPinVerifiedForUserId: mockSetPinVerifiedForUserId,
         })}
       >
         <PickNamePage />
@@ -200,7 +201,7 @@ describe('PickNamePage Component', () => {
   
     await waitFor(() => {
       expect(mockSetLoggedInUserId).toHaveBeenCalledWith(null);
-      expect(mockSetPinVerified).toHaveBeenCalledWith(false);
+      expect(mockSetPinVerifiedForUserId).toHaveBeenCalledWith(null);
     });
   });
 });

--- a/src/pages/authentication/PickNamePage.tsx
+++ b/src/pages/authentication/PickNamePage.tsx
@@ -24,7 +24,7 @@ import { trackException } from '../../utils/appInsights';
 import { useSnackbar } from '../../hooks/useSnackbar';
 
 const PickYourNamePage: React.FC = () => {
-  const { user, loggedInUserId, setLoggedInUserId, activeVolunteers, setActiveVolunteers, setPinVerified } = useContext(UserContext);
+  const { user, loggedInUserId, setLoggedInUserId, activeVolunteers, setActiveVolunteers, setPinVerifiedForUserId } = useContext(UserContext);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const { snackbarState, showSnackbar, handleClose } = useSnackbar();
 
@@ -32,7 +32,7 @@ const PickYourNamePage: React.FC = () => {
 
   useEffect(() => {
     setLoggedInUserId(null);
-    setPinVerified(false);
+    setPinVerifiedForUserId(null);
     // Intentionally run only when entering the name-selection page.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/pages/catalog/index.test.tsx
+++ b/src/pages/catalog/index.test.tsx
@@ -38,7 +38,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
       setActiveVolunteers: vi.fn(),
       isLoading: false,
       pinVerified: false,
-      setPinVerified: vi.fn(),
+      setPinVerifiedForUserId: vi.fn(),
     }}
   >
     {children}

--- a/src/pages/catalog/useCatalog.test.tsx
+++ b/src/pages/catalog/useCatalog.test.tsx
@@ -27,7 +27,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
       setActiveVolunteers: vi.fn(),
       isLoading: false,
       pinVerified: false,
-      setPinVerified: vi.fn(),
+      setPinVerifiedForUserId: vi.fn(),
     }}
   >
     {children}

--- a/src/pages/checkout/CheckoutPage.test.tsx
+++ b/src/pages/checkout/CheckoutPage.test.tsx
@@ -21,7 +21,7 @@ const mockUserContext = {
   setActiveVolunteers: vi.fn(),
   isLoading: false,
   pinVerified: false,
-  setPinVerified: vi.fn(),
+  setPinVerifiedForUserId: vi.fn(),
 };
 
 describe('CheckoutPage', async () => {

--- a/src/pages/history/index.test.tsx
+++ b/src/pages/history/index.test.tsx
@@ -156,7 +156,7 @@ const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
         setActiveVolunteers: vi.fn(),
         isLoading: false,
         pinVerified: false,
-        setPinVerified: vi.fn(),
+        setPinVerifiedForUserId: vi.fn(),
       }}
     >
       {children}

--- a/src/pages/inventory/Inventory.test.tsx
+++ b/src/pages/inventory/Inventory.test.tsx
@@ -66,7 +66,7 @@ const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
       setActiveVolunteers: vi.fn(),
       isLoading: false,
       pinVerified: false,
-      setPinVerified: vi.fn(),
+      setPinVerifiedForUserId: vi.fn(),
     }}
   >
     {children}

--- a/src/pages/people/useUsers.test.tsx
+++ b/src/pages/people/useUsers.test.tsx
@@ -29,7 +29,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
       setActiveVolunteers: vi.fn(),
       isLoading: false,
       pinVerified: false,
-      setPinVerified: vi.fn(),
+      setPinVerifiedForUserId: vi.fn(),
     }}
   >
     {children}

--- a/src/pages/residents/index.test.tsx
+++ b/src/pages/residents/index.test.tsx
@@ -46,7 +46,7 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => (
       setActiveVolunteers: vi.fn(),
       isLoading: false,
       pinVerified: false,
-      setPinVerified: vi.fn(),
+      setPinVerifiedForUserId: vi.fn(),
     }}
   >
     {children}

--- a/src/pages/residents/useResidentsByBuilding.test.ts
+++ b/src/pages/residents/useResidentsByBuilding.test.ts
@@ -31,7 +31,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) =>
       setActiveVolunteers: vi.fn(),
       isLoading: false,
       pinVerified: false,
-      setPinVerified: vi.fn(),
+      setPinVerifiedForUserId: vi.fn(),
     },
     children,
   });

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -86,7 +86,7 @@ export interface UserContextType {
   setActiveVolunteers: (activeVolunteers: User[]) => void;
   isLoading: boolean;
   pinVerified: boolean;
-  setPinVerified: (verified: boolean) => void;
+  setPinVerifiedForUserId: (userId: number | null) => void;
 }
 
 // BaseUser defines the common properties shared by all user types.


### PR DESCRIPTION
## Description

Follow-up to PIT-521 to preserve the original volunteer session behavior across page refreshes and browser reopen, while keeping the PIN verification security gate introduced by the original fix.

The original PIT-521 fix used non-persistent React state for `pinVerified`, which correctly prevented PIN bypass through browser navigation but also caused a successfully verified volunteer to lose their verified state after a page refresh or browser reopen.

This change persists the PIN verification state for the currently selected volunteer. Verification is tied to the volunteer's ID, so switching volunteers still requires PIN verification.

Please pay attention to: the verification state is persisted by volunteer ID rather than as a standalone boolean. This allows refresh/browser reopen to preserve the verified session while ensuring that switching volunteers clears the previous verification and requires a new PIN.

## Jira Ticket

* Closes: [PIT-521](https://das-ph-inventory-tracker.atlassian.net/browse/PIT-521)

## Type of Change

**Type:** Bug fix

## Changes Made

* Persisted the ID of the volunteer whose PIN was successfully verified.
* Derived `pinVerified` by matching the persisted verified volunteer ID with the currently selected volunteer.
* Cleared PIN verification when switching volunteers or returning to volunteer name selection.
* Updated `EnterPinPage` to persist verification only after a successful PIN validation.
* Updated existing tests to use the new PIN verification state and setter.
* Preserved the PIT-521 security gate that prevents unverified volunteers from accessing protected routes.

## Checklist

* [x] My code follows the project's style guidelines
* [x]  I have run prettier on the code
* [x] I have performed a self-review of my code
* [x] I have commented my code only in hard-to-understand areas
* [x] I have updated the documentation accordingly
* [x] My changes generate no new warnings in Chrome Dev Tools
* [x] I have added unit tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes

## QA Instructions, Screenshots, Recordings

### Volunteer session persistence

1. Log in as a volunteer and select a volunteer.
2. Enter the correct PIN and confirm the volunteer dashboard loads.
3. Refresh the page.
4. Confirm the volunteer remains logged in and is not prompted for the PIN again.
5. Close and reopen the browser.
6. Confirm the volunteer remains logged in without being prompted for the PIN again.

### Volunteer switching

1. While logged in as a volunteer, use **Change Volunteer**.
2. Select another volunteer.
3. Confirm the PIN page is shown.
4. Enter the correct PIN and confirm the second volunteer's dashboard loads.
5. Switch back to the previously verified volunteer.
6. Confirm the PIN page is shown again and the previous volunteer's dashboard cannot be accessed without entering the PIN.

### PIT-521 security regression

1. Select a volunteer and navigate to the PIN entry page.
2. Use browser back/forward navigation before entering the PIN.
3. Confirm the volunteer dashboard cannot be accessed without valid PIN verification.
4. Confirm directly navigating to `/volunteer-home` without valid PIN verification is still blocked.

### Existing logout behavior

1. Confirm the existing 15-minute inactivity timeout still logs the volunteer out.
2. Confirm explicit logout still logs the volunteer out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PIN verification is now associated with the specific volunteer who completed verification.
  * Switching volunteers clears the previous verification, requiring the newly selected volunteer to enter their PIN.
  * Returning to volunteer selection also clears PIN verification appropriately.

* **New Features**
  * Added “This month,” “Last month,” and “Last 30 days” as date selection options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->